### PR TITLE
Various fixes

### DIFF
--- a/code/modules/halo/machinery/npc_comms.dm
+++ b/code/modules/halo/machinery/npc_comms.dm
@@ -16,7 +16,7 @@
 	hitscan = 1
 	var/authority_level = 0
 
-/obj/item/projectile/overmap/npc_comms_projectile/New(var/obj/spawner)
+/obj/item/projectile/overmap/npc_comms_projectile/New(var/spawnloc,var/obj/spawner)
 	. = ..()
 	var/obj/machinery/overmap_weapon_console/npc_comms_console/console = spawner
 	if(istype(console))

--- a/code/modules/halo/machinery/overmap_weapon.dm
+++ b/code/modules/halo/machinery/overmap_weapon.dm
@@ -85,7 +85,7 @@
 
 /obj/machinery/overmap_weapon_console/proc/fire_projectile(var/atom/target,var/mob/user,var/directly_above = 0)
 	var/obj/om_obj = map_sectors["[z]"]
-	var/obj/item/projectile/new_projectile = new fired_projectile (om_obj.loc)
+	var/obj/item/projectile/new_projectile = new fired_projectile (om_obj.loc,om_obj)
 	new_projectile.damage += get_linked_device_damage_mod()
 	new_projectile.permutated = map_sectors["[z]"] //Ensuring we don't hit ourselves somehow
 	new_projectile.firer = user

--- a/code/modules/halo/overmap/automated_defense.dm
+++ b/code/modules/halo/overmap/automated_defense.dm
@@ -19,6 +19,9 @@
 	. = ..()
 	GLOB.overmap_tiles_uncontrolled -= range(defense_range*2,src)
 
+/obj/effect/overmap/ship/npc_ship/automated_defenses/can_board() //Now you can board them, any time you want!
+	return 1
+
 /obj/effect/overmap/ship/npc_ship/automated_defenses/take_projectiles(var/obj/item/projectile/overmap/proj,var/add_proj = 1)
 	. = ..()
 	for(var/datum/npc_ship_request/automated_defense_process/p in available_ship_requests)

--- a/maps/_gamemodes/invasion/invasion.dm
+++ b/maps/_gamemodes/invasion/invasion.dm
@@ -139,7 +139,7 @@
 	round_end_reasons = list()
 
 	//the cov ship has been destroyed or gone to slipspace
-	if(!cov_ship || cov_ship.loc == null)
+	if(!cov_ship)
 		if(covenant_ship_slipspaced)
 			round_end_reasons += "the Covenant ship has gone to slipspace and left the system"
 			var/datum/faction/covenant/C = locate() in factions
@@ -148,7 +148,7 @@
 			round_end_reasons += "the Covenant ship has been destroyed"
 
 	//the UNSC ship has been destroyed
-	if(!unsc_ship || unsc_ship.loc == null)
+	if(!unsc_ship)
 		round_end_reasons += "the UNSC ship has been destroyed"
 
 	//the colony has been destroyed (nuked/glassed)

--- a/maps/first_contact/maps/faction_bases/Innie_Shuttle.dmm
+++ b/maps/first_contact/maps/faction_bases/Innie_Shuttle.dmm
@@ -1,9 +1,9 @@
 "a" = (/turf/space,/area/space)
