### PR TITLE
Various fixes, stun-related

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -117,7 +117,7 @@
 /obj/item/weapon/melee/baton/attack(mob/M, mob/user)
 	if(status && (CLUMSY in user.mutations) && prob(50))
 		to_chat(user, "<span class='danger'>You accidentally hit yourself with the [src]!</span>")
-		user.Weaken(30)
+		user.confused += 20
 		deductcharge(hitcost)
 		return
 	return ..()
@@ -159,7 +159,8 @@
 
 	//stun effects
 	if(status)
-		target.stun_effect_act(stun, agony, hit_zone, src)
+		target.stun_effect_act(stun/2, agony, hit_zone, src)
+		target.confused += stun
 		msg_admin_attack("[key_name(user)] stunned [key_name(target)] with the [src].")
 
 		deductcharge(hitcost)

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -320,7 +320,7 @@
 	if(!istype(L) || . == 0)
 		return 0
 
-	L.Stun(stun_time)
+	L.Weaken(stun_time/2)
 	L.confused += disorient_time/2
 	shake_camera(L,disorient_time,2)
 	L.overlay_fullscreen("supress",/obj/screen/fullscreen/oxy, 6)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -125,7 +125,7 @@
 				ear_damage += 30
 				ear_deaf += 120
 			if (prob(70))
-				Paralyse(10)
+				confused += 10
 
 		if(3.0)
 			b_loss = 30
@@ -133,7 +133,7 @@
 				ear_damage += 15
 				ear_deaf += 60
 			if (prob(50))
-				Paralyse(10)
+				confused += 10
 
 	// factor in armour
 	var/protection = blocked_mult(getarmor(null, "bomb"))


### PR DESCRIPTION
Makes the stunbaton stun much lower and provides it with a confusion effect to compensate.

Explosions no longer paralyse the person for 10 seconds, instead they confuse.

SDSR-10 now actually uses Weaken() instead of Stun()

fixes some of the issues addressed in #861 