### PR TITLE
Flood infestation changes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1452,6 +1452,7 @@
 #include "code\modules\halo\covenant\spirit.dm"
 #include "code\modules\halo\doors\halo_doors.dm"
 #include "code\modules\halo\flood\flood.dm"
+#include "code\modules\halo\flood\flood_infection_chem.dm"
 #include "code\modules\halo\flood\flood_npc.dm"
 #include "code\modules\halo\flood\flood_spawn.dm"
 #include "code\modules\halo\flood\flood_spawn_bio.dm"

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -1,7 +1,6 @@
 GLOBAL_VAR(max_flood_simplemobs)
 GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 
-#define INFECT_DELAY 13 SECONDS
 #define PLAYER_FLOOD_HEALTH_MOD 1.5
 #define COMBAT_FORM_INFESTOR_SPAWN_DELAY 30SECONDS
 #define TO_PLAYER_INFECTED_SOUND 'code/modules/halo/sounds/flood_infect_gravemind.ogg'
@@ -86,20 +85,19 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		else
 			mob_type_spawn = /mob/living/simple_animal/hostile/flood/combat_form/minor
 
-	spawn(INFECT_DELAY)
-		var/mob/living/simple_animal/hostile/flood/combat_form/new_combat_form = new mob_type_spawn
-		new_combat_form.maxHealth *= PLAYER_FLOOD_HEALTH_MOD //Buff their health a bit.
-		new_combat_form.health *= PLAYER_FLOOD_HEALTH_MOD
-		new_combat_form.forceMove(h.loc)
-		new_combat_form.ckey = h.ckey
-		new_combat_form.name = h.real_name
-		if(prob(25))
-			playsound(new_combat_form.loc,PLAYER_TRANSFORM_SFX,100)
-		if(new_combat_form.ckey)
-			new_combat_form.stop_automated_movement = 1
-		for(var/obj/i in h.contents)
-			h.drop_from_inventory(i)
-		qdel(h)
+	var/mob/living/simple_animal/hostile/flood/combat_form/new_combat_form = new mob_type_spawn
+	new_combat_form.maxHealth *= PLAYER_FLOOD_HEALTH_MOD //Buff their health a bit.
+	new_combat_form.health *= PLAYER_FLOOD_HEALTH_MOD
+	new_combat_form.forceMove(h.loc)
+	new_combat_form.ckey = h.ckey
+	new_combat_form.name = h.real_name
+	if(prob(25))
+		playsound(new_combat_form.loc,PLAYER_TRANSFORM_SFX,100)
+	if(new_combat_form.ckey)
+		new_combat_form.stop_automated_movement = 1
+	for(var/obj/i in h.contents)
+		h.drop_from_inventory(i)
+	qdel(h)
 
 /mob/living/simple_animal/hostile/flood/infestor
 	name = "Flood infestor"

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -73,6 +73,9 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		flood_spawner = null
 
 /mob/living/simple_animal/hostile/flood/proc/do_infect(var/mob/living/carbon/human/h)
+	sound_to(h,TO_PLAYER_INFECTED_SOUND)
+	var/obj/infest_placeholder = new /obj/effect/dead_infestor
+	h.contents += infest_placeholder
 	h.Stun(999)
 	h.visible_message("<span class = 'danger'>[h.name] vomits up blood, red-feelers emerging from their chest...</span>")
 	new /obj/effect/decal/cleanable/blood/splatter(h.loc)
@@ -97,7 +100,6 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		for(var/obj/i in h.contents)
 			h.drop_from_inventory(i)
 		qdel(h)
-		adjustBruteLoss(1)
 
 /mob/living/simple_animal/hostile/flood/infestor
 	name = "Flood infestor"
@@ -144,15 +146,9 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	if(is_being_infested(h))
 		return 0
 	visible_message("<span class = 'danger'>[name] leaps at [h.name], tearing at their armor and burrowing through their skin!</span>")
