### PR TITLE
Adds tactical comms for ODSTs & ONI

### DIFF
--- a/code/modules/halo/comms/channel_keys.dm
+++ b/code/modules/halo/comms/channel_keys.dm
@@ -10,12 +10,14 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 #define COV_COMMON_NAME "Battlenet"
 #define CIV_NAME "Common"
 #define SEC_NAME "GCPD"
+#define ODST_NAME "TACCOM"
 
 /datum/halo_frequencies
 	var/innie_channel = "INNIECOM"
 	var/innie_freq = -1
 	var/shipcom_freq = -1
 	var/teamcom_freq = -1
+	var/odst_freq = -1
 	var/squadcom_freq = -1
 	var/fleetcom_freq = -1
 	var/const/eband_freq = 1160
@@ -23,7 +25,7 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 	var/covenant_battlenet_freq = -1
 	var/police_freq = -1
 	var/list/used_freqs = list()
-	var/list/frequencies = list("INNIECOM",SHIPCOM_NAME,TEAMCOM_NAME,SQUADCOM_NAME,FLEETCOM_NAME,EBAND_NAME,CIV_NAME,COV_COMMON_NAME,SEC_NAME)
+	var/list/frequencies = list("INNIECOM",SHIPCOM_NAME,TEAMCOM_NAME,SQUADCOM_NAME,FLEETCOM_NAME,EBAND_NAME,CIV_NAME,COV_COMMON_NAME,SEC_NAME,ODST_NAME)
 
 /datum/halo_frequencies/New()
 	if(GLOB.using_map.use_global_covenant_comms)
@@ -51,6 +53,7 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 	frequencies[CIV_NAME] = civ_freq
 	frequencies[COV_COMMON_NAME] = covenant_battlenet_freq
 	frequencies[SEC_NAME] = police_freq
+	frequencies[ODST_NAME] = odst_freq
 	radiochannels = frequencies
 
 /datum/halo_frequencies/proc/setup_com_channels()
@@ -97,6 +100,11 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 		fleetcom_freq = rand(1001, 9998)
 	used_freqs += "[fleetcom_freq]"
 
+	odst_freq = rand(1001, 9998)
+	while(used_freqs.Find("[odst_freq]"))
+		odst_freq = rand(1001, 9998)
+	used_freqs += "[odst_freq]"
+
 	while(used_freqs.Find("[covenant_battlenet_freq]"))
 		covenant_battlenet_freq = rand(1460, 9998)
 	used_freqs += "[covenant_battlenet_freq]"
@@ -131,6 +139,9 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 
 /obj/item/device/encryptionkey/squadcom
 	channels = list(SHIPCOM_NAME = 1,SQUADCOM_NAME = 1,EBAND_NAME = 1)
+
+/obj/item/device/encryptionkey/taccom
+	channels = list(SHIPCOM_NAME = 1,SQUADCOM_NAME = 1,EBAND_NAME = 1, ODST_NAME = 1)
 
 /obj/item/device/encryptionkey/teamcom
 	channels = list(SHIPCOM_NAME = 1,TEAMCOM_NAME = 1,SQUADCOM_NAME = 1,EBAND_NAME = 1)

--- a/code/modules/halo/comms/commsitems.dm
+++ b/code/modules/halo/comms/commsitems.dm
@@ -77,7 +77,7 @@
 
 /obj/item/device/mobilecomms/commsbackpack/unsc
 	desc = "A reinforced backpack filled with an array of wires and communication equipment. The insignia of the UNSC is stitched into the back."
-	recieving_frequencies = list(TEAMCOM_NAME,CIV_NAME,EBAND_NAME,FLEETCOM_NAME,SQUADCOM_NAME,SHIPCOM_NAME)
+	recieving_frequencies = list(TEAMCOM_NAME,CIV_NAME,EBAND_NAME,FLEETCOM_NAME,SQUADCOM_NAME,SHIPCOM_NAME,ODST_NAME)
 
 /obj/item/device/mobilecomms/commsbackpack/innie
 	desc = "A reinforced backpack filled with an array of wires and communication equipment. This one appears to have been tampered with."
@@ -117,3 +117,4 @@
 #undef EBAND_NAME
 #undef CIV_NAME
 #undef SEC_NAME
+#undef ODST_NAME

--- a/code/modules/halo/comms/headsets.dm
+++ b/code/modules/halo/comms/headsets.dm
@@ -18,6 +18,9 @@
 /obj/item/device/radio/headset/unsc/marine
 	ks2type = /obj/item/device/encryptionkey/teamcom
 
+/obj/item/device/radio/headset/unsc/odst
+	ks2type = /obj/item/device/encryptionkey/taccom
+
 //unsc officer headset
 /obj/item/device/radio/headset/unsc/officer
 	ks2type = /obj/item/device/encryptionkey/officercom

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -9,6 +9,7 @@ var/list/department_radio_keys = list(
 	  ":q" = "SQUADCOM",	".q" = "SQUADCOM",
 	  ":e" = "EBAND",		".e" = "EBAND",
 	  ":g" = "GCPD",		".g" = "GCPD",
+	  ":t" = "TACCOM",		".t" = "TACCOM",
 	  ":b" = "INNIECOM",	".b" = "INNIECOM",
 
 	  ":R" = "right ear",	".R" = "right ear",
@@ -21,6 +22,7 @@ var/list/department_radio_keys = list(
 	  ":Q" = "SQUADCOM",	".Q" = "SQUADCOM",
 	  ":E" = "EBAND",		".E" = "EBAND",
 	  ":G" = "GCPD",		".G" = "GCPD",
+	  ":T" = "TACCOM",		".T" = "TACCOM",
 	  ":B" = "INNIECOM",	".B" = "INNIECOM",
 
 	/*

--- a/html/changelogs/tactical-comms-nalar.yml
+++ b/html/changelogs/tactical-comms-nalar.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nalar
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: Adds a private ODST channel called TACCOM so ODSTs and ONI can coordinate better.

--- a/maps/unsc_frigate/outfits/marines.dm
+++ b/maps/unsc_frigate/outfits/marines.dm
@@ -68,7 +68,7 @@
 
 /decl/hierarchy/outfit/job/UNSC_ship/odst
 	name = "ODST Rifleman"
-	l_ear = /obj/item/device/radio/headset/unsc/marine
+	l_ear = /obj/item/device/radio/headset/unsc/odst
 	glasses = /obj/item/clothing/glasses/hud/tactical
 	uniform = /obj/item/clothing/under/unsc/odst_jumpsuit
 	shoes = /obj/item/clothing/shoes/jungleboots
@@ -79,7 +79,7 @@
 
 /decl/hierarchy/outfit/job/UNSC_ship/odsto
 	name = "ONI Bridge Officer"
-	l_ear = /obj/item/device/radio/headset/unsc/marine
+	l_ear = /obj/item/device/radio/headset/unsc/odst
 	uniform = /obj/item/clothing/under/utility
 	shoes = /obj/item/clothing/shoes/dress
 	belt = /obj/item/weapon/gun/projectile/m6c_magnum_s


### PR DESCRIPTION
Added a tactical communication channel (TACCOM, accessed with :t) for ODSTs and the ONI bridge officer to allow them to properly coordinate their efforts.