### PR TITLE
Makes plasma grenades reliable

### DIFF
--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -4,6 +4,8 @@
 	desc = "When activated, the coating of this grenade becomes a powerful adhesive, sticking to anyone it is thrown at."
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "plasmagrenade"
+	var/alt_explosion_damage_max = 70 //The amount of damage done when grenade is stuck inside someone
+	var/alt_explosion_range = 3
 
 /obj/item/weapon/grenade/plasma/throw_impact(var/atom/A)
 	. = ..()
@@ -16,6 +18,24 @@
 	A.visible_message("<span class = 'danger'>[src.name] sticks to [L.name]!</span>")
 
 /obj/item/weapon/grenade/plasma/detonate()
-	explosion(src.loc, -1, 1, 3, 5, 0)
+	var/mob/living/carbon/human/mob_containing = loc
+	if(istype(mob_containing))
+		mob_containing.adjustFireLoss(alt_explosion_damage_max)
+		to_chat(mob_containing,"<span class = 'danger'>[src] explodes! The immense heat burns through your flesh...</span>")
+	else
+		for(var/mob/living/hit_mob in range(alt_explosion_range,src))
+			hit_mob.adjustFireLoss(alt_explosion_damage_max/2)
+			to_chat(hit_mob,"<span class = 'danger'>[src] explodes! Heat from the explosion washes over your body...</span>")
+	explosion(src.loc, -1, -1, 3, 5, 0)
 	loc.contents -= src
 	qdel(src)
+
+/obj/item/weapon/grenade/plasma/heavy_plasma
+	name = "Type-1 Antipersonnel Grenade - Modified"
+	desc = "When activated, the coating of this grenade becomes a powerful adhesive, sticking to anyone it is thrown at. \
+	It seems to be heavier than a normal Type-1, and you doubt you could throw it very far."
+
+	throw_range = 1
+
+	alt_explosion_damage_max = 100
+	alt_explosion_range = 2


### PR DESCRIPTION
Provides a long-awaited buff to plasma grenades by making them much more reliable in terms of damage output.
Instead of relying on an explosion, plasma grenades will now incinerate the area around them, or if embedded, the unfortunate person with the grenade in them. 70 flat burn on embedded-explode, 35 in a 3 tile radius on ground-explode.

Also added heavy-plasma suicide grenades for adminspawning. 100 damage on embedded-explode. 50 in 2 tile radius on ground-explode.