### PR TITLE
Fixes announcements

### DIFF
--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -41,7 +41,7 @@
 
 	var/msg = FormMessage(message, message_title)
 	for(var/mob/M in GLOB.player_list)
-		if((M.z in GLOB.using_map.contact_levels) && !istype(M,/mob/new_player) && !isdeaf(M))
+		if(!istype(M,/mob/new_player) && !isdeaf(M))
 			to_chat(M, msg)
 			if(message_sound)
 				sound_to(M, message_sound)

--- a/html/changelogs/announce-fix-nalar-1.yml
+++ b/html/changelogs/announce-fix-nalar-1.yml
@@ -1,0 +1,4 @@
+author: Nalar
+delete-after: True
+changes: 
+  - bugfix: Announcements generated via admins or the communications console can now be heard by characters in-game.


### PR DESCRIPTION
Removes unused contact_levels check that prevents ingame characters from hearing generated announcements.

As we rely on randomly generated zlevels, ontop of maps that don't make use of the contact_levels system, I've removed this from the check. This doesn't seem to have broken or affected anything else.