### PR TITLE
Some Buffs for Spartans

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1423,6 +1423,7 @@
 #include "code\modules\halo\chemicals\containers.dm"
 #include "code\modules\halo\chemicals\medicine.dm"
 #include "code\modules\halo\chemicals\recipes.dm"
+#include "code\modules\halo\chemicals\toxins.dm"
 #include "code\modules\halo\clothing\insurrectionists.dm"
 #include "code\modules\halo\clothing\jumpsuits.dm"
 #include "code\modules\halo\clothing\marine.dm"

--- a/code/modules/halo/chemicals/toxins.dm
+++ b/code/modules/halo/chemicals/toxins.dm
@@ -1,0 +1,23 @@
+/datum/reagent/radiotox
+	name = "Radio-Toxins"
+	description = "Produced by several types of radiation scavengers."
+	taste_description = "metal"
+	reagent_state = SOLID
+	color = "#0047AB" //Cobalt blue!
+	metabolism = REM // Default metabolism
+
+	var/radiation_potential = 10
+
+/datum/reagent/radiotox/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/mob/living/carbon/human/H = M
+	if(istype(H))
+		if(!(H.internal_organs_by_name[BP_LIVER] || H.internal_organs_by_name[BP_KIDNEYS]))
+			//No organ to process away the toxin, so it starts to have an impact
+			H.apply_effect(radiation_potential * removed, IRRADIATE, blocked = 0)
+		else
+			if(prob(5))
+				to_chat(H, "<span class='warning'>You feel naseous</span>")
+				H.adjustToxLoss(radiation_potential * removed)
+			else if(prob(1))
+				//Compound has broken down into real toxins
+				H.vessel.add_reagent(/datum/reagent/toxin, removed)

--- a/code/modules/halo/species_items/spartan.dm
+++ b/code/modules/halo/species_items/spartan.dm
@@ -43,3 +43,34 @@
 
 /obj/item/organ/external/foot/right/augmented
 	min_broken_damage = 50
+
+/obj/item/organ/internal/eyes/occipital_reversal
+	//Organ is slightly tougher
+	min_bruised_damage = 25
+	min_broken_damage = 35
+	//Minor protection from flashes
+	innate_flash_protection = FLASH_PROTECTION_MODERATE
+	//Also protects against Phoron gas
+	phoron_guard = 1
+
+/obj/item/organ/internal/liver/spartan
+	//Twice as good at handling toxin damage... but not any tougher
+	toxin_danger_level = 120
+
+/obj/item/organ/internal/liver/spartan/process()
+	//To allow some filtering first, we're putting off our ..() call
+	if(owner.chem_effects[CE_ALCOHOL] && owner.chem_effects[CE_ALCOHOL_TOXIC])
+		//Remove an additional amount of alcohol
+		owner.vessel.remove_reagent(/datum/reagent/ethanol, min(owner.chem_effects[CE_ALCOHOL_TOXIC], 3))
+
+	// Small amounts of radiation can be handled by a spartan
+	if(owner.radiation && !owner.chem_effects[CE_TOXIN])
+		var/amount = min(owner.radiation, 10)
+		owner.radiation -= amount
+		//Radiation is scavenged into metabolizable compounds by the enhanced liver
+		owner.vessel.add_reagent(/datum/reagent/radiotox, amount)
+
+	. = ..()
+
+
+

--- a/code/modules/halo/species_items/spartan.dm
+++ b/code/modules/halo/species_items/spartan.dm
@@ -54,6 +54,7 @@
 	phoron_guard = 1
 
 /obj/item/organ/internal/liver/spartan
+	name = "augmented liver"
 	//Twice as good at handling toxin damage... but not any tougher
 	toxin_danger_level = 120
 
@@ -72,5 +73,9 @@
 
 	. = ..()
 
-
-
+/obj/item/organ/internal/heart/spartan
+	name = "enhanced heart"
+	desc = "a dense mass of muscle, vaugely resembling a heart"
+	max_damage = 60
+	min_bruised_damage = 30 //Considerably tougher
+	min_broken_damage = 45

