### PR TITLE
SDV cloak changes

### DIFF
--- a/maps/first_contact/maps/Covenant Corvette/overmap.dm
+++ b/maps/first_contact/maps/Covenant Corvette/overmap.dm
@@ -18,9 +18,9 @@
 /obj/effect/overmap/ship/covenant_corvette/process()
 	. = ..()
 	if(is_still())
-		animate(src,alpha = 15,time = 2 SECONDS) //Hard to see if sat still.
+		animate(src,alpha = 15,color = rgb(255,255,255),time = 2 SECONDS) //Hard to see if sat still.
 	else
-		animate(src,alpha = 255, time = 2 SECONDS)
+		animate(src,alpha = 255,color = initial(color), time = 2 SECONDS)
 
 //overmap weapons//
 /obj/machinery/overmap_weapon_console/deck_gun_control/local/cov_pulse_turretport/kig_yar_corvette


### PR DESCRIPTION
Changes the SDV's cloak to tint the vessel black as well as fade out.

This is due to purple being too easy to see even when cloaked.