### PR TITLE
Bullet wall damage tweaks

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -73,7 +73,7 @@
 	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
 	var/damage = min(proj_damage, 100)
 
-	take_damage(damage)
+	take_damage(damage / 10)
 	return
 
 /turf/simulated/wall/hitby(AM as mob|obj, var/speed=THROWFORCE_SPEED_DIVISOR)

--- a/html/changelogs/wall-damage-tweak-nalar.yml
+++ b/html/changelogs/wall-damage-tweak-nalar.yml
@@ -1,0 +1,4 @@
+author: Nalar
+delete-after: True
+changes: 
+  - bugfix: Bullets now do significantly less damage to walls.


### PR DESCRIPTION
Bullets now do much, much less damage to walls. 

For normal walls, it takes over a full SMG magazine to cause a wall to disintegrate. For LMGs, slightly less than a full magazine.

Reinforced walls are almost impervious to small arms fire. They do still take damage, but it's very very small.