### PR TITLE
Aim mode changes

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -470,7 +470,8 @@
 		//If you aim at someone beforehead, it'll hit more often.
 		//Kinda balanced by fact you need like 2 seconds to aim
 		//As opposed to no-delay pew pew
-		P.accuracy += 2
+		//Increased to +3 to add a larger incentive to use it, even if you are stuck in one spot with the fast-paced combat system
+		P.accuracy += 3
 
 //does the actual launching of the projectile
 /obj/item/weapon/gun/proc/process_projectile(obj/projectile, mob/user, atom/target, var/target_zone, var/params=null)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -26,4 +26,6 @@
 	owner.visible_message("<span class='danger'>\The [owner] pulls the trigger reflexively!</span>")
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))
+		var/gun_shoot_time = (G.burst - 1)* G.burst_delay
+		owner.setMoveCooldown(max(1,(3*(gun_shoot_time/4)))) //Allows for movement near the end of the burst but mostly holds the player in one spot.
 		G.Fire(aiming_at, owner)


### PR DESCRIPTION
Changes aim mode to now apply a movement-stop on fire, equal to 3/4 of the weapon's burst size, or one tick, whichever's the highest.

Accuracy buff provided by aim mode increased from +2 to +3 to compensate.

closes #1097 