### PR TITLE
Shield code changes

### DIFF
--- a/code/modules/halo/machinery/MAC.dm
+++ b/code/modules/halo/machinery/MAC.dm
@@ -1,4 +1,4 @@
-#define CAPACITOR_DAMAGE_AMOUNT 0.8
+#define CAPACITOR_DAMAGE_AMOUNT 27 //3 Direct MAC shots to down a fully charged shield from a 22-capacitor MAC.
 #define CAPACITOR_MAX_STORED_CHARGE 50000
 #define CAPACITOR_RECHARGE_TIME 10 //This is in seconds.
 #define ACCELERATOR_OVERLAY_ICON_STATE "mac_accelerator_effect"

--- a/code/modules/halo/machinery/proj_deck_gun.dm
+++ b/code/modules/halo/machinery/proj_deck_gun.dm
@@ -159,12 +159,10 @@
 	damtype = BRUTE
 	damage = 200
 
-/obj/item/projectile/deck_gun_damage_proj/get_structure_damage()
-	return damage * 10 //Counteract the /10 from wallcode damage processing.
-
 /obj/item/projectile/deck_gun_damage_proj/Bump(var/atom/impacted)
 	var/turf/simulated/wall/wall = impacted
 	if(istype(wall) && wall.reinf_material)
+		damage *= 10 //counteract the /10 from wallcode damage processing
 		damage *= wall.reinf_material.brute_armor //negates the damage loss from reinforced walls
 	. = ..()
 

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -207,6 +207,9 @@
 
 // Projectiles
 /obj/effect/shield/bullet_act(var/obj/item/projectile/proj)
+	if(!(proj.penetrating > 0))
+		proj.damage /= 100 //reduces the damage of a deck-gun from 200 to 2.
+	proj.penetrating = 0
 	if(proj.damage_type == BURN)
 		take_damage(proj.get_structure_damage(), SHIELD_DAMTYPE_HEAT)
 	else if (proj.damage_type == BRUTE)


### PR DESCRIPTION
modifies the way shield code calculates impacted projectiles damage.

ensures covie shields don't drop to literally 0 via a single deck gun round

buffs the damage obtained by each MAC capacitor (0.8 > 27)

closes #1059 