### PR TITLE
Commando armour tweak

### DIFF
--- a/code/modules/halo/clothing/urf_commando.dm
+++ b/code/modules/halo/clothing/urf_commando.dm
@@ -30,7 +30,7 @@
 	light_overlay = "helmet_light"
 	brightness_on = 4
 	on = 0
-	armor_thickness = 20
+	armor_thickness = 10
 
 /obj/item/clothing/suit/armor/special/urfc
 	name = "URFC Rifleman Armour"
@@ -43,12 +43,12 @@
 	item_state_slots = list(slot_l_hand_str = "urf_armour", slot_r_hand_str = "urf_armour")
 	armor = list(melee = 55, bullet = 50, laser = 55, energy = 45, bomb = 60, bio = 100, rad = 25)
 	item_flags = THICKMATERIAL | STOPPRESSUREDAMAGE
-	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS | FEET
+	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	armor_thickness = 20
+	armor_thickness = 10
 
 /obj/item/clothing/shoes/magboots/urfc
 	name = "URFC Magboots"


### PR DESCRIPTION
After some discussion with commando players over the last few days, I decided to change a few values for their armour. This PR simply re-adds arm and hand protection to their armour, while reducing the thickness to 10 (half). This may be considered a fair trade so that they aren't copy/pasted from ODSTs as much. Most likely requires discussion before being implemented into the server.