### PR TITLE
makes turf-penetration do more damage

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -270,6 +270,7 @@
 		if(A)
 			if(istype(A, /turf))
 				loc = A
+				A.bullet_act(src, def_zone) //We're burrowing through the turf, let's damage it again.
 			else
 				loc = A.loc
 			permutated.Add(A)


### PR DESCRIPTION
Makes penetration through a turf do damage to that turf a second time, due to the projectile burrowing through instead of striking the outer armour.

Ran across this whilst investigating a #1164 which this may also fix.