### PR TITLE
Makes slipspace re-entry create jump alerts

### DIFF
--- a/code/modules/halo/machinery/slipspace_engine.dm
+++ b/code/modules/halo/machinery/slipspace_engine.dm
@@ -118,6 +118,7 @@
 		T = get_step(T,headingdir)
 	new /obj/effect/slipspace_rupture(T)
 	play_jump_sound(T)
+	send_jump_alert(T)
 	om_ship.loc = T
 	walk_to(om_ship,exit_loc,0,1,0)
 	spawn(SLIPSPACE_PORTAL_DIST)


### PR DESCRIPTION
Re-entry from slipspace to realspace creates a jump alert to all ships within 14 tiles, providing them with a general direction from their location.