### PR TITLE
NPC ships player-control groundwork

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1582,6 +1582,7 @@
 #include "code\modules\halo\overmap\combat_npc_ship.dm"
 #include "code\modules\halo\overmap\fusion_thruster.dm"
 #include "code\modules\halo\overmap\npc_cargo_ship.dm"
+#include "code\modules\halo\overmap\npc_ship_playercontrol.dm"
 #include "code\modules\halo\overmap\npc_shipmap_handler.dm"
 #include "code\modules\halo\overmap\npc_ships.dm"
 #include "code\modules\halo\overmap\slipspace_gen.dm"

--- a/code/modules/halo/overmap/combat_npc_ship.dm
+++ b/code/modules/halo/overmap/combat_npc_ship.dm
@@ -29,6 +29,8 @@
 	available_ship_requests = newlist(/datum/npc_ship_request/halt,/datum/npc_ship_request/fire_on_target)
 
 /obj/effect/overmap/ship/npc_ship/combat/proc/fire_at_target()
+	if(is_player_controlled())
+		return
 	if(target_disengage_at == 0)
 		target_disengage_at = world.time + TARGET_LOSE_INTEREST_DELAY
 	if(target_disengage_at != 0 && world.time > target_disengage_at)
@@ -45,6 +47,8 @@
 /obj/effect/overmap/ship/npc_ship/combat/process()
 	if(hull <= initial(hull)/4)
 		return
+	if(is_player_controlled())
+		return ..()
 	if(target && (target in view(7,src)))
 		if(world.time > next_fireat)
 			var/obj/effect/overmap/ship/npc_ship/targ_ship = target

--- a/code/modules/halo/overmap/npc_ship_playercontrol.dm
+++ b/code/modules/halo/overmap/npc_ship_playercontrol.dm
@@ -3,7 +3,7 @@
 	for(var/datum/request in available_ship_requests)
 		qdel(request)
 	available_ship_requests.Cut()
-	available_ship_requests = list(/datum/npc_ship_request/player_controlled)
+	available_ship_requests = list(new /datum/npc_ship_request/player_controlled)
 	load_mapfile()
 
 /datum/npc_ship_request/player_controlled

--- a/code/modules/halo/overmap/npc_ship_playercontrol.dm
+++ b/code/modules/halo/overmap/npc_ship_playercontrol.dm
@@ -4,6 +4,7 @@
 		qdel(request)
 	available_ship_requests.Cut()
 	available_ship_requests = list(/datum/npc_ship_request/player_controlled)
+	load_mapfile()
 
 /datum/npc_ship_request/player_controlled
 	request_requires_processing = 1

--- a/code/modules/halo/overmap/npc_ship_playercontrol.dm
+++ b/code/modules/halo/overmap/npc_ship_playercontrol.dm
@@ -10,4 +10,6 @@
 	request_requires_processing = 1
 
 /datum/npc_ship_request/player_controlled/do_request_process(var/obj/effect/overmap/ship/npc_ship/ship_source)
+	if(ship_source.hull > initial(ship_source.hull)/4) //Slowly reduce the hull over time to eventually start the lose_to_space processing
+		ship_source.hull--
 	return 1

--- a/code/modules/halo/overmap/npc_ship_playercontrol.dm
+++ b/code/modules/halo/overmap/npc_ship_playercontrol.dm
@@ -1,0 +1,12 @@
+//Clears an NPC ship's requests list and replaces it with a request that will cause the npc ship to do nothing besides sit still.
+/obj/effect/overmap/ship/npc_ship/proc/make_player_controlled()
+	for(var/datum/request in available_ship_requests)
+		qdel(request)
+	available_ship_requests.Cut()
+	available_ship_requests = list(/datum/npc_ship_request/player_controlled)
+
+/datum/npc_ship_request/player_controlled
+	request_requires_processing = 1
+
+/datum/npc_ship_request/player_controlled/do_request_process(var/obj/effect/overmap/ship/npc_ship/ship_source)
+	return 1

--- a/code/modules/halo/overmap/npc_ships.dm
+++ b/code/modules/halo/overmap/npc_ships.dm
@@ -60,7 +60,7 @@
 	return 0
 
 /obj/effect/overmap/ship/npc_ship/proc/lose_to_space()
-	if(hull > initial(hull)/4 && !is_player_controlled())//If they still have more than quarter of their "hull" left, let them drift in space.
+	if(hull > initial(hull)/4)//If they still have more than quarter of their "hull" left, let them drift in space.
 		return
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.z in map_z && player.stat != DEAD)
@@ -100,7 +100,7 @@
 		for(var/datum/npc_ship_request/request in available_ship_requests)
 			if(request.request_requires_processing)
 				stop_normal_operations = request.do_request_process(src)
-		if(stop_normal_operations)
+		if(stop_normal_operations || is_player_controlled())
 			return
 		if(loc == target_loc)
 			pick_target_loc()

--- a/code/modules/halo/overmap/npc_ships.dm
+++ b/code/modules/halo/overmap/npc_ships.dm
@@ -60,7 +60,7 @@
 	return 0
 
 /obj/effect/overmap/ship/npc_ship/proc/lose_to_space()
-	if(hull > initial(hull)/4)//If they still have more than quarter of their "hull" left, let them drift in space.
+	if(hull > initial(hull)/4 && !is_player_controlled())//If they still have more than quarter of their "hull" left, let them drift in space.
 		return
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.z in map_z && player.stat != DEAD)
@@ -81,7 +81,8 @@
 	var/turf/start_turf = locate(x,y,z)
 	. = ..()
 	map_z.Cut()
-	forceMove(start_turf)
+	if(!isnull(start_turf))
+		forceMove(start_turf)
 	pick_target_loc()
 
 /obj/effect/overmap/ship/npc_ship/proc/pick_target_loc()


### PR DESCRIPTION
Groundwork for allowing players to "take control" of an NPC ship, essentially making it into a fully player controlled ship.

Will be used for player-base-spawned ship-shuttles