### PR TITLE
Armour ability fix

### DIFF
--- a/code/modules/halo/clothing/spartan_armour.dm
+++ b/code/modules/halo/clothing/spartan_armour.dm
@@ -73,7 +73,7 @@
 	..()
 
 	spawn(0)
-		if(user && user.client && specials.len <= 2 && available_abilities.len)
+		if(user && user.client && specials.len <= 3 && available_abilities.len)
 			var/ability_type_string = input(user, "Choose the armour ability of your MJOLNIR","MJOLNIR Armour Ability") in available_abilities
 			var/ability_type = available_abilities[ability_type_string]
 			specials.Add(new ability_type(src))


### PR DESCRIPTION
Fixes Armour Abilities not being added to Spartans on spawn by changing the maximum amount of armour abilities from 2 to 3. (Shields and shieldmonitor both count as AAs in the code)
