### PR TITLE
Various Fixes

### DIFF
--- a/code/modules/halo/chemicals/medicine.dm
+++ b/code/modules/halo/chemicals/medicine.dm
@@ -140,8 +140,8 @@
 	if(H.internal_organs_by_name[BP_LIVER])
 		var/obj/item/organ/user_liver = H.internal_organs_by_name[BP_LIVER]
 		user_liver.take_damage(1,1)
-	H.adjustToxLoss(2)
-	if(prob(5))
+	H.adjustToxLoss(1)
+	if(prob(10))
 		H.emote(pick("twitch", "blink_r", "shiver"))
 	H.add_chemical_effect(CE_SPEEDBOOST, 1)
 	H.add_chemical_effect(CE_PULSE, 2)

--- a/code/modules/halo/chemicals/medicine.dm
+++ b/code/modules/halo/chemicals/medicine.dm
@@ -94,6 +94,7 @@
 				if(!prob(BIOFOAM_PROB_REMOVE_EMBEDDED))
 					continue
 				w.embedded_objects -= embedded //Removing the embedded item from the wound
+				M.contents -= embedded
 				embedded.loc = M.loc //And placing it on the ground below
 				to_chat(M,"<span class = 'notice'>The [embedded.name] is pushed out of the [w.desc] in your [o.name].</span>")
 

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -45,6 +45,7 @@
 	step_delay = 0
 	tracer_type = /obj/effect/projectile/beam_rifle
 	tracer_delay_time = 1 SECOND
+	penetrating = 2
 	invisibility = 101
 
 /obj/effect/projectile/beam_rifle

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -48,6 +48,13 @@
 	penetrating = 2
 	invisibility = 101
 
+/obj/item/projectile/bullet/covenant/beamrifle/attack_mob(var/mob/living/carbon/human/L)
+	if(!istype(L))
+		. = ..()
+		return
+	L.radiation += 10
+	. = ..()
+
 /obj/effect/projectile/beam_rifle
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "beam_rifle_trail"
@@ -155,6 +162,13 @@
 	tracer_type = /obj/effect/projectile/type51carbine
 	tracer_delay_time = 1.5 SECONDS
 	invisibility = 101
+
+/obj/item/projectile/bullet/covenant/type51carbine/attack_mob(var/mob/living/carbon/human/L)
+	if(!istype(L))
+		. = ..()
+		return
+	L.radiation += 15
+	. = ..()
 
 /obj/effect/projectile/type51carbine
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'


### PR DESCRIPTION
Makes concentrated hyperzine do less damage.
Fixes biofoam shrapnel to not duplicate itself. (closes #1182 )
Gives the beam rifle some wall-penetration
Makes the covenant carbine and the beam rifle apply some radiation on hit.