-	wander = 0
-	stop_automated_movement = 1
-	invisibility = 101
-	anchored = 1
-	density = 0
-	sound_to(h,TO_PLAYER_INFECTED_SOUND)
-	var/obj/infest_placeholder = new /obj/effect/dead_infestor
-	h.contents += infest_placeholder
-	h.vessel.add_reagent("Unknown Biological Contaminant",15)
+	h.vessel.remove_reagent(/datum/reagent/blood,15) //Remove some blood to make way for the infectiontoxin. This also models the "corruption" of the bloodstream.
+	h.vessel.add_reagent(/datum/reagent/floodinfectiontoxin,15)
+	adjustBruteLoss(1)
 	return 1
 
 /mob/living/simple_animal/hostile/flood/infestor/proc/attempt_nearby_infect()

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -146,8 +146,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	if(is_being_infested(h))
 		return 0
 	visible_message("<span class = 'danger'>[name] leaps at [h.name], tearing at their armor and burrowing through their skin!</span>")
-	h.vessel.remove_reagent(/datum/reagent/blood,15) //Remove some blood to make way for the infectiontoxin. This also models the "corruption" of the bloodstream.
-	h.vessel.add_reagent(/datum/reagent/floodinfectiontoxin,15)
+	h.bloodstr.add_reagent(/datum/reagent/floodinfectiontoxin,15)
 	adjustBruteLoss(1)
 	return 1
 

--- a/code/modules/halo/flood/flood_infection_chem.dm
+++ b/code/modules/halo/flood/flood_infection_chem.dm
@@ -1,4 +1,4 @@
-#define FLOOD_INFECTION_MESSAGE_PROB 1
+#define FLOOD_INFECTION_MESSAGE_PROB 5
 #define FLOOD_INFECTION_MESSAGES_LOW list(\
 "Your skin becomes cold to the touch...",\
 "A spasm runs through your body...",\

--- a/code/modules/halo/flood/flood_infection_chem.dm
+++ b/code/modules/halo/flood/flood_infection_chem.dm
@@ -1,0 +1,49 @@
+#define FLOOD_INFECTION_MESSAGE_PROB 1
+#define FLOOD_INFECTION_MESSAGES_LOW list(\
+"Your skin becomes cold to the touch...",\
+"A spasm runs through your body...",\
+"Visions of a unified purpose invade your thoughts..."\
+)
+#define FLOOD_INFECTION_MESSAGES_MEDIUM list(\
+"Something wriggles underneath your skin...",\
+"Your mind goes blank for a moment, replaced only by visions of an endless void...",\
+"You feel your mind slipping..."\
+)
+#define FLOOD_INFECTION_MESSAGES_HIGH list(\
+"A chorus of voices speaks in riddles...",\
+"You feel something digging into your spinal column...",\
+"You hear the voices of long-dead friends..."\
+)
+
+//Infection toxin chemical
+
+/datum/reagent/floodinfectiontoxin
+	name = "Unknown Biological Contaminant"
+	description = "A substance with no known classification."
+	reagent_state = LIQUID
+	color = "#00BFFF"
+	metabolism = 0.1
+	overdose = 27 //Time (60 seconds gas exposure) / 2 (2 seconds between life ticks) * 0.9 (Chemicals lost due to metabolism).
+	scannable = 1
+	flags = AFFECTS_DEAD
+
+/datum/reagent/floodinfectiontoxin/affect_blood(var/mob/living/carbon/human/H, var/alien, var/removed)
+	if(!prob(FLOOD_INFECTION_MESSAGE_PROB))
+		return
+	var/percent_to_overdose = (volume / overdose) * 100
+	var/message = ""
+	if(percent_to_overdose <= 100)
+		message = pick(FLOOD_INFECTION_MESSAGES_HIGH)
+	if(percent_to_overdose < 75)
+		message = pick(FLOOD_INFECTION_MESSAGES_MEDIUM)
+	if(percent_to_overdose < 50)
+		message = pick(FLOOD_INFECTION_MESSAGES_LOW)
+	to_chat(H,"<span class = 'warning'>[message]</span>")
+
+/datum/reagent/floodinfectiontoxin/overdose(var/mob/living/carbon/human/H)
+	holder.remove_reagent("Unknown Biological Contaminant",volume)
+	to_chat(H,"<span class = 'danger'>Your flesh writhes and twists against your own control...</span>")
+	spawn(20)
+		var/mob/living/simple_animal/hostile/flood/spawned_flood = new
+		spawned_flood.do_infect(H)
+		qdel(spawned_flood)

