### PR TITLE
Faction Base groundwork

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1582,6 +1582,7 @@
 #include "code\modules\halo\NPC\NPC_types\weapon_smuggler.dm"
 #include "code\modules\halo\overmap\automated_defense.dm"
 #include "code\modules\halo\overmap\combat_npc_ship.dm"
+#include "code\modules\halo\overmap\faction_base.dm"
 #include "code\modules\halo\overmap\fusion_thruster.dm"
 #include "code\modules\halo\overmap\nav_data_computer.dm"
 #include "code\modules\halo\overmap\npc_cargo_ship.dm"

--- a/code/modules/halo/overmap/automated_defense.dm
+++ b/code/modules/halo/overmap/automated_defense.dm
@@ -14,6 +14,10 @@
 	var/defense_range = 7
 	var/obj/item/projectile/overmap/proj_fired = /obj/item/projectile/overmap/auto_defense_proj
 
+/obj/effect/overmap/ship/npc_ship/automated_defenses/Initialize()
+	. = ..()
+	GLOB.overmap_tiles_uncontrolled -= range(defense_range,src)
+
 /datum/npc_ship_request/automated_defense_process
 	request_auth_levels = list()
 	request_requires_processing = 1

--- a/code/modules/halo/overmap/faction_base.dm
+++ b/code/modules/halo/overmap/faction_base.dm
@@ -1,0 +1,17 @@
+
+/obj/effect/overmap/ship/faction_base //It's a /ship to ensure that it is attacked by overmap weapons like a ship would.
+	vessel_mass = 999
+	faction = "faction_base" //This should be changed for each faction base overmap object.
+	var/spawn_defenses_amount = 4
+	var/spawn_defenses_maxrange = 1
+	var/obj/effect/overmap/ship/npc_ship/automated_defenses/defense_type = /obj/effect/overmap/ship/npc_ship/automated_defenses
+
+/obj/effect/overmap/ship/faction_base/Initialize()
+	. = ..()
+	var/list/spawn_locs = range(spawn_defenses_maxrange,src)
+	var/iter = 0
+	for(iter = 0; iter <= spawn_defenses_amount;iter++)
+		var/loc_spawnat = pick(spawn_locs)
+		spawn_locs -= loc_spawnat
+		var/obj/effect/overmap/spawned = new defense_type (loc_spawnat)
+		spawned.faction = faction

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -1,6 +1,8 @@
 //===================================================================================
 //Overmap object representing zlevel(s)
 //===================================================================================
+GLOBAL_LIST_EMPTY(overmap_tiles_uncontrolled) //This is any overmap sectors that are uncontrolled by any faction
+
 var/list/points_of_interest = list()
 
 /obj/effect/overmap
@@ -62,12 +64,11 @@ var/list/points_of_interest = list()
 	//map_z = GetConnectedZlevels(z)
 	//for(var/zlevel in map_z)
 	//	map_sectors["[zlevel]"] = src
+	var/turf/move_to_loc = pick(GLOB.overmap_tiles_uncontrolled)
 
-	start_x = start_x || rand(OVERMAP_EDGE, GLOB.using_map.overmap_size - OVERMAP_EDGE)
-	start_y = start_y || rand(OVERMAP_EDGE, GLOB.using_map.overmap_size - OVERMAP_EDGE)
+	forceMove(move_to_loc)
 
-	forceMove(locate(start_x, start_y, GLOB.using_map.overmap_z))
-	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")
+	testing("Located sector \"[name]\" at [move_to_loc.x],[move_to_loc.y], containing Z [english_list(map_z)]")
 	//points_of_interest += name
 
 	/*
@@ -185,6 +186,7 @@ var/list/points_of_interest = list()
 
 	var/area/overmap/A = new
 	A.contents.Add(turfs)
+	GLOB.overmap_tiles_uncontrolled = turfs
 
 	GLOB.using_map.sealed_levels |= GLOB.using_map.overmap_z
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -64,11 +64,12 @@ var/list/points_of_interest = list()
 	//map_z = GetConnectedZlevels(z)
 	//for(var/zlevel in map_z)
 	//	map_sectors["[zlevel]"] = src
-	var/turf/move_to_loc = pick(GLOB.overmap_tiles_uncontrolled)
+	if(GLOB.using_map.use_overmap)
+		var/turf/move_to_loc = pick(GLOB.overmap_tiles_uncontrolled)
 
-	forceMove(move_to_loc)
+		forceMove(move_to_loc)
 
-	testing("Located sector \"[name]\" at [move_to_loc.x],[move_to_loc.y], containing Z [english_list(map_z)]")
+		testing("Located sector \"[name]\" at [move_to_loc.x],[move_to_loc.y], containing Z [english_list(map_z)]")
 	//points_of_interest += name
 
 	/*


### PR DESCRIPTION
Defines an overmap object that automatically spawns defence platforms nearby.

Makes automated defence platforms stop any overmap objects from being naturally spawned within their range.

Will be used for faction bases