### PR TITLE
Report New Notes and Bans to Cicero

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -180,6 +180,8 @@ var/list/gamemode_cache = list()
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 
+	var/discord_bot_address = "" //The address to push info to the discord bot
+
 	// Event settings
 	var/expected_round_length = 3 * 60 * 60 * 10 // 3 hours
 	// If the first delay has a custom start time
@@ -578,6 +580,9 @@ var/list/gamemode_cache = list()
 
 				if("irc_bot_export")
 					irc_bot_export = 1
+
+				if("discord_bot_address")
+					discord_bot_address = value
 
 				if("ticklag")
 					var/ticklag = text2num(value)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -120,6 +120,15 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	note_list << note_keys
 	del(note_list) // savefile, so NOT qdel
 
+	//Report notes to Discord
+	if(config.discord_bot_address != "")
+		var/list/discord_report = list()
+		discord_report["key"] = config.comms_password
+		discord_report["note"] = "New Note:\n[P.content]\nby [P.author] ([P.rank]) on [P.timestamp]"
+		discord_report["ckey"] = "[key]"
+		//Send the note
+		world.Export("[config.discord_bot_address]/newnote?[list2params(discord_report)]")
+
 
 /proc/notes_del(var/key, var/index)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")


### PR DESCRIPTION
This adds a new configuration option that allows the game to send a copy of any new notes and bans (as creating a ban produces a note) to our Discord bot.

This was requested by @Desolane 

See: [here](https://gitlab.com/bloxgate/cicero-bot/commit/53676ac2ad107e1ac0be476d20610b8cd4f90620) for the changes done on Cicero's side.
