### PR TITLE
Small Weapon Fixes

### DIFF
--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -53,7 +53,7 @@
 		else
 			if(user)
 				visible_message("<span class='notice'>[user.name]'s [src]'s lights darken</span>","<span class='notice'>You deactivate your [src]'s overcharge</span>")
-			projectile_type = /obj/item/projectile/covenant/plasmapistol
+			projectile_type = initial(projectile_type)
 			overcharge = 0
 			charge_cost = initial(charge_cost)
 			overlays -= "overcharge"
@@ -72,6 +72,9 @@
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "Training Pistol"
 	projectile_type = /obj/item/projectile/covenant/trainingpistol
+
+/obj/item/weapon/gun/energy/plasmapistol/trainingpistol/set_overcharge(var/new_overcharge = 1, var/mob/user = null)
+	return
 
 /obj/item/weapon/gun/projectile/needler // Uses "magazines" to reload rather than inbuilt cells.
 	name = "Type-33 Guided Munitions Launcher"

--- a/code/modules/halo/weapons/projectiles/beams.dm
+++ b/code/modules/halo/weapons/projectiles/beams.dm
@@ -2,6 +2,8 @@
 	name = "spartan laser"
 	icon_state = "heavylaser"
 	damage = 500 //This should one-hit kill all mobs, including lekgolo. Likely destroys most vehicles just as fast, if not instantly.
+	damage_type = "bomb"
+	damtype = "bomb"
 	armor_penetration = 100
 
 	fire_sound = 'code/modules/halo/sounds/Spartan_Laser_Beam_Shot_Sound_Effect.ogg'
@@ -9,3 +11,8 @@
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
 	impact_type = /obj/effect/projectile/laser_heavy/impact
+
+/obj/item/projectile/beam/spartan/attack_mob()
+	damage_type = BURN
+	damtype = BURN
+	return ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -90,6 +90,7 @@
 	var/is_charged_weapon = 0 //Does the weapon require charging? Defaults to 0 unless it's from /charged weapon sets
 	var/arm_time = 25 //Default charge time for weapons that charge
 	var/charge_sound = 'code/modules/halo/sounds/Spartan_Laser_Charge_Sound_Effect.ogg'
+	var/is_charging = 0
 	var/irradiate_non_cov = 0 //Set this to anything above 0, and it'll irradiate humans when fired. Spartans and Orions are ok.
 
 /obj/item/weapon/gun/New()
@@ -245,13 +246,19 @@
 		to_chat(user, "<span class='warning'>You refrain from firing your [src] as your intent is set to help.</span>")
 		return
 
+	if(is_charging)
+		to_chat(user,"<span class = 'notice'>[src] is charging and cannot fire</span>")
+		return
+
 	if(is_charged_weapon==1)
 		playsound(src.loc, charge_sound, 100, 1)
 		user.visible_message("<span class = 'notice'>[user] starts charging the [src]!</span>")
 
+		is_charging = 1
 		if (!do_after(user,arm_time,src))
 			return
 		Fire(A,user,params)
+		is_charging = 0
 	else
 		Fire(A,user,params) //Otherwise, fire normally.
 


### PR DESCRIPTION
Disables training plasmapistol overcharge.
Fixes a chargable weapon bug that let you charge multiple shots at one time.
(Should allow the spartan laser to be adminspawned now that the main bug is fixed.)
Buffs the spartan laser's projectile vs vehicles, makes it inflict burn damage against mobs.