### PR TITLE
Species Item inhand offsets

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/kig-yar.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/kig-yar.dm
@@ -13,6 +13,7 @@
 	spawn_flags = SPECIES_IS_WHITELISTED
 	darksight = 6
 	brute_mod = 1.1
+	item_icon_offsets = list(-1,1)
 
 	has_limbs = list(
 		BP_CHEST =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/mob/living/carbon/human/species/outsider/sangheili.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/sangheili.dm
@@ -14,6 +14,7 @@
 	radiation_mod = 0.6 //Covie weapons emit beta radiation. Resistant to 1/3 types of radiation.
 	spawn_flags = SPECIES_IS_WHITELISTED
 	brute_mod = 0.9
+	item_icon_offsets = list(-1,2)
 
 	has_organ = list(
 	BP_HEART =    /obj/item/organ/internal/heart,

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -184,6 +184,9 @@
 	var/pass_flags = 0
 	var/breathing_sound = 'sound/voice/monkey.ogg'
 
+	var/list/item_icon_offsets = list(0,0) //A list (x,y) of offsets to apply to inhand images.
+	//NOTE FOR ABOVE: Posive X moves right, positive Y moves up.
+
 /datum/species/proc/get_eyes(var/mob/living/carbon/human/H)
 	return
 

--- a/code/modules/mob/living/carbon/human/species/station/spartan.dm
+++ b/code/modules/mob/living/carbon/human/species/station/spartan.dm
@@ -11,6 +11,7 @@
 	total_health = 250 //Same base health as sangheili
 	spawn_flags = SPECIES_IS_WHITELISTED
 	brute_mod = 0.8 //Lower amount of brute damage taken than sangheili
+	item_icon_offsets = list(-1,3)
 
 	has_limbs =  list(
 		BP_CHEST =  list("path" = /obj/item/organ/external/chest/augmented),

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -605,6 +605,10 @@ var/global/list/damage_icon_parts = list()
 			hud_used.hidden_inventory_update() 	//Updates the screenloc of the items on the 'other' inventory bar
 
 
+/mob/living/carbon/human/proc/apply_hand_offsets(var/image/image)
+	image.pixel_x = species.item_icon_offsets[1]
+	image.pixel_y = species.item_icon_offsets[2]
+
 /mob/living/carbon/human/update_inv_handcuffed(var/update_icons=1)
 	if(handcuffed)
 		overlays_standing[HANDCUFF_LAYER] = handcuffed.get_mob_overlay(src,slot_handcuffed_str)
@@ -615,6 +619,7 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/update_inv_r_hand(var/update_icons=1)
 	if(r_hand)
 		var/image/standing = r_hand.get_mob_overlay(src,slot_r_hand_str)
+		apply_hand_offsets(standing)
 		if(standing)
 			standing.appearance_flags |= RESET_ALPHA
 		overlays_standing[R_HAND_LAYER] = standing
@@ -629,6 +634,7 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/update_inv_l_hand(var/update_icons=1)
 	if(l_hand)
 		var/image/standing = l_hand.get_mob_overlay(src,slot_l_hand_str)
+		apply_hand_offsets(standing)
 		if(standing)
 			standing.appearance_flags |= RESET_ALPHA
 		overlays_standing[L_HAND_LAYER] = standing


### PR DESCRIPTION
A basic system to apply offsets to item inhands by taking x and y offsets from the species datum. Runs on the assumption that the item inhand being used was created for humans.