### PR TITLE
Glassing laser shipcombat

### DIFF
--- a/code/modules/halo/machinery/Energy_projector.dm
+++ b/code/modules/halo/machinery/Energy_projector.dm
@@ -237,15 +237,17 @@
 /obj/item/projectile/projector_laser_damage_proj/proc/create_child_projs()
 	//Spawn 4 child-projectiles
 	var/list/obj/item/projectile/child_projs = list()
-	var/list/adjacent_turfs = range(starting,2) - starting
+	var/list/adjacent_turfs = range(starting,1) - starting
 	var/i //Why do you need to do it this way, DMcode, WHY?!?!
 	for(i=0,i<=4,i++)
 		var/turf/spawnloc = pick(adjacent_turfs)
 		adjacent_turfs =- spawnloc
-		child_projs += new /obj/item/projectile/projector_laser_damage_proj/childproj(spawnloc)
+		var/spawned_proj = new /obj/item/projectile/projector_laser_damage_proj/childproj(spawnloc)
+		child_projs.Add(spawned_proj)
 
 	for(var/obj/item/projectile/childproj in child_projs)
-		childproj.launch(pick(range(original,2)-original))
+		childproj.launch(pick(range(original,1)-original))
+
 
 /obj/item/projectile/projector_laser_damage_proj/childproj/create_child_projs()
 	return

--- a/code/modules/halo/machinery/Energy_projector.dm
+++ b/code/modules/halo/machinery/Energy_projector.dm
@@ -1,5 +1,6 @@
 #define ACCELERATOR_OVERLAY_ICON_STATE "lrport1"
-#define MAC_AMMO_LIMIT 3
+#define AMMO_LIMIT 1
+#define LOAD_AMMO_DELAY 140
 #define CAPACITOR_DAMAGE_AMOUNT 0.8
 #define CAPACITOR_MAX_STORED_CHARGE 150000
 #define CAPACITOR_RECHARGE_TIME 15 //This is in seconds.
@@ -36,12 +37,12 @@
 
 /obj/machinery/Energy_projector/energy_loader/examine(var/mob/user)
 	. = ..()
-	to_chat(user,"<span class = 'notice'>[contained_rounds.len]/[MAC_AMMO_LIMIT] plasma charges loaded.</span>")
+	to_chat(user,"<span class = 'notice'>[contained_rounds.len]/[AMMO_LIMIT] plasma charges loaded.</span>")
 
 /obj/machinery/Energy_projector/energy_loader/attack_hand(var/mob/user)
 	if(loading)
 		return
-	if(contained_rounds.len >= MAC_AMMO_LIMIT)
+	if(contained_rounds.len >= AMMO_LIMIT)
 		to_chat(user,"<span class = 'notice'>The Energy projector cannot load any more plasma.</span>")
 		return
 	visible_message("[user] activates the projector's loading mechanism.")
@@ -216,8 +217,7 @@
 	penetrating = 999
 	step_delay = 0.0 SECONDS
 	tracer_type = /obj/effect/projectile/projector_laser_proj
-	tracer_delay_time = 2 SECONDS
-
+	tracer_delay_time = 5 SECONDS
 
 /obj/item/projectile/projector_laser_damage_proj/attack_mob()
 	damage_type = BURN
@@ -230,6 +230,29 @@
 		damage *= wall.reinf_material.brute_armor //negates the damage loss from reinforced walls
 	. = ..()
 
+/obj/item/projectile/projector_laser_damage_proj/launch()
+	create_child_projs()
+	. = ..()
 
-#undef MAC_AMMO_LIMIT
+/obj/item/projectile/projector_laser_damage_proj/proc/create_child_projs()
+	//Spawn 4 child-projectiles
+	var/list/obj/item/projectile/child_projs = list()
+	var/list/adjacent_turfs = range(starting,1)
+	var/i //Why do you need to do it this way, DMcode, WHY?!?!
+	for(i=0,i<=4,i++)
+		var/turf/spawnloc = pick(adjacent_turfs)
+		adjacent_turfs =- spawnloc
+		child_projs += new /obj/item/projectile/projector_laser_damage_proj/childproj(spawnloc)
+
+	for(var/obj/item/projectile/childproj in child_projs)
+		childproj.launch(pick(range(original,1)))
+
+/obj/item/projectile/projector_laser_damage_proj/childproj/create_child_projs()
+	return
+
+#undef AMMO_LIMIT
 #undef ACCELERATOR_OVERLAY_ICON_STATE
+#undef LOAD_AMMO_DELAY
+#undef CAPACITOR_DAMAGE_AMOUNT
+#undef CAPACITOR_MAX_STORED_CHARGE
+#undef CAPACITOR_RECHARGE_TIME

--- a/code/modules/halo/machinery/Energy_projector.dm
+++ b/code/modules/halo/machinery/Energy_projector.dm
@@ -237,7 +237,7 @@
 /obj/item/projectile/projector_laser_damage_proj/proc/create_child_projs()
 	//Spawn 4 child-projectiles
 	var/list/obj/item/projectile/child_projs = list()
-	var/list/adjacent_turfs = range(starting,1)
+	var/list/adjacent_turfs = range(starting,2) - starting
 	var/i //Why do you need to do it this way, DMcode, WHY?!?!
 	for(i=0,i<=4,i++)
 		var/turf/spawnloc = pick(adjacent_turfs)
@@ -245,7 +245,7 @@
 		child_projs += new /obj/item/projectile/projector_laser_damage_proj/childproj(spawnloc)
 
 	for(var/obj/item/projectile/childproj in child_projs)
