### PR TITLE
Communication channel colours

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -331,7 +331,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		var/part_b_extra = ""
 		if(data == 3) // intercepted radio message
 			part_b_extra = " <i>(Intercepted)</i>"
-		var/part_a = "<span class='[frequency_span_class(display_freq)]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
+		var/part_a = "<span class='[halo_frequency_span_class(display_freq)]'>\icon[radio]<b>\[[freq_text]\][part_b_extra]</b> <span class='name'>" // goes in the actual output
 
 		// --- Some more pre-message formatting ---
 		var/part_b = "</span> <span class='message'>" // Tweaked for security headsets -- TLE
@@ -511,7 +511,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	if (length(heard_normal) || length(heard_garbled) || length(heard_gibberish))
 
 	  /* --- Some miscellaneous variables to format the string output --- */
-		var/part_a = "<span class='[frequency_span_class(display_freq)]'><span class='name'>" // goes in the actual output
+		var/part_a = "<span class='[halo_frequency_span_class(display_freq)]'><span class='name'>" // goes in the actual output
 		var/freq_text = get_frequency_name(display_freq)
 
 		// --- Some more pre-message formatting ---

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -106,7 +106,7 @@
 		var/chan_stat = channels[ch_name]
 		var/listening = !!(chan_stat & FREQ_LISTENING) != 0
 
-		dat.Add(list(list("chan" = ch_name, "display_name" = ch_name, "secure_channel" = 1, "sec_channel_listen" = !listening, "chan_span" = frequency_span_class(radiochannels[ch_name]))))
+		dat.Add(list(list("chan" = ch_name, "display_name" = ch_name, "secure_channel" = 1, "sec_channel_listen" = !listening, "chan_span" = halo_frequency_span_class(radiochannels[ch_name]))))
 
 	return dat
 
@@ -114,7 +114,7 @@
 	var/dat[0]
 	for(var/internal_chan in internal_channels)
 		if(has_channel_access(user, internal_chan))
-			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_name(text2num(internal_chan)), "chan_span" = frequency_span_class(text2num(internal_chan)))))
+			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_name(text2num(internal_chan)), "chan_span" = halo_frequency_span_class(text2num(internal_chan)))))
 
 	return dat
 

--- a/code/modules/halo/comms/channel_keys.dm
+++ b/code/modules/halo/comms/channel_keys.dm
@@ -168,6 +168,6 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 
 	//general ship comms
 	if(frequency == halo_frequencies.shipcom_freq)
-		return "srvradio"
+		return "comradio"
 
 	return "radio"

--- a/code/modules/halo/comms/channel_keys.dm
+++ b/code/modules/halo/comms/channel_keys.dm
@@ -152,3 +152,22 @@ var/global/datum/halo_frequencies/halo_frequencies = new()
 
 /obj/item/device/encryptionkey/public
 	channels = list(CIV_NAME = 1)
+
+/proc/halo_frequency_span_class(var/frequency)
+	//Innie channel
+	if (frequency == halo_frequencies.innie_freq)
+		return "syndradio"
+
+	// GCPD channel
+	if(frequency == halo_frequencies.police_freq)
+		return "secradio"
+
+	// ODST channel
+	if(frequency == halo_frequencies.odst_freq)
+		return "centradio"
+
+	//general ship comms
+	if(frequency == halo_frequencies.shipcom_freq)
+		return "srvradio"
+
+	return "radio"

--- a/html/changelogs/comms-colours-first-nalar.yml
+++ b/html/changelogs/comms-colours-first-nalar.yml
@@ -1,0 +1,4 @@
+author: Nalar
+delete-after: True
+changes: 
+  - rscadd: The more commonly used radio channels now have different colours!


### PR DESCRIPTION
Adds colours for the currently used communications channels

Insurrection
https://i.imgur.com/z5SOtEO.png

ODST
https://i.imgur.com/6Pbhync.png

System & GCPD
https://i.imgur.com/ohPxTMs.png

SHIPCOM
https://i.imgur.com/sAB5dil.png

I'm not 100% sure on the SHIPCOM colour being blue, but I felt there should be some sort of differentation between shipcom and system for the sake of usability and readability,
