### PR TITLE
Gives the Spirit Dropship some useful overmap and view range

### DIFF
--- a/code/modules/halo/vehicles/spirit_dropship.dm
+++ b/code/modules/halo/vehicles/spirit_dropship.dm
@@ -25,6 +25,10 @@
 
 	vehicle_size = 128
 
+	overmap_range = 2
+
+	vehicle_view_modifier = 1.3
+
 /obj/vehicles/air/overmap/spirit_dropship/proc/update_pixel_xy()
 	pixel_x = 0
 	pixel_y = 0


### PR DESCRIPTION
Sets the Spirit Dropship's overmap range to 2: Higher than a pelican, lower than a boarding pod.

View range whilst in the spirit is now 9 tiles.