### PR TITLE
Elite Nerfs (And other small nerfs/buffs)

### DIFF
--- a/code/modules/halo/species/sangheili.dm
+++ b/code/modules/halo/species/sangheili.dm
@@ -18,8 +18,8 @@
 	radiation_mod = 0.6 //Covie weapons emit beta radiation. Resistant to 1/3 types of radiation.
 	spawn_flags = SPECIES_CAN_JOIN
 	brute_mod = 0.9
-	pain_mod = 0.75 //Pain has half an effect on them.
-	slowdown = -1 //negates noshoes
+	pain_mod = 0.75 //Pain has quarter an effect on them
+	slowdown = -0.5
 	pixel_offset_x = -8
 	item_icon_offsets = list(0,2)
 	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)

--- a/code/modules/halo/vehicles/mongoose.dm
+++ b/code/modules/halo/vehicles/mongoose.dm
@@ -12,7 +12,7 @@
 
 	comp_prof = /datum/component_profile/mongoose
 
-	vehicle_move_delay = 1
+	vehicle_move_delay = 0.5
 
 	occupants = list(1,0)
 	exposed_positions = list("driver" = 10,"passenger" = 25)

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -47,7 +47,7 @@
 	if(isnull(mob) || !istype(mob))
 		return 0
 	if(mob.species.type in ESWORD_LEAP_FAR_SPECIES)
-		return 5
+		return 4
 	return ESWORD_LEAP_DIST
 
 /obj/item/weapon/melee/energy/elite_sword/afterattack(var/atom/target,var/mob/user)

--- a/maps/first_contact/maps/Exoplanet Research/ExoResearch_2.dmm
+++ b/maps/first_contact/maps/Exoplanet Research/ExoResearch_2.dmm
@@ -332,7 +332,7 @@
 "gt" = (/obj/structure/closet/crate/bin,/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
 "gu" = (/obj/structure/bed/chair/office/dark{dir = 1},/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
 "gv" = (/obj/structure/table/steel,/obj/item/clothing/suit/armor/special/unggoy_combat_harness/major{anchored = 1},/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
-"gw" = (/obj/structure/table/steel,/obj/item/weapon/gun/projectile/type51carbine{anchored = 1; is_jammed = 1},/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
+"gw" = (/obj/structure/table/steel,/obj/item/weapon/gun/projectile/type51carbine{anchored = 1; is_jammed = 1; jam_chance = 100},/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
 "gx" = (/obj/machinery/button/remote/blast_door{_wifi_id = "Test 1"; id = "Test 1"; name = "Testing Chamber Shutters"; pixel_x = 32; pixel_y = 0},/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/weapons)
 "gy" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/storage)
 "gz" = (/obj/structure/closet/crate/large{icon_opened = "densecrate"; icon_state = "densecrate"; name = "Cardboard Supplies"; tag = "icon-densecrate"},/obj/item/stack/material/cardboard/ten,/turf/simulated/floor/tiled/dark,/area/exo_research_facility/sublevel1/interior/storage)


### PR DESCRIPTION
Reduces the speed increase for elites. It was only set to what it was to negate noshoes slowdown.
Reduces the max leap distance by one tile.
Buffs the mongoose's speed.
Make the VT9 covenant carbines have a 100% jam chance to ensure they're not effective weapons.