-		childproj.launch(pick(range(original,1)))
+		childproj.launch(pick(range(original,2)-original))
 
 /obj/item/projectile/projector_laser_damage_proj/childproj/create_child_projs()
 	return

--- a/code/modules/halo/machinery/MAC.dm
+++ b/code/modules/halo/machinery/MAC.dm
@@ -2,7 +2,8 @@
 #define CAPACITOR_MAX_STORED_CHARGE 50000
 #define CAPACITOR_RECHARGE_TIME 10 //This is in seconds.
 #define ACCELERATOR_OVERLAY_ICON_STATE "mac_accelerator_effect"
-#define MAC_AMMO_LIMIT 3
+#define AMMO_LIMIT 3
+#define LOAD_AMMO_DELAY 70
 
 /obj/machinery/mac_cannon
 	name = "MAC Component"
@@ -29,18 +30,18 @@
 
 /obj/machinery/mac_cannon/ammo_loader/examine(var/mob/user)
 	. = ..()
-	to_chat(user,"<span class = 'notice'>[contained_rounds.len]/[MAC_AMMO_LIMIT] rounds loaded.</span>")
+	to_chat(user,"<span class = 'notice'>[contained_rounds.len]/[AMMO_LIMIT] rounds loaded.</span>")
 
 /obj/machinery/mac_cannon/ammo_loader/attack_hand(var/mob/user)
 	if(loading)
 		return
-	if(contained_rounds.len >= MAC_AMMO_LIMIT)
+	if(contained_rounds.len >= AMMO_LIMIT)
 		to_chat(user,"<span class = 'notice'>The MAC cannot load any more rounds.</span>")
 		return
 	visible_message("[user] activates the MAC's loading mechanism.")
 	loading = 1
 	playsound(loc, 'code/modules/halo/machinery/mac_gun_load.ogg', 100,1, 255)
-	spawn(70) //Loading sound take 70 seconds to complete
+	spawn(LOAD_AMMO_DELAY) //Loading sound take 7 seconds to complete
 		var/obj/new_round = new /obj/overmap_weapon_ammo/mac
 		contents += new_round
 		contained_rounds += new_round
@@ -260,5 +261,9 @@
 	. = ..()
 	explosion(impacted,rand(2,3),rand(4,6),rand(6,8),rand(10,20))
 
-#undef MAC_AMMO_LIMIT
+#undef AMMO_LIMIT
 #undef ACCELERATOR_OVERLAY_ICON_STATE
+#undef LOAD_AMMO_DELAY
+#undef CAPACITOR_DAMAGE_AMOUNT
+#undef CAPACITOR_MAX_STORED_CHARGE
+#undef CAPACITOR_RECHARGE_TIME

--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -3,6 +3,7 @@
 	var/obj/effect/projectile/ship_damage_projectile = /obj/item/projectile/overmap_test_round //This is the projectile used when this impacts a ship on the overmap. This is spawned in a random connected z-level of that overmap ship object.
 	step_delay = 1 SECOND //These will only be traversing overmap tiles.
 	var/obj/effect/overmap/overmap_fired_by
+	accuracy = 100
 
 /obj/item/projectile/overmap/New(var/obj/spawner)
 	if(map_sectors["[spawner.z]"])
@@ -71,8 +72,8 @@
 		end_co_ords = generate_co_ords_y_end(start_co_ords,overmap_object_hit.map_bounds)
 	var/turf/proj_spawn_loc = locate(start_co_ords[1],start_co_ords[2],z_level)
 	var/turf/proj_end_loc = locate(end_co_ords[1],end_co_ords[2],z_level)
-	var/obj/item/projectile/new_proj = new ship_damage_projectile
-	new_proj.loc = proj_spawn_loc
+	var/obj/item/projectile/new_proj = new ship_damage_projectile (proj_spawn_loc)
+	new_proj.starting = proj_spawn_loc
 	new_proj.launch(proj_end_loc)
 
 /obj/item/projectile/overmap/on_impact(var/atom/impacted)

--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -74,6 +74,7 @@
 	var/turf/proj_end_loc = locate(end_co_ords[1],end_co_ords[2],z_level)
 	var/obj/item/projectile/new_proj = new ship_damage_projectile (proj_spawn_loc)
 	new_proj.starting = proj_spawn_loc
+	new_proj.original = proj_end_loc
 	new_proj.launch(proj_end_loc)
 
 /obj/item/projectile/overmap/on_impact(var/atom/impacted)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -256,11 +256,11 @@
 
 	//penetrating projectiles can pass through things that otherwise would not let them
 	if(!passthrough && penetrating > 0)
-		if(check_penetrate(A))
-			passthrough = 1
 		if(penetrating == 999)
 			passthrough = 1
 		else
+			if(check_penetrate(A))
+				passthrough = 1
 			penetrating--
 
 	//the bullet passes through a dense object!

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -31,7 +31,7 @@
 	var/taser_effect = 0 //If set then the projectile will apply it's agony damage using stun_effect_act() to mobs it hits, and other damage will be ignored
 	var/check_armour = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
 	var/projectile_type = /obj/item/projectile
-	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate()
+	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate(). If 999, always penetrates.
 	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.
 		//Effects
 	var/stun = 0
@@ -258,7 +258,10 @@
 	if(!passthrough && penetrating > 0)
 		if(check_penetrate(A))
 			passthrough = 1
-		penetrating--
+		if(penetrating == 999)
+			passthrough = 1
+		else
+			penetrating--
 
 	//the bullet passes through a dense object!
 	if(passthrough)


### PR DESCRIPTION
Changes the way the glassing laser works to make it more suitable for ship-v-ship combat.
Due to the potential power of the weapon, the amount of held ammo has been reduced from 3 to 1.