### PR TITLE
Flood Biomass spawning re-enabled

### DIFF
--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	. = ..()
 	if(ckey || client)
 		return
-	spawn_infestor()
+	//spawn_infestor() //Had too much of a performance hit over the duration of a round.
 	if(!our_gun)
 		for(var/obj/item/weapon/gun/G in view(1,src))
 			pickup_gun(G)

--- a/code/modules/halo/flood/flood_spawn.dm
+++ b/code/modules/halo/flood/flood_spawn.dm
@@ -64,8 +64,6 @@
 /datum/flood_spawner/proc/spawn_flood()
 	if(!owner || !owner.loc)
 		return 0
-	//disable infector spawning
-	return 0
 
 	var/mob/living/simple_animal/hostile/flood/F
 	var/spawn_type = pick(spawn_pool)


### PR DESCRIPTION
Re-enables flood biomass' ability to spawn flood-related simplemobs.

Disables NPC flood combat form's abiity to spawn flood infestors.