### PR TITLE
Potential hunter immortality fix

### DIFF
--- a/code/modules/halo/species_items/lekgolo.dm
+++ b/code/modules/halo/species_items/lekgolo.dm
@@ -78,6 +78,8 @@
 			hud_setup = update_action_buttons()
 	else if(hud_setup)
 		hud_setup = 0
+	
+	. = ..() //Placed here to ensure that it can still check the health before regeneration happens.
 
 	//heal a little
 	if(stat != DEAD && health < maxHealth)
@@ -86,7 +88,6 @@
 	//regain charge
 	if(active_weapon.charge_amount <= active_weapon.charge_max)
 		active_weapon.charge_amount += active_weapon.charge_recharge_amount
-	return ..()
 
 /mob/living/simple_animal/mgalekgolo/verb/set_name()
 	set name = "Set Name"


### PR DESCRIPTION
If I recall correctly, A simple-mob's decision to die is taken during the Life() tick, which meant that the hunter could never actually die due to regeneration happening before the Life() tick was processed.