### PR TITLE
Hunter crash fix

### DIFF
--- a/code/modules/halo/species_items/lekgolo.dm
+++ b/code/modules/halo/species_items/lekgolo.dm
@@ -46,12 +46,8 @@
 /mob/living/simple_animal/lekgolo/proc/random_name()
  	var/list/syllables = list("rg","rx","ll","rk","ck","rt","tr","rl","sn","ns","sl","ls","sp","ps")
  	var/list/vowels = list("a","e","i","o","u")
- 	var/syllables_left = rand(4,10)
- 	var/final_name = ""
- 	while(syllables_left > 0)
-		syllables_left -= 1
-		final_name += pick(vowels)
-		final_name += pick(syllables)
+ 	var/final_name = pick(syllables) + pick(vowels) + pick(syllables) + pick(vowels) + pick(syllables) + pick(vowels) + pick(syllables) + pick(vowels) + pick(syllables) + pick(vowels) + pick(syllables) + pick(vowels)
+ 	//The loop that was doing the above in previous versions was causing crashes. I've only done it this way as a temporary fix until a more efficient version does not crash.
  	return final_name
 
 /mob/living/simple_animal/lekgolo/verb/set_name()


### PR DESCRIPTION
Removes the while loop that caused server crash and replaced it with something less efficient that doesn't crash. I'll consider this a temporary fix so that OPRF can actually finish rounds until someone implements a more efficient system that doesn't crash.