### PR TITLE
Update note report to indicate the ckey the note is set on

### DIFF
--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -124,7 +124,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	if(config.discord_bot_address != "")
 		var/list/discord_report = list()
 		discord_report["key"] = config.comms_password
-		discord_report["note"] = "New Note:\n[P.content]\nby [P.author] ([P.rank]) on [P.timestamp]"
+		discord_report["note"] = "New Note for [key]:\n[P.content]\nby [P.author] ([P.rank]) on [P.timestamp]"
 		discord_report["ckey"] = "[key]"
 		//Send the note
 		world.Export("[config.discord_bot_address]/newnote?[list2params(discord_report)]")


### PR DESCRIPTION
I forgot to show this unless the situation in which a placeholder message is given occurred.