### PR TITLE
Flood Infestor Revivification

### DIFF
--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 
 /mob/living/simple_animal/hostile/flood/Life()
 	..()
-	if(client)
+	if(client || ckey)
 		target_mob = null
 	if(assault_target && stance == HOSTILE_STANCE_IDLE)
 		//spawn(rand(-1,20))
@@ -308,7 +308,11 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 /mob/living/simple_animal/hostile/flood/combat_form/verb/create_infestor_form()
 	set name = "Create Infestor Form"
 	set category = "Abilities"
-
+	
+	if(stat == DEAD)
+		to_chat(usr,"<span class = 'notice'>You can't do that, you're dead!</span>")
+		return
+		
 	spawn_infestor()
 
 /mob/living/simple_animal/hostile/flood/combat_form/IsAdvancedToolUser()
@@ -355,6 +359,8 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 
 /mob/living/simple_animal/hostile/flood/combat_form/Move()
 	. = ..()
+	if(stat == DEAD)
+		return
 	if(ckey || client)
 		return
 	if(locate(/mob/living/carbon/human) in view(1,src) && isnull(our_infestor))

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -169,24 +169,12 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		adjustBruteLoss(1)
 		return 1 //One at a time.
 
-/mob/living/simple_animal/hostile/flood/infestor/proc/heal_nearby_combatforms()
-	for(var/mob/living/simple_animal/hostile/flood/combat_form/floodform in view(2,src))
-		if(floodform.health < floodform.maxHealth)
-			visible_message("<span class = 'danger'>[src] leaps at [floodform], melding into its flesh...</span>")
-			var/newhealth = floodform.health + (floodform.maxHealth/4)
-			if(newhealth > floodform.maxHealth)
-				floodform.health = floodform.maxHealth
-			else
-				floodform.health = newhealth
-		return 1 //One at a time.
-
 /mob/living/simple_animal/hostile/flood/infestor/Move()
 	. = ..()
 	if(ckey || client)
 		return
 	if(!attempt_nearby_infect())
-		if(!revive_nearby_combatforms())
-			heal_nearby_combatforms()
+		revive_nearby_combatforms()
 
 /mob/living/simple_animal/hostile/flood/infestor/AttackingTarget()
 	. = ..()
@@ -308,11 +296,11 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 /mob/living/simple_animal/hostile/flood/combat_form/verb/create_infestor_form()
 	set name = "Create Infestor Form"
 	set category = "Abilities"
-	
+
 	if(stat == DEAD)
 		to_chat(usr,"<span class = 'notice'>You can't do that, you're dead!</span>")
 		return
-		
+
 	spawn_infestor()
 
 /mob/living/simple_animal/hostile/flood/combat_form/IsAdvancedToolUser()

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -160,17 +160,33 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		var/mob/living/simple_animal/hostile/flood/combat_form/newform = new floodform.type (floodform.loc)
 		if(floodform.ckey || floodform.client)
 			newform.ckey = floodform.ckey
-
+		newform.name = floodform.name
+		newform.icon = floodform.icon
+		newform.icon_state = initial(floodform.icon_state)
+		visible_message("<span class = 'notice'>[src] leaps at [floodform]'s chest cavity and burrows in.</span>")
+		visible_message("<span class = 'danger'>[floodform] lurches back to life, the new infection form twitching in place...</span>")
 		qdel(floodform)
 		adjustBruteLoss(1)
-		return //One at a time.
+		return 1 //One at a time.
+
+/mob/living/simple_animal/hostile/flood/infestor/proc/heal_nearby_combatforms()
+	for(var/mob/living/simple_animal/hostile/flood/combat_form/floodform in view(2,src))
+		if(floodform.health < floodform.maxHealth)
+			visible_message("<span class = 'danger'>[src] leaps at [floodform], melding into its flesh...</span>")
+			var/newhealth = floodform.health + (floodform.maxHealth/4)
+			if(newhealth > floodform.maxHealth)
+				floodform.health = floodform.maxHealth
+			else
+				floodform.health = newhealth
+		return 1 //One at a time.
 
 /mob/living/simple_animal/hostile/flood/infestor/Move()
 	. = ..()
 	if(ckey || client)
 		return
 	if(!attempt_nearby_infect())
