### PR TITLE
Basic supression effects

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -4,6 +4,7 @@ Contains most of the procs that are called when a mob is attacked by something
 bullet_act
 ex_act
 meteor_act
+surpression_act
 
 */
 
@@ -472,3 +473,22 @@ meteor_act
 		perm += perm_by_part[part]
 
 	return perm
+
+/mob/living/carbon/human/proc/supression_act(var/obj/item/projectile/P)
+	if(!client)
+		return
+	var/seconds_since_supression = (world.time - time_last_supressed)/10
+	if(seconds_since_supression <= 1)
+		shake_camera(src,2,1)
+		overlay_fullscreen("supress",/obj/screen/fullscreen/oxy, 6)
+		//severe supression effects
+	else if(seconds_since_supression <=5)
+		overlay_fullscreen("supress",/obj/screen/fullscreen/oxy, 5)
+		//medium supression effects
+	else if(seconds_since_supression <=10)
+		overlay_fullscreen("supress",/obj/screen/fullscreen/oxy, 4)
+		//low supression effects
+	else if(seconds_since_supression > 10)
+		if(prob(40))
+			visible_message("<span class = 'danger'>The [P.name] whizzes past [src]!</span>")
+	time_last_supressed = world.time

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -114,3 +114,6 @@
 	var/shock_stage
 
 	var/obj/item/grab/current_grab_type 	// What type of grab they use when they grab someone.
+
+	var/list/supression_icons = list()
+	var/time_last_supressed = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -53,6 +53,8 @@
 	// update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
 
+	clear_fullscreen("supress")
+
 	// This is not an ideal place for this but it will do for now.
 	if(wearing_rig && wearing_rig.offline)
 		wearing_rig = null

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -207,6 +207,10 @@
 
 	return 1
 
+/obj/item/projectile/proc/do_supression_aoe(var/location)
+	for(var/mob/living/carbon/human/h in orange(1,location))
+		h.supression_act(src)
+
 /obj/item/projectile/Bump(atom/A as mob|obj|turf|area, forced=0)
 	if(A == src)
 		return 0 //no
@@ -303,6 +307,9 @@
 
 		before_move()
 		Move(location.return_turf())
+		if(first_step != 1)
+			spawn()
+				do_supression_aoe(loc)
 
 		if(!bumped && !isturf(original))
 			if(loc == get_turf(original))


### PR DESCRIPTION
Adds basic supression effects including slight screenshake at highest level alongside screen-darkening (currently uses oxygen deprivation effect)

Example of effects:
https://gfycat.com/gifs/detail/EllipticalEvenIceblueredtopzebra