### PR TITLE
Adds an EVA mode to shields

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1434,6 +1434,7 @@
 #include "code\modules\halo\clothing\spartan_armour_variants.dm"
 #include "code\modules\halo\clothing\spartan_gear.dm"
 #include "code\modules\halo\clothing\special_armour.dm"
+#include "code\modules\halo\clothing\special_armour_procs.dm"
 #include "code\modules\halo\clothing\urc_commando_variants.dm"
 #include "code\modules\halo\clothing\urf_commando.dm"
 #include "code\modules\halo\clothing\urf_commando_sets.dm"

--- a/code/modules/halo/clothing/special_armour_procs.dm
+++ b/code/modules/halo/clothing/special_armour_procs.dm
@@ -1,0 +1,11 @@
+
+/obj/item/clothing/suit/armor/special/proc/toggle_eva_mode()
+	set name = "Toggle Shield EVA Mode"
+	set category = "Object"
+
+	var/mob/living/toggler = usr
+	if(!istype(toggler))
+		return
+
+	for (var/datum/armourspecials/shields/s in specials)
+		s.toggle_eva_mode(toggler)

--- a/code/modules/halo/misc/armourspecials/shields.dm
+++ b/code/modules/halo/misc/armourspecials/shields.dm
@@ -55,11 +55,6 @@
 		connectedarmour.item_flags |= AIRTIGHT
 		connectedarmour.min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 		connectedarmour.cold_protection = FULL_BODY //There's probably a better way to do this, but I'm not sure of the correct use of the operators.
-		connectedarmour.cold_protection |= HEAD
-		connectedarmour.cold_protection |= FACE
-		connectedarmour.body_parts_covered = FULL_BODY
-		connectedarmour.body_parts_covered |= HEAD
-		connectedarmour.body_parts_covered |= FACE
 
 	else
 		connectedarmour.visible_message("[toggler] reroutes their shields, prioritising defense.")
@@ -69,7 +64,6 @@
 		connectedarmour.item_flags = initial(connectedarmour.item_flags)
 		connectedarmour.min_cold_protection_temperature = initial(connectedarmour.min_cold_protection_temperature)
 		connectedarmour.cold_protection = initial(connectedarmour.cold_protection)
-		connectedarmour.body_parts_covered = initial(connectedarmour.body_parts_covered)
 
 /datum/armourspecials/shields/update_mob_overlay(var/image/generated_overlay)
 	mob_overlay = generated_overlay

--- a/code/modules/halo/misc/armourspecials/shields.dm
+++ b/code/modules/halo/misc/armourspecials/shields.dm
@@ -42,17 +42,11 @@
 	add_evamode_verb()
 
 /datum/armourspecials/shields/proc/add_evamode_verb() //Proc-ified to allow subtypes to disable EVA mode.
-	connectedarmour.verbs += /datum/armourspecials/shields/proc/toggle_eva_mode
+	connectedarmour.verbs += /obj/item/clothing/suit/armor/special/proc/toggle_eva_mode
 
-/datum/armourspecials/shields/proc/toggle_eva_mode()
-	set name = "Toggle Shield EVA Mode"
-	set category = "Object"
+/datum/armourspecials/shields/proc/toggle_eva_mode(var/mob/toggler)
 
-	var/mob/living/toggler = usr
-	if(!istype(toggler))
-		return
-
-	eva_mode_active = !eva_mode_active
+	src.eva_mode_active = !src.eva_mode_active
 	if(eva_mode_active)
 		connectedarmour.visible_message("[toggler] reroutes their shields, prioritising atmospheric and pressure containment.")
 		totalshields = connectedarmour.totalshields /4
@@ -60,8 +54,13 @@
 		connectedarmour.item_flags |= STOPPRESSUREDAMAGE
 		connectedarmour.item_flags |= AIRTIGHT
 		connectedarmour.min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-		connectedarmour.cold_protection = FULL_BODY
+		connectedarmour.cold_protection = FULL_BODY //There's probably a better way to do this, but I'm not sure of the correct use of the operators.
+		connectedarmour.cold_protection |= HEAD
+		connectedarmour.cold_protection |= FACE
 		connectedarmour.body_parts_covered = FULL_BODY
