### PR TITLE
General fix and rebalance pass

### DIFF
--- a/code/modules/halo/chemicals/containers.dm
+++ b/code/modules/halo/chemicals/containers.dm
@@ -43,7 +43,20 @@
 		mode = SYRINGE_INJECT
 		update_icon()
 
+//Iron pills + bottle define//
+/obj/item/weapon/reagent_containers/pill/iron
+	name = "Iron pill"
+	desc = "Used to increase the speed of blood replenishment."
+	icon_state = "pill18"
+	New()
+		..()
+		reagents.add_reagent(/datum/reagent/iron, 20)
 
+/obj/item/weapon/storage/pill_bottle/iron
+	name = "bottle of Iron pills"
+	desc = "Contains pills used to assist in blood replenishment."
+
+	startswith = list(/obj/item/weapon/reagent_containers/pill/iron = 7)
 
 #undef SYRINGE_DRAW
 #undef SYRINGE_INJECT

--- a/code/modules/halo/misc/tools_items_gear.dm
+++ b/code/modules/halo/misc/tools_items_gear.dm
@@ -43,8 +43,7 @@
 		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/reagent_containers/syringe/biofoam,
 		/obj/item/weapon/reagent_containers/syringe/biofoam,
-		/obj/item/weapon/reagent_containers/syringe/biofoam,
-		/obj/item/weapon/reagent_containers/syringe/biofoam,
+		/obj/item/weapon/storage/pill_bottle/iron,
 		/obj/item/weapon/storage/pill_bottle/tramadol,
 		/obj/item/device/healthanalyzer
 		)

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -161,9 +161,9 @@
 	damage = 80
 	stun = 1
 	weaken = 1
+	step_delay = 0.3
 	penetrating = 5
 	armor_penetration = 80
-	hitscan = 1
 	accuracy = 6
 
 /obj/item/weapon/storage/box/m145_ap

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -45,7 +45,7 @@
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
 
 	var/hitscan = 0		// whether the projectile should be hitscan
-	var/step_delay = 1	// the delay between iterations if not a hitscan projectile
+	var/step_delay = 0.5	// the delay between iterations if not a hitscan projectile
 
 	// effect types to be used
 	var/muzzle_type

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -168,7 +168,7 @@
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
-	damage = 13
+	damage = 15
 	pellets = 6
 	range_step = 1
 	spread_step = 10


### PR DESCRIPTION
Snipers no-longer hitscan: Sniper projectile delay lowered to compensate.
General speed of projectiles increased.
Shotgun pellet damage increased to 15 from 13, shotguns were seen as quite weak.

There was no way to increase blood regeneration. Removed 2 biofoam syringes from medikit and replaced with an iron pill bottle.