### PR TITLE
allows MAC designator linking.

### DIFF
--- a/code/modules/halo/machinery/MAC.dm
+++ b/code/modules/halo/machinery/MAC.dm
@@ -242,7 +242,7 @@
 /obj/machinery/overmap_weapon_console/mac/orbital_bombard/attackby(var/obj/item/weapon/W, var/mob/user)
 	var/obj/item/weapon/laser_designator/designator = W
 	if(istype(W))
-		W.creator = src
+		designator.creator = src
 		to_chat(user,"Device linked to console. Designated targets will now be relayed for firing.")
 
 //MAC OVERMAP PROJECTILE//

--- a/code/modules/halo/machinery/MAC.dm
+++ b/code/modules/halo/machinery/MAC.dm
@@ -239,6 +239,12 @@
 		play_fire_sound(targ_overmap,target_turf)
 		explosion(target_turf,4,5,6,20)
 
+/obj/machinery/overmap_weapon_console/mac/orbital_bombard/attackby(var/obj/item/weapon/W, var/mob/user)
+	var/obj/item/weapon/laser_designator/designator = W
+	if(istype(W))
+		W.creator = src
+		to_chat(user,"Device linked to console. Designated targets will now be relayed for firing.")
+
 //MAC OVERMAP PROJECTILE//
 /obj/item/projectile/overmap/mac
 	name = "MAC Slug"


### PR DESCRIPTION
Smack a MAC orbital bombardment console with a designator and it'll link it. Any designators placed on-map will require this before they will function.