### PR TITLE
Overmap Weapons Fix : Energy Beam Penetration

### DIFF
--- a/code/modules/halo/machinery/Energy_projector.dm
+++ b/code/modules/halo/machinery/Energy_projector.dm
@@ -216,6 +216,7 @@
 	damage = 900
 	penetrating = 999
 	step_delay = 0.0 SECONDS
+	kill_count = 999 //so it doesn't despawn before cutting through the ship
 	tracer_type = /obj/effect/projectile/projector_laser_proj
 	tracer_delay_time = 5 SECONDS
 

--- a/code/modules/halo/machinery/covie_pulse_turret.dm
+++ b/code/modules/halo/machinery/covie_pulse_turret.dm
@@ -56,6 +56,7 @@
 	damage = 300
 	penetrating = 999
 	step_delay = 0.0 SECONDS
+	kill_count = 999 //so it doesn't despawn before cutting through the ship
 	tracer_type = /obj/effect/projectile/pulse_laser_dam_proj
 	tracer_delay_time = 2 SECONDS
 


### PR DESCRIPTION
Makes energy projector and pulse lasers hopefully penetrate the entire vessel instead of timing out midway through