-		revive_nearby_combatforms()
+		if(!revive_nearby_combatforms())
+			heal_nearby_combatforms()
 
 /mob/living/simple_animal/hostile/flood/infestor/AttackingTarget()
 	. = ..()

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -292,6 +292,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 
 /mob/living/simple_animal/hostile/flood/combat_form
 	var/next_infestor_spawn = 0
+	var/our_infestor
 
 	var/obj/item/weapon/gun/our_gun
 
@@ -301,7 +302,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 			to_chat(src,"<span class = 'notice'>Your biomass hasn't recovered from the previous formation.</span>")
 		return
 	next_infestor_spawn = world.time + COMBAT_FORM_INFESTOR_SPAWN_DELAY
-	new /mob/living/simple_animal/hostile/flood/infestor (src.loc)
+	our_infestor = new /mob/living/simple_animal/hostile/flood/infestor (src.loc)
 	visible_message("<span class = 'warning'>[src]'s flesh writhes for a moment, blood-red feelers emerging, followed by a singular infection form.</span>")
 
 /mob/living/simple_animal/hostile/flood/combat_form/verb/create_infestor_form()
@@ -356,7 +357,8 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	. = ..()
 	if(ckey || client)
 		return
-	//spawn_infestor() //Had too much of a performance hit over the duration of a round.
+	if(locate(/mob/living/carbon/human) in view(1,src) && isnull(our_infestor))
+		spawn_infestor()
 	if(!our_gun)
 		for(var/obj/item/weapon/gun/G in view(1,src))
 			pickup_gun(G)

--- a/code/modules/halo/machinery/slipspace_engine.dm
+++ b/code/modules/halo/machinery/slipspace_engine.dm
@@ -268,11 +268,7 @@
 /datum/explosion/slipspace_core/New(var/obj/payload/b)
 	if(config.oni_discord)
 		message2discord(config.oni_discord, "@here, slipspace core detonation detected. [b.name] @ ([b.loc.x],[b.loc.y],[b.loc.z])")
-	for(var/area/a in range(50,b.loc))
-		for(var/obj in a.contents)
-			spawn(0)
-				qdel(obj)
-		new /area/space/ (a.loc)
+	explosion(50, 100, 0, 0, 255)
 
 /obj/payload/slipspace_core/cov
 	icon = 'code/modules/halo/icons/machinery/covenant/slipspace_drive.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -79,6 +79,8 @@
 		else
 			stance = HOSTILE_STANCE_ATTACKING
 			walk_to(src, target_mob, 1, move_to_delay)
+			spawn(get_dist(src,target_mob)*move_to_delay) //If the target is within range after our original move, we attack them.
+				AttackTarget()
 
 /mob/living/simple_animal/hostile/proc/AttackTarget()
 	stop_automated_movement = 1

--- a/html/changelogs/xo-11 - flood_infestor_features.yml
+++ b/html/changelogs/xo-11 - flood_infestor_features.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: XO-11
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Makes flood infestors able to heal and revive flood combat forms.
+  - rscadd: "Allows hostile mobs to both attack and move, so simply running away should be less viable."
+  - rscadd: "Allows flood combat forms to produce infestors, but only one can live at a time."
+  - tweak: "Tones down the effect of slipspade drive overloading. Sadly it's now just a really big explosion, but it shouldn't crash the server anymore."

--- a/html/changelogs/xo-11 - flood_infestor_features.yml
+++ b/html/changelogs/xo-11 - flood_infestor_features.yml
@@ -33,7 +33,7 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Makes flood infestors able to heal and revive flood combat forms.
+  - rscadd: "Makes flood infestors able to heal and revive flood combat forms."
   - rscadd: "Allows hostile mobs to both attack and move, so simply running away should be less viable."
   - rscadd: "Allows flood combat forms to produce infestors, but only one can live at a time."
   - tweak: "Tones down the effect of slipspade drive overloading. Sadly it's now just a really big explosion, but it shouldn't crash the server anymore."


### PR DESCRIPTION
Makes flood infestors able to revive (and heal) flood combat forms.

Re-enables combat form infestor spawning, restricted to one infestor per combat form.

Also makes hostile mobs a bit more deadly by allowing them to attack and move at the same time.