### PR TITLE
Makes flood infestor forms have the PASSTABLE flag

### DIFF
--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -76,6 +76,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	icon_state = "static"
 	icon_living = "static"
 	icon_dead = "dead"
+	passflags = PASSTABLE
 	//
 	move_to_delay = 15
 	health = 1

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	icon_state = "static"
 	icon_living = "static"
 	icon_dead = "dead"
-	passflags = PASSTABLE
+	pass_flags = PASSTABLE
 	//
 	move_to_delay = 15
 	health = 1


### PR DESCRIPTION
These should honestly not be blocked by tables. This will, by extension, allow them to pass tanktraps.