--- a/code/modules/mob/living/carbon/human/species/station/spartan.dm
+++ b/code/modules/mob/living/carbon/human/species/station/spartan.dm
@@ -15,7 +15,7 @@
 
 	//Spartan's have some better organs than normal humans. Also, we'll say the UNSC cut out their appendix already
 	has_organ = list(
-		BP_HEART =    /obj/item/organ/internal/heart,
+		BP_HEART =    /obj/item/organ/internal/heart/spartan,
 		BP_LUNGS =    /obj/item/organ/internal/lungs,
 		BP_LIVER =    /obj/item/organ/internal/liver/spartan,
 		BP_KIDNEYS =  /obj/item/organ/internal/kidneys,

--- a/code/modules/mob/living/carbon/human/species/station/spartan.dm
+++ b/code/modules/mob/living/carbon/human/species/station/spartan.dm
@@ -13,6 +13,16 @@
 	brute_mod = 0.8 //Lower amount of brute damage taken than sangheili
 	item_icon_offsets = list(-1,3)
 
+	//Spartan's have some better organs than normal humans. Also, we'll say the UNSC cut out their appendix already
+	has_organ = list(
+		BP_HEART =    /obj/item/organ/internal/heart,
+		BP_LUNGS =    /obj/item/organ/internal/lungs,
+		BP_LIVER =    /obj/item/organ/internal/liver/spartan,
+		BP_KIDNEYS =  /obj/item/organ/internal/kidneys,
+		BP_BRAIN =    /obj/item/organ/internal/brain,
+		BP_EYES =     /obj/item/organ/internal/eyes/occipital_reversal
+		)
+
 	has_limbs =  list(
 		BP_CHEST =  list("path" = /obj/item/organ/external/chest/augmented),
 		BP_GROIN =  list("path" = /obj/item/organ/external/groin/augmented),

--- a/code/modules/mob/living/carbon/human/species/station/spartan.dm
+++ b/code/modules/mob/living/carbon/human/species/station/spartan.dm
@@ -29,6 +29,10 @@
 	cold_level_2 = 190 //-83C
 	cold_level_3 = 114 //-159C
 
+	//As of 2018-03-24 we're in 2525 - 2526, thus Spartans IIs were just augmented
+	min_age = 14
+	max_age = 15
+
 	//Spartan's have some better organs than normal humans. Also, we'll say the UNSC cut out their appendix already
 	has_organ = list(
 		BP_HEART =    /obj/item/organ/internal/heart/spartan,

--- a/code/modules/mob/living/carbon/human/species/station/spartan.dm
+++ b/code/modules/mob/living/carbon/human/species/station/spartan.dm
@@ -13,6 +13,22 @@
 	brute_mod = 0.8 //Lower amount of brute damage taken than sangheili
 	item_icon_offsets = list(-1,3)
 
+	metabolism_mod = 1.25 //Faster metabolism
+	breath_pressure = 14.5 //Better lungs!
+	darksight = 4 //Beter night vision!
+
+	//Spartans have a bit better temperature tolerance
+	siemens_coefficient = 0.9 //Better insulated against temp changes
+	heat_discomfort_level = 330 //57C
+	cold_discomfort_level = T0C
+	//Buff to temperature damage levels (5% per level)
+	heat_level_1 = 380 //~107C
+	heat_level_2 = 420 //147C
+	heat_level_3 = 1050 //777C
+	cold_level_1 = 247 //-26C
+	cold_level_2 = 190 //-83C
+	cold_level_3 = 114 //-159C
+
 	//Spartan's have some better organs than normal humans. Also, we'll say the UNSC cut out their appendix already
 	has_organ = list(
 		BP_HEART =    /obj/item/organ/internal/heart/spartan,

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -9,6 +9,9 @@
 	max_damage = 70
 	relative_size = 60
 
+	//At what point does toxin damage become dangerous
+	var/toxin_danger_level = 60
+
 /obj/item/organ/internal/liver/robotize()
 	. = ..()
 	icon_state = "liver-prosthetic"
@@ -29,7 +32,7 @@
 	if(owner.life_tick % PROCESS_ACCURACY == 0)
 
 		//High toxins levels are dangerous
-		if(owner.getToxLoss() >= 60 && !owner.chem_effects[CE_ANTITOX])
+		if(owner.getToxLoss() >= toxin_danger_level && !owner.chem_effects[CE_ANTITOX])
 			//Healthy liver suffers on its own
 			if (src.damage < min_broken_damage)
 				src.damage += 0.2 * PROCESS_ACCURACY

--- a/html/changelogs/bloxgate-spartan-buffing.yml
+++ b/html/changelogs/bloxgate-spartan-buffing.yml
@@ -1,0 +1,10 @@
+author: bloxgate
+delete-after: True
+changes:
+ - rscadd: "Enhanced liver for Spartans. Handles radiation and some toxins better."
+ - rscadd: "Enhanced eyes for Spartans. Better protection from some blinding effects."
+ - tweak: "Spartan's hearts can take more damage than normal humans."
+ - tweak: "Spartans have a greater temperature tolerance."
+ - experiment: "Spartans are more insulated than regular humans."
+ - bugfix: "Spartans now have their player ages restricted to a lore-friendly range."
+ 


### PR DESCRIPTION
Applies some buffing to Spartans' internal organs and general modifiers.

* Several internal organs are toughened
  * Eyes are protected from phoron and have extra-human flash protection
  * The liver can process toxic alcohol levels faster, and converts radiation to "safe" chemicals
  * The heart can take much more damage
* Spartans now have a faster metabolism rate
* Spartans now have better dark vision
* Spartans can handle a lower partial pressure of oxygen when their lungs are healthy
  * Spartans are not negatively impacted by bruised lungs at standard atmospheric pressure
  * Collapsed lungs still require high pressure internals or surgical intervention
* Spartans have better temperature tolerances than humans
  * 5% buff to damage levels
  * Significant buffs to discomfort levels
  * Better insulated against changes
* Spartan ages are restricted to a lore-friendly range
