### PR TITLE
Removes ship-shield "adaptive" mode

### DIFF
--- a/code/modules/shield_generators/modes.dm
+++ b/code/modules/shield_generators/modes.dm
@@ -50,11 +50,12 @@
 	mode_flag = MODEFLAG_HULL
 	multiplier = 1
 
+/*
 /datum/shield_mode/adaptive
 	mode_name = "Adaptive Field Harmonics"
 	mode_desc = "This mode modulates the shield harmonic frequencies, allowing the field to adapt to various damage types."
 	mode_flag = MODEFLAG_MODULATE
-	multiplier = 2
+	multiplier = 2*/
 
 /datum/shield_mode/bypass
 	mode_name = "Diffuser Bypass"


### PR DESCRIPTION
The damage-adaptation provided by the adaptive ship-shield mode is too powerful in the current state of overmap combat where each faction has a focused damage-type, instead of multiple different damage types. Covenant shields should be not-as-powerful now.