### PR TITLE
adds a null-console check

### DIFF
--- a/code/modules/halo/machinery/overmap_projectile.dm
+++ b/code/modules/halo/machinery/overmap_projectile.dm
@@ -81,7 +81,7 @@
 	new_proj.original = proj_end_loc
 	new_proj.firer = firer
 
-	if(console_fired_by.do_track_fired_proj && isnull(console_fired_by.currently_tracked_proj))
+	if(!isnull(console_fired_by) && console_fired_by.do_track_fired_proj && isnull(console_fired_by.currently_tracked_proj))
 		var/obj/item/projectile/camera_track/camera_track_proj = new /obj/item/projectile/camera_track (proj_spawn_loc)
 		console_fired_by.currently_tracked_proj = camera_track_proj
 		camera_track_proj.firer = firer


### PR DESCRIPTION
adds a check to overmap projectile code to deal with a weapon console being destroyed in the time between projectile impact and projecitle firing