### PR TITLE
stop-the-venting

### DIFF
--- a/code/modules/halo/clothing/odst.dm
+++ b/code/modules/halo/clothing/odst.dm
@@ -21,7 +21,7 @@
 	icon_override = ODST_OVERRIDE
 	item_state = "Odst Helmet"
 	icon_state = "Helmet"
-	item_flags = THICKMATERIAL
+	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL
 	body_parts_covered = HEAD|FACE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	cold_protection = HEAD

--- a/code/modules/halo/overmap/npc_cargo_ship.dm
+++ b/code/modules/halo/overmap/npc_cargo_ship.dm
@@ -1,4 +1,5 @@
 #define BASE_CARGO_STAY_TIME 10 MINUTES
+#define BASE_CARGO_DEPART_TIME 2 MINUTES
 
 /obj/effect/overmap/ship/npc_ship/cargo
 	name = "Cargo Ship"
@@ -6,6 +7,7 @@
 
 	var/atom/cargo_call_target
 	var/cargo_stay_time = BASE_CARGO_STAY_TIME
+	var/warn_depart_time = BASE_CARGO_DEPART_TIME
 	var/on_call = 0
 
 /obj/effect/overmap/ship/npc_ship/cargo/proc/set_cargo_call_status(var/atom/call_target)//Leave target null to cancel cargo call.
@@ -28,6 +30,8 @@
 			GLOB.global_headset.autosay("Alright, we're here. Dock with us. You have [cargo_stay_time/600] minutes.","[name]","Common")
 			target_loc = null
 			on_call = 1
+			spawn(cargo_stay_time-warn_depart_time)
+				GLOB.global_headset.autosay("I'll be leaving in [warn_depart_time/600] minutes. Better pack your stuff up.","[name]","Common")
 			spawn(cargo_stay_time)
 				GLOB.global_headset.autosay("Thanks for the trade! We're leaving now.","[name]","Common")
 				cargo_call_target = null

--- a/maps/unsc_frigate/unsc_frigate_spawndefs_geminus.dm
+++ b/maps/unsc_frigate/unsc_frigate_spawndefs_geminus.dm
@@ -9,7 +9,7 @@
 /datum/job/UNSC_ship/pilot,/datum/job/UNSC_ship/ai,\
 /datum/job/UNSC_ship/technician_chief,/datum/job/UNSC_ship/technician)
 	allowed_spawns = list("UNSC Frigate","Colony Arrival Shuttle")
-	base_turf_by_z = list("5" = /turf/simulated/floor/planet/dirt)
+	base_turf_by_z = list("6" = /turf/simulated/floor/planet/dirt)
 
 
 //jobs below are cut from the list above because they have yet to be implemented

--- a/maps/unsc_frigate/unsc_frigate_spawndefs_innies_geminus.dm
+++ b/maps/unsc_frigate/unsc_frigate_spawndefs_innies_geminus.dm
@@ -10,7 +10,7 @@
 /datum/job/UNSC_ship/pilot,/datum/job/UNSC_ship/ai,\
 /datum/job/UNSC_ship/technician_chief,/datum/job/UNSC_ship/technician)
 	allowed_spawns = list("UNSC Frigate","Colony Arrival Shuttle","Insurrectionist","Insurrectionist Leader")
-	base_turf_by_z = list("5" = /turf/simulated/floor/planet/dirt)
+	base_turf_by_z = list("6" = /turf/simulated/floor/planet/dirt)
 
 //jobs below are cut from the list above because they have yet to be implemented
 //when implemented simply cut and paste from below into the list above with proper slashes and commas respectively


### PR DESCRIPTION
stops geminus venting. Also adds a warning from cargo ships to leave two minutes before they depart.