+		connectedarmour.body_parts_covered |= HEAD
+		connectedarmour.body_parts_covered |= FACE
+
 	else
 		connectedarmour.visible_message("[toggler] reroutes their shields, prioritising defense.")
 		totalshields = connectedarmour.totalshields

--- a/code/modules/halo/misc/armourspecials/shields.dm
+++ b/code/modules/halo/misc/armourspecials/shields.dm
@@ -32,12 +32,45 @@
 	var/armour_state = SHIELD_IDLE
 	var/tick_recharge = 30
 	var/intercept_chance = 100
+	var/eva_mode_active = 0
 
 /datum/armourspecials/shields/New(var/obj/item/clothing/suit/armor/special/c) //Needed the type path for typecasting to use the totalshields var.
 	connectedarmour = c
 	totalshields = connectedarmour.totalshields
 	shieldstrength = totalshields
 	armourvalue = connectedarmour.armor
+	add_evamode_verb()
+
+/datum/armourspecials/shields/proc/add_evamode_verb() //Proc-ified to allow subtypes to disable EVA mode.
+	connectedarmour.verbs += /datum/armourspecials/shields/proc/toggle_eva_mode
+
+/datum/armourspecials/shields/proc/toggle_eva_mode()
+	set name = "Toggle Shield EVA Mode"
+	set category = "Object"
+
+	var/mob/living/toggler = usr
+	if(!istype(toggler))
+		return
+
+	eva_mode_active = !eva_mode_active
+	if(eva_mode_active)
+		connectedarmour.visible_message("[toggler] reroutes their shields, prioritising atmospheric and pressure containment.")
+		totalshields = connectedarmour.totalshields /4
+		shieldstrength = 0
+		connectedarmour.item_flags |= STOPPRESSUREDAMAGE
+		connectedarmour.item_flags |= AIRTIGHT
+		connectedarmour.min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+		connectedarmour.cold_protection = FULL_BODY
+		connectedarmour.body_parts_covered = FULL_BODY
+	else
+		connectedarmour.visible_message("[toggler] reroutes their shields, prioritising defense.")
+		totalshields = connectedarmour.totalshields
+		shieldstrength = 0
+		armourvalue = connectedarmour.armor
+		connectedarmour.item_flags = initial(connectedarmour.item_flags)
+		connectedarmour.min_cold_protection_temperature = initial(connectedarmour.min_cold_protection_temperature)
+		connectedarmour.cold_protection = initial(connectedarmour.cold_protection)
+		connectedarmour.body_parts_covered = initial(connectedarmour.body_parts_covered)
 
 /datum/armourspecials/shields/update_mob_overlay(var/image/generated_overlay)
 	mob_overlay = generated_overlay

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -19,13 +19,13 @@
 	active_throwforce = 12
 	edge = 0
 	sharp = 0
-	var/failsafe = 1
+	var/failsafe = 0
 	activate_sound = 'code/modules/halo/sounds/Energysworddeploy.ogg'
 	var/next_leapwhen
 
 /obj/item/weapon/melee/energy/elite_sword/New()
 	. = ..()
-	verbs += /obj/item/weapon/melee/energy/elite_sword/proc/disable_failsafe
+	verbs += /obj/item/weapon/melee/energy/elite_sword/proc/enable_failsafe
 
 /obj/item/weapon/melee/energy/elite_sword/proc/enable_failsafe()
 	set name = "Enable weapon failsafe"
@@ -51,6 +51,8 @@
 	return ESWORD_LEAP_DIST
 
 /obj/item/weapon/melee/energy/elite_sword/afterattack(var/atom/target,var/mob/user)
+	if(user.loc.Adjacent(target))
+		return
 	if(world.time < next_leapwhen)
 		to_chat(user,"<span class = 'notice'>You're still recovering from the last lunge!</span>")
 		return
@@ -122,8 +124,10 @@
 
 /obj/item/weapon/melee/energy/elite_sword/dropped(var/mob/user)
 	. = ..()
+	if(loc == null) //We probably shouldn't be exploding if we're in nullspace.
+		return
 	if(!istype(loc,/mob))
