### PR TITLE
MAC sector blindfire

### DIFF
--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -10,47 +10,58 @@
 		return
 	.=..()
 
-/obj/item/projectile/overmap/proc/generate_co_ords_x_start(var/obj/effect/overmap/ship/o_obj)
+/obj/item/projectile/overmap/proc/generate_co_ords_x_start(var/list/bounds_list)
 	var/co_ords = list(1,1)
-	co_ords[1] = rand(o_obj.map_bounds[3],o_obj.map_bounds[1])
-	co_ords[2] = text2num(pick("[o_obj.map_bounds[2]]","[o_obj.map_bounds[4]]"))
+	co_ords[1] = rand(bounds_list[3],bounds_list[1])
+	co_ords[2] = text2num(pick("[bounds_list[2]]","[bounds_list[4]]"))
 	return co_ords
 
-/obj/item/projectile/overmap/proc/generate_co_ords_y_start(var/obj/effect/overmap/ship/o_obj)
+/obj/item/projectile/overmap/proc/generate_co_ords_y_start(var/list/bounds_list)
 	var/co_ords = list(1,1)
-	co_ords[2] = rand(o_obj.map_bounds[4],o_obj.map_bounds[2])
-	co_ords[1] = text2num(pick("[o_obj.map_bounds[1]]","[o_obj.map_bounds[3]]"))
+	co_ords[2] = rand(bounds_list[4],bounds_list[2])
+	co_ords[1] = text2num(pick("[bounds_list[1]]","[bounds_list[3]]"))
 	return co_ords
 
-/obj/item/projectile/overmap/proc/generate_co_ords_x_end(var/start_co_ords,var/obj/effect/overmap/ship/o_obj)
+/obj/item/projectile/overmap/proc/generate_co_ords_x_end(var/start_co_ords,var/list/bounds_list)
 	var/co_ords = list(1,1)
 	co_ords[1] = start_co_ords[1] + rand(-dispersion,dispersion)
-	if(start_co_ords[2] == o_obj.map_bounds[2])
-		co_ords[2] = o_obj.map_bounds[4]
+	if(start_co_ords[2] == bounds_list[2])
+		co_ords[2] = bounds_list[4]
 		return co_ords
-	else if(start_co_ords[2] == o_obj.map_bounds[4])
-		co_ords[2] = o_obj.map_bounds[2]
+	else if(start_co_ords[2] == bounds_list[4])
+		co_ords[2] = bounds_list[2]
 		return co_ords
 
-/obj/item/projectile/overmap/proc/generate_co_ords_y_end(var/start_co_ords,var/obj/effect/overmap/ship/o_obj)
+/obj/item/projectile/overmap/proc/generate_co_ords_y_end(var/start_co_ords,var/list/bounds_list)
 	var/co_ords = list(1,1)
 	co_ords[2] = start_co_ords[2] + rand(-dispersion,dispersion)
-	if(start_co_ords[1] == o_obj.map_bounds[1])
-		co_ords[1] = o_obj.map_bounds[3]
+	if(start_co_ords[1] == bounds_list[1])
+		co_ords[1] = bounds_list[3]
 		return co_ords
-	else if(start_co_ords[1] == o_obj.map_bounds[3])
-		co_ords[1] = o_obj.map_bounds[1]
+	else if(start_co_ords[1] == bounds_list[3])
+		co_ords[1] = bounds_list[1]
 		return co_ords
+
+/obj/item/projectile/overmap/proc/do_sector_hit(var/z_level,var/obj/effect/overmap/object_hit)
+	if(prob(33)) //33% chance we miss the populated area entirely
+		visible_message("<span class = 'notice'>[src] misses the vital parts of [object_hit]</span>")
+		return
+	var/list/hit_bounds = list(1,255,255,1)
+	if(prob(35))
+		hit_bounds  = pick(object_hit.weapon_locations)
+
+	var/turf/turf_to_explode = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
+	explosion(turf_to_explode,5,7,8,10)
 
 /obj/item/projectile/overmap/proc/do_z_level_proj_spawn(var/z_level,var/obj/effect/overmap/ship/overmap_object_hit)
 	var/start_co_ords
 	var/end_co_ords
 	if(overmap_object_hit.fore_dir == EAST || WEST)
-		start_co_ords = generate_co_ords_x_start(overmap_object_hit)
-		end_co_ords = generate_co_ords_x_end(start_co_ords,overmap_object_hit)
+		start_co_ords = generate_co_ords_x_start(overmap_object_hit.map_bounds)
+		end_co_ords = generate_co_ords_x_end(start_co_ords,overmap_object_hit.map_bounds)
 	else if(overmap_object_hit.fore_dir == NORTH || SOUTH)
-		start_co_ords = generate_co_ords_y_start(overmap_object_hit)
-		end_co_ords = generate_co_ords_y_end(start_co_ords,overmap_object_hit)
+		start_co_ords = generate_co_ords_y_start(overmap_object_hit.map_bounds)
+		end_co_ords = generate_co_ords_y_end(start_co_ords,overmap_object_hit.map_bounds)
 	var/turf/proj_spawn_loc = locate(start_co_ords[1],start_co_ords[2],z_level)
 	var/turf/proj_end_loc = locate(end_co_ords[1],end_co_ords[2],z_level)
 	var/obj/item/projectile/new_proj = new ship_damage_projectile
@@ -58,18 +69,13 @@
 	new_proj.launch(proj_end_loc)
 
 /obj/item/projectile/overmap/on_impact(var/atom/impacted)
-	var/obj/effect/overmap/ship/overmap_object
-	if(istype(impacted,/obj/effect/overmap/ship))
-		overmap_object = impacted
-	else
-		for(var/obj/effect/overmap/ship/o_obj in impacted.loc.contents)
-			overmap_object = o_obj
-			break
-	if(!overmap_object)
-		return
+	var/obj/effect/overmap/overmap_object = impacted
 	var/chosen_impact_z = pick(overmap_object.map_z)
 
-	do_z_level_proj_spawn(chosen_impact_z,overmap_object)
+	if(istype(impacted,/obj/effect/overmap/sector))
+		do_sector_hit(chosen_impact_z,impacted)
+	else if(istype(impacted,/obj/effect/overmap/ship))
+		do_z_level_proj_spawn(chosen_impact_z,overmap_object)
 	qdel(src)
 	return 1
 

--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -51,7 +51,7 @@
 		hit_bounds  = pick(object_hit.weapon_locations)
 
 	var/turf/turf_to_explode = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
-	explosion(turf_to_explode,5,7,8,10)
+	explosion(turf_to_explode,3,5,7,10)
 
 /obj/item/projectile/overmap/proc/do_z_level_proj_spawn(var/z_level,var/obj/effect/overmap/ship/overmap_object_hit)
 	var/start_co_ords

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -8,6 +8,7 @@ var/list/points_of_interest = list()
 	icon = 'icons/obj/overmap.dmi'
 	icon_state = "object"
 	var/list/map_z = list()
+	var/list/weapon_locations = list(list(1,255,255,1)) //used for orbital unaimed MAC bombardment. Format: list(top_left_x,top_left_y,bottom_right_x,bottom_right_y) for each "visible" ground-to-ship weapon on the map.
 
 	var/list/generic_waypoints = list()    //waypoints that any shuttle can use
 	var/list/restricted_waypoints = list() //waypoints for specific shuttles

--- a/maps/geminus_city/geminus_city_overmap.dm
+++ b/maps/geminus_city/geminus_city_overmap.dm
@@ -3,3 +3,5 @@
 	name = "Geminus City Colony"
 	icon = 'maps/geminus_city/sector_icon.dmi'
 	icon_state = "geminus"
+
+	weapon_locations = list(list(154,106,174,89))


### PR DESCRIPTION
Adds a behaviour for MAC cannons to blindfire at a sector, causing a lot of untargeted damage. 

Also makes MAC blindfire have a chance to target pre-defined areas on a sector: eg the colony MAC.