### PR TITLE
Makes the infinite APC config option no longer create a bucket of runtimes

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -167,7 +167,7 @@
 		src.update_icon()
 
 	if(config.infinite_apc)
-		cell = /obj/item/weapon/cell/infinite
+		cell = new /obj/item/weapon/cell/infinite
 		cell_type = null //set this to null so the if in init() doesnt reset the cell.
 
 /obj/machinery/power/apc/Destroy()


### PR DESCRIPTION
As per title - I fixed this since infinite APCs were the default config option