### PR TITLE
Unggoy tank slot fix

### DIFF
--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -114,6 +114,7 @@
 	icon = GRUNT_GEAR_ICON
 	icon_state = "methane_tank_orange"
 	item_state_slots = list(slot_back_str = "methanetank_red_back", slot_l_hand_str = "methanetank_red", slot_r_hand_str = "methanetank_red")
+	slot_flags = SLOT_BACK
 
 /obj/item/weapon/tank/methane/unggoy_internal/red
 	icon_state = "methane_tank_red"


### PR DESCRIPTION
Makes unggoy internal tanks restricted to being worn on the back.
They spawn on your back for a reason.