### PR TITLE
Beam Rifle: Near Miss Burn damage

### DIFF
--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -55,6 +55,11 @@
 	L.radiation += 10
 	. = ..()
 
+/obj/item/projectile/bullet/covenant/beamrifle/do_supression_aoe(var/location)
+	. = ..()
+	for(var/mob/living/carbon/human/h in orange(1,location))
+		h.adjustBurn(damage/2)
+
 /obj/effect/projectile/beam_rifle
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "beam_rifle_trail"


### PR DESCRIPTION
Makes the beam rifle apply half of it's damage when it near-misses a person.

To adhere to lore and to shut #unsc_barracks up.