-"b" = (/turf/simulated/shuttle/wall,/area/faction_base/innie_shuttle)
-"c" = (/turf/simulated/wall/r_wall,/area/faction_base/innie_shuttle)
-"d" = (/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
-"e" = (/obj/machinery/fusion_thruster/fueled{tag = "icon-nozzle1 (WEST)"; icon_state = "nozzle1"; dir = 8},/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
-"f" = (/obj/machinery/light/spot{dir = 1},/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
+"b" = (/turf/simulated/wall/r_wall,/area/faction_base/innie_shuttle)
+"c" = (/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
+"d" = (/obj/machinery/fusion_thruster/fueled{tag = "icon-nozzle1 (WEST)"; icon_state = "nozzle1"; dir = 8},/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
+"e" = (/obj/machinery/light/spot{dir = 1},/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
+"f" = (/obj/effect/hull_segment,/turf/simulated/wall/r_wall,/area/faction_base/innie_shuttle)
 "g" = (/obj/machinery/door/airlock/halo_maint,/turf/simulated/floor/tiled,/area/faction_base/innie_shuttle)
 "h" = (/obj/structure/table/rack,/turf/simulated/floor/tiled,/area/faction_base/innie_shuttle)
 "i" = (/obj/structure/table/rack,/obj/machinery/light/spot{dir = 1},/turf/simulated/floor/tiled,/area/faction_base/innie_shuttle)
@@ -40,7 +40,6 @@
 "N" = (/obj/effect/floor_decal/industrial/warning/dust/corner{tag = "icon-warningcorner_dust (NORTH)"; icon_state = "warningcorner_dust"; dir = 1},/turf/simulated/floor/tiled,/area/faction_base/innie_shuttle)
 "O" = (/obj/structure/table/rack,/obj/machinery/light/spot,/turf/simulated/floor/tiled,/area/faction_base/innie_shuttle)
 "P" = (/obj/machinery/light/spot,/turf/simulated/floor/plating,/area/faction_base/innie_shuttle)
-"Q" = (/obj/effect/hull_segment,/turf/simulated/shuttle/wall,/area/faction_base/innie_shuttle)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -51,23 +50,23 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaabbbbbbbbaaabbbbbbbbbbaaaa
-aaaaaaaaaaaaaabbbbaaabbbccccccbaabbbbbbbbbbbaaaa
-aaaaaaaaaaaaabbddeaabbccccccccbaabbfdddddfdeaaaa
-aaaaaaaaaaaaabfddeaabcccccccccbaabbddddddddeaaaa
-aaaaaaaaabbbbbdbbbbbbbbbbbbbbbbQbbbddbbbbbbbaaaa
-aaaaaabbbbbbQbgbbbbbbhhhhihhhhbbbbbgbbbaaaaaaaaa
+aaaaaaaaaaaaaabbbbaaabbbbbbbbbbaabbbbbbbbbbbaaaa
+aaaaaaaaaaaaabbccdaabbbbbbbbbbbaabbecccccecdaaaa
+aaaaaaaaaaaaabeccdaabbbbbbbbbbbaabbccccccccdaaaa
+aaaaaaaaabbbbbcbbbbbbbbbbbbbbbbfbbbccbbbbbbbaaaa
+aaaaaabbbbbbfbgbbbbbbhhhhihhhhbbbbbgbbbaaaaaaaaa
 aaaaabbbbbbjklmnoooonooooooooonoooopkkbbbaaaaaaa
 aaaqqbbrstbjkkuvwwwwwwwwwwwwwwwwwwxykklkbbaaaaaa
-aaqqzAlkkBbCkkuwwwwwwwwwwwwwwwwwwwwykkkkcbaaaaaa
-aaqqDkkkkkEkkkuwwwwwwwwwwwwwwwwwwwwykkkkcbaaaaaa
+aaqqzAlkkBbCkkuwwwwwwwwwwwwwwwwwwwwykkkkbbaaaaaa
+aaqqDkkkkkEkkkuwwwwwwwwwwwwwwwwwwwwykkkkbbaaaaaa
 aaqqFAGkkHbCkkuwwwwwwwwwwwwwwwwwwwwykkkkIbaaaaaa
 aaaqqbbkJkbjkkuxwwwwwwwwwwwwwwwwwwvykkGkbbaaaaaa
 aaaaabbbbbbjkGKLMMMMLMMMMMMMMMLMMMMNkkbbbaaaaaaa
-aaaaaabbbbbbQbgbbbbbbhhhhOhhhhbQbbbgbbbaaaaaaaaa
-aaaaaaaaabbbbbdbbbbbbbbbbbbbbbbbbbbddbbbbbbbaaaa
-aaaaaaaaaaaaabPddeaabcccccccccbaabbddddddddeaaaa
-aaaaaaaaaaaaabbddeaabbccccccccbaabbPdddddPdeaaaa
-aaaaaaaaaaaaaabbbbaaabbbccccccbaabbbbbbbbbbbaaaa
+aaaaaabbbbbbfbgbbbbbbhhhhOhhhhbfbbbgbbbaaaaaaaaa
+aaaaaaaaabbbbbcbbbbbbbbbbbbbbbbbbbbccbbbbbbbaaaa
+aaaaaaaaaaaaabPccdaabbbbbbbbbbbaabbccccccccdaaaa
+aaaaaaaaaaaaabbccdaabbbbbbbbbbbaabbPcccccPcdaaaa
+aaaaaaaaaaaaaabbbbaaabbbbbbbbbbaabbbbbbbbbbbaaaa
 aaaaaaaaaaaaaaaaaaaaaaabbbbbbbbaaabbbbbbbbbbaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Makes automated defenses boardable.
Makes NPC comms consoles work.
Makes the innie shuttle not immediately be marked as destroyed, leading to deletion whilst in use.
Changes the invasion gamemode's checks for destroyed to allow for things to reside in nullspace.