--- a/code/modules/halo/flood/flood_infection_chem.dm
+++ b/code/modules/halo/flood/flood_infection_chem.dm
@@ -42,8 +42,22 @@
 
 /datum/reagent/floodinfectiontoxin/overdose(var/mob/living/carbon/human/H)
 	holder.remove_reagent("Unknown Biological Contaminant",volume)
+	if(locate(/obj/effect/dead_infestor) in H.contents)
+		return
 	to_chat(H,"<span class = 'danger'>Your flesh writhes and twists against your own control...</span>")
-	spawn(20)
-		var/mob/living/simple_animal/hostile/flood/spawned_flood = new
-		spawned_flood.do_infect(H)
-		qdel(spawned_flood)
+	var/mob/living/simple_animal/hostile/flood/spawned_flood = new
+	spawned_flood.do_infect(H)
+	qdel(spawned_flood)
+
+//Items for testing.
+/obj/item/weapon/reagent_containers/syringe/floodtox
+	name = "Unknown Biological Contaminant"
+	desc = "A syringe filled with a green, bloodlike substance that appears to have lifeforms floating in it."
+	volume = 30
+	amount_per_transfer_from_this = 30
+
+
+	New()
+		..()
+		reagents.add_reagent(/datum/reagent/floodinfectiontoxin, 30)
+		update_icon()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -118,6 +118,10 @@
 		M.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 		return M
 
+	if(istype(attacked,/obj/structure))
+		var/obj/structure/attacked_obj = attacked
+		attacked_obj.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
+
 /mob/living/simple_animal/hostile/RangedAttack(var/atom/attacked)
 	if(!ranged)
 		return

--- a/maps/desert_outpost/gamemode/mode_stranded.dm
+++ b/maps/desert_outpost/gamemode/mode_stranded.dm
@@ -9,7 +9,7 @@
 	extended_round_description = "Your ship has crash landed on a distant alien world. Now waves of Flood are attacking and there is only limited time to setup defences. Can you survive until the rescue team arrives?"
 	//hub_descriptions = list("desperately struggling to survive against waves of parasitic aliens on a distant world...")
 
-	allowed_ghost_roles = list(/datum/ghost_role/flood_combat_form)
+	allowed_ghost_roles = list()
 
 	var/player_faction = "UNSC"
 	var/wave_num = 0

--- a/maps/desert_outpost/gamemode/mode_stranded_attackers_spawn.dm
+++ b/maps/desert_outpost/gamemode/mode_stranded_attackers_spawn.dm
@@ -1,6 +1,8 @@
 
 /datum/game_mode/stranded/proc/spawn_attackers_tick(var/amount = 1)
 	set background = 1
+	if(allowed_ghost_roles.len == 0 || isnull(allowed_ghost_roles))
+		allowed_ghost_roles += list(/datum/ghost_role/flood_combat_form)
 	amount += bonus_spawns
 	bonus_spawns = 0
 	while(amount >= 1)


### PR DESCRIPTION
Changes flood infestation to use a chemical to track the progression of the infestation. A single infestor form provides half of the required amount to fully infect someone. Partial infection merely rarely displays a message. The infection chemical is purposefully scannable and can be harvested from partially-infested people to create powerful bioweapons.

Fixes the issue of player flood-forms being inable to attack structures.

Slightly changes the stranded gamemode to ensure players do not ghost-spawn as combat forms before normal spawning has started.