-		if(w_class != ITEM_SIZE_SMALL)
+		if(icon_state == icon_state_deployed)
 			if(failsafe)
 				src.visible_message("<span class='warning'>[src] bursts into a superheated flash of plasma!</span>")
 				flick("blade burnout",src)
@@ -139,7 +143,6 @@
 					qdel(src)
 			else
 				deactivate(user)
-				visible_message("<span class='notice'>\The [src] disappears in a flash of light.</span>")
 
 /obj/item/weapon/melee/energy/elite_sword/attack(var/mob/m,var/mob/user)
 	if(ismob(m))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -113,14 +113,18 @@
 
 	var/pressure_adjustment_coefficient = 1 // Assume no protection at first.
 
+	if(head && (head.item_flags & STOPPRESSUREDAMAGE) && wear_suit && (wear_suit.item_flags & STOPPRESSUREDAMAGE))
+		pressure_adjustment_coefficient -= 0.4 //A full set reduces it to 0
+
 	if(head && head.item_flags & STOPPRESSUREDAMAGE)
-		pressure_adjustment_coefficient -= THERMAL_PROTECTION_HEAD
+		pressure_adjustment_coefficient -= 0.3 //But each one has it's own, lower effect.
+		//Value chosen to reduce the pressure damage down one level but not remove the warning
 
 	if(wear_suit && (wear_suit.item_flags & STOPPRESSUREDAMAGE))
-		if(wear_suit.body_parts_covered & HEAD)
-			pressure_adjustment_coefficient = 1
+		if(wear_suit.cold_protection & HEAD) //Cold protected areas on a sealed suit are also probably pressure-sealed
+			pressure_adjustment_coefficient = 0
 		else
-			pressure_adjustment_coefficient -= (1 - THERMAL_PROTECTION_HEAD)
+			pressure_adjustment_coefficient -= 0.3
 
 		// Handles breaches in your space suit. 10 suit damage equals a 100% loss of pressure protection.
 		if(istype(wear_suit,/obj/item/clothing/suit/space))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -113,8 +113,14 @@
 
 	var/pressure_adjustment_coefficient = 1 // Assume no protection at first.
 
-	if(wear_suit && (wear_suit.item_flags & STOPPRESSUREDAMAGE) && head && (head.item_flags & STOPPRESSUREDAMAGE)) // Complete set of pressure-proof suit worn, assume fully sealed.
-		pressure_adjustment_coefficient = 0
+	if(head && head.item_flags & STOPPRESSUREDAMAGE)
+		pressure_adjustment_coefficient -= THERMAL_PROTECTION_HEAD
+
+	if(wear_suit && (wear_suit.item_flags & STOPPRESSUREDAMAGE))
+		if(wear_suit.body_parts_covered & HEAD)
+			pressure_adjustment_coefficient = 1
+		else
+			pressure_adjustment_coefficient -= (1 - THERMAL_PROTECTION_HEAD)
 
 		// Handles breaches in your space suit. 10 suit damage equals a 100% loss of pressure protection.
 		if(istype(wear_suit,/obj/item/clothing/suit/space))

--- a/html/changelogs/XO11 - Shield EVA Mode.yml
+++ b/html/changelogs/XO11 - Shield EVA Mode.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: XO-11
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds a (verb-activated) mode to all shield-using armor that allows the toggling of an "EVA Mode" which reduces the maximum shield strength by a quarter but provides full protection against pressure and cold."

--- a/html/changelogs/XO11 - Shield EVA Mode.yml
+++ b/html/changelogs/XO11 - Shield EVA Mode.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Adds a (verb-activated) mode to all shield-using armor that allows the toggling of an "EVA Mode" which reduces the maximum shield strength by a quarter but provides full protection against pressure and cold."
+  - rscadd: "Adds a (verb-activated) mode to all shield-using armor that allows the toggling of an EVA Mode which reduces the maximum shield strength by a quarter but provides full protection against pressure and cold."


### PR DESCRIPTION
EVA mode is toggled via a verb, it provides full protection against pressure and cold.

Shield strength is set to 0 when toggling between modes

Maximum shield strength in EVA mode is a quarter of the original shield strength.

closes #1018 

Includes minor change to elite_sword object, making failsafes disabled by default.