### PR TITLE
moves shipmaphandler maxz caching

### DIFF
--- a/code/modules/halo/overmap/npc_shipmap_handler.dm
+++ b/code/modules/halo/overmap/npc_shipmap_handler.dm
@@ -10,7 +10,6 @@ var/global/datum/npc_ship_map_handler/shipmap_handler = new
 
 /datum/npc_ship_map_handler/New()
 	. = ..()
-	max_z_cached = world.maxz
 
 /datum/npc_ship_map_handler/proc/free_map(var/z_to_free)
 	if(z_to_free in free_ship_map_zs)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -258,6 +258,7 @@ var/list/points_of_interest = list()
 	GLOB.using_map.sealed_levels |= GLOB.using_map.overmap_z
 
 	report_progress("Overmap build complete.")
+	shipmap_handler.max_z_cached = world.maxz
 	return 1
 
 


### PR DESCRIPTION
this should stop shuttles from breaking spacetime and loading onto the overmap. This will also stop the shuttles from loading onto the overmap and then being deleted, leading to the entire overmap being deleted.