### PR TITLE
DMR ammunition fix

### DIFF
--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -125,8 +125,8 @@
 
 /obj/item/ammo_casing/a762_m392
 	desc = "A 7.62mm bullet casing."
-	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet/a762/M392
+	caliber = "a762dmr"
+	projectile_type = /obj/item/projectile/bullet/a762_M392
 
 /obj/item/projectile/bullet/a762_ap
 	damage = 30
@@ -138,7 +138,7 @@
 	damage_type = PAIN
 	penetrating = 0
 
-/obj/item/projectile/bullet/a762/M392
+/obj/item/projectile/bullet/a762_M392
 	damage = 35
 	armor_penetration = 10
 

--- a/code/modules/halo/weapons/snipers.dm
+++ b/code/modules/halo/weapons/snipers.dm
@@ -50,7 +50,7 @@
 	icon_state = "M395"
 	item_state = "m392"
 	load_method = MAGAZINE
-	caliber = "a762"
+	caliber = "a762dmr"
 	slot_flags = SLOT_BACK
 	magazine_type = /obj/item/ammo_magazine/m762_ap/M392
 	allowed_magazines = list(/obj/item/ammo_magazine/m762_ap/M392) //Disallows loading LMG boxmags into the DMR.


### PR DESCRIPTION
Makes DMR ammo incompatible with the MA5B.

Due to DMR ammo being superior to MA5B, gameplay over lore will have to be utilised here to ensure powergaming is halted.

closes #1134 