### PR TITLE
Covenant wall and Projeresist window explosion buffs

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -572,3 +572,11 @@
 
 /obj/structure/window/reinforced/projresist/bullet_act(var/obj/item/projectile/p)
 	visible_message("<span class = 'danger'>[name] doesn't appear to take any damage from [p.name]</span>")
+
+/obj/structure/window/reinforced/projresist/ex_act(var/severity)
+	if(severity > 1) //Anything other than a direct epicenter hit just damages the window.
+		take_damage(100)
+	else if(prob(25))
+		shatter(0)
+	else
+		take_damage(300)

--- a/code/modules/halo/turfs/covenant/materials.dm
+++ b/code/modules/halo/turfs/covenant/materials.dm
@@ -15,11 +15,11 @@
 	melting_point = 17273
 
 	brute_armor = 15
-	burn_armor = 1 //Not as defensive when burn applied.
+	burn_armor = 10 //Not as defensive when burn applied.
 
-	integrity = 500
+	integrity = 600
 
-	explosion_resistance = 10
+	explosion_resistance = 45
 
 	stack_type = /obj/item/stack/material/nanolaminate
 


### PR DESCRIPTION
Raises the explosion resistance of covenant walls.
Modifies projresist window explosion handling to ensure that they can withstand explosions for a longer time.

Testing of new covenant wall explosion resistance showed "moderate" damage at the explosion impact point and "slight" damage elsewhere.

Fixes #613 