### PR TITLE
Missile changes

### DIFF
--- a/code/modules/halo/machinery/missile_pods.dm
+++ b/code/modules/halo/machinery/missile_pods.dm
@@ -61,6 +61,7 @@
 	desc = "An explosive warhead on the end of a guided thruster."
 	icon = 'code/modules/halo/machinery/deck_missile_pod.dmi'
 	icon_state = "missile"
+	damage = 0 //It's a missile, it has no innate damage.
 
 /obj/item/projectile/missile_damage_proj/on_impact(var/atom/impacted)
 	explosion(loc,-1,1,3,5)
@@ -75,10 +76,9 @@
 /obj/item/projectile/missile_damage_proj/burrowing
 	name = "missile"
 	desc = "An explosive warhead on the end of a guided thruster."
-	damage = 200 //Same damage as a deck gun, but without the armour bypass.
 	penetrating = 2
 
-/obj/item/projectile/missile_damage_proj/Move(var/turf/new_loc,var/dir)
+/obj/item/projectile/missile_damage_proj/burrowing/Move(var/turf/new_loc,var/dir)
 	if(istype(new_loc,/turf/simulated/floor))
 		. = ..()
 		explosion(new_loc,-1,-1.5,10)

--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -155,7 +155,7 @@
 	spawn(TRACK_PROJECTILE_IMPACT_RESET_DELAY)
 		source_console.currently_tracked_proj = null
 		if(firer_using_console())
-			firer.reset_view(firer)
+			firer.reset_view(map_sectors["[source_console.z]"])
 		qdel()
 
 //Base Ship Damage Projectile//


### PR DESCRIPTION
Changes missiles to have no innate damage.

Also fixes an issue where missiles would explode each time they passed over a floor tile, instead of just on impact.

Makes the Ordinance Tracking System reset to an overmap-view instead of a mob-view