### PR TITLE
Few small changes

### DIFF
--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -72,6 +72,9 @@
 	var/obj/effect/overmap/overmap_object = impacted
 	var/chosen_impact_z = pick(overmap_object.map_z)
 
+	if(!(starting in range(1,impacted)) && prob(overmap_object.weapon_miss_chance))
+		visible_message("<span class = 'warning'>[src] flies past [impacted].</span>")
+		return 0
 	if(istype(impacted,/obj/effect/overmap/sector))
 		do_sector_hit(chosen_impact_z,impacted)
 	else if(istype(impacted,/obj/effect/overmap/ship))

--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -23,6 +23,7 @@ var/global/list/map_sectors = list()
 /turf/unsimulated/map/New()
 	..()
 	name = "[x]-[y]"
+	icon_state = "[rand(0,25)]"
 	var/list/numbers = list()
 
 	if(x == 1 || x == GLOB.using_map.overmap_size)
@@ -67,7 +68,7 @@ proc/toggle_move_stars(zlevel, direction)
 
 	if (moving_levels["[zlevel]"] != gen_dir)
 		moving_levels["[zlevel]"] = gen_dir
-		
+
 		var/list/spaceturfs = block(locate(1, 1, zlevel), locate(world.maxx, world.maxy, zlevel))
 		for(var/turf/space/T in spaceturfs)
 			if(!gen_dir)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -9,6 +9,7 @@ var/list/points_of_interest = list()
 	icon_state = "object"
 	var/list/map_z = list()
 	var/list/weapon_locations = list(list(1,255,255,1)) //used for orbital unaimed MAC bombardment. Format: list(top_left_x,top_left_y,bottom_right_x,bottom_right_y) for each "visible" ground-to-ship weapon on the map.
+	var/weapon_miss_chance = 35
 
 	var/list/generic_waypoints = list()    //waypoints that any shuttle can use
 	var/list/restricted_waypoints = list() //waypoints for specific shuttles

--- a/maps/geminus_city/geminus_city_outfits.dm
+++ b/maps/geminus_city/geminus_city_outfits.dm
@@ -60,10 +60,7 @@
 /decl/hierarchy/outfit/job/colonist/innie_sympathiser
 	name = "Insurrectionist Sympathiser"
 
-	mask = /obj/item/clothing/mask/innie/shemagh
-
 	l_pocket = /obj/item/ammo_magazine/m127_saphp
-	l_ear = /obj/item/device/radio/headset/insurrection
 
 /decl/hierarchy/outfit/job/colonist/innie_sympathiser/equip_special()
 	return


### PR DESCRIPTION
Adds a miss chance to overmap weapons, defined by sectors.
Makes overmap sectors icons use space-sprites.

Removes inniecomms and shemagh from innie sympathisers, allowing their role to be to actually sympathise, not be a sleeper agent.