### PR TITLE
Destroyed Vehicles now automatically cause occupants to be hit by bullets

### DIFF
--- a/code/modules/halo/vehicles/drop_pod.dm
+++ b/code/modules/halo/vehicles/drop_pod.dm
@@ -1,4 +1,4 @@
-#define POD_FAIL_CHANCE 5 //This is the chance a drop-pod will fail on impact and auto-eject the user + exploding.
+#define POD_FAIL_CHANCE 1 //This is the chance a drop-pod will fail on impact and auto-eject the user + exploding.
 
 /obj/vehicles/drop_pod
 	name = "SOEIV Drop Pod"
@@ -26,6 +26,9 @@
 	var/launch_arm_time = 5 SECONDS
 
 	var/pod_range = 3 //Range of pod in overmap tiles
+
+/obj/vehicles/drop_pod/on_death()
+	return
 
 /obj/vehicles/drop_pod/update_object_sprites()
 	overlays.Cut()
@@ -177,7 +180,7 @@
 			valid_points += l
 	var/beacons_present = 1
 	for(var/obj/item/drop_pod_beacon/b in world)
-		if(!(b.z  in om_targ_zs))
+		if(!(text2num("[b.z]")  in om_targ_zs))
 			continue
 		if(b.is_active == 1)
 			if(!beacons_present) //If we've not already realised we have beacons, remove all normal drop-pod markers from pick-choice.

--- a/code/modules/halo/vehicles/scorpion.dm
+++ b/code/modules/halo/vehicles/scorpion.dm
@@ -21,7 +21,7 @@
 
 	move_sound = 'code/modules/halo/sounds/scorp_move.ogg'
 
-	vehicle_view_modifier = 1.5
+	vehicle_view_modifier = 1.3
 
 /obj/item/vehicle_component/health_manager/scorpion
 	integrity = 750

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -299,19 +299,19 @@
 
 /obj/vehicles/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	var/pos_to_dam = should_damage_occ()
-	if(!isnull(pos_to_dam) || guns_disabled)
-		var/position_found = 0
-		while(position_found)
-			if(guns_disabled)
-				var/positions_pickfrom = list("driver","gunner","passenger")
-				pos_to_dam = pick(positions_pickfrom)
-			var/should_continue = damage_occupant(pos_to_dam,P)
-			position_found = 1
-			if(!should_continue && guns_disabled)
-				position_found = 0
-				positions_pickfrom -= pos_to_dam
-			else if(!should_continue)
-				return
+	var/mob/mob_to_dam
+	if(guns_disabled)
+		var/list/mobs = list()
+		for(var/mob/m in occupants)
+			mobs += m
+		mob_to_dam = pick(mobs)
+		if(!isnull(mob_to_dam))
+			mob_to_dam.bullet_act(P)
+			return
+	if(!isnull(pos_to_dam))
+		var/should_continue = damage_occupant(pos_to_dam,P)
+		if(!should_continue)
+			return
 	comp_prof.take_component_damage(P.get_structure_damage(),P.damtype)
 
 /obj/vehicles/ex_act(var/severity)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -299,10 +299,19 @@
 
 /obj/vehicles/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	var/pos_to_dam = should_damage_occ()
-	if(!isnull(pos_to_dam))
-		var/should_continue = damage_occupant(pos_to_dam,P)
-		if(!should_continue)
-			return
+	if(!isnull(pos_to_dam) || guns_disabled)
+		var/position_found = 0
+		while(position_found)
+			if(guns_disabled)
+				var/positions_pickfrom = list("driver","gunner","passenger")
+				pos_to_dam = pick(positions_pickfrom)
+			var/should_continue = damage_occupant(pos_to_dam,P)
+			position_found = 1
+			if(!should_continue && guns_disabled)
+				position_found = 0
+				positions_pickfrom -= pos_to_dam
+			else if(!should_continue)
+				return
 	comp_prof.take_component_damage(P.get_structure_damage(),P.damtype)
 
 /obj/vehicles/ex_act(var/severity)


### PR DESCRIPTION
This bypasses any normal "exposed occupant" checks. Implemented to balance vehicles being able to fire when disabled.