### PR TITLE
Adds a Loot Distribution System for use by mappers

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1547,6 +1547,7 @@
 #include "code\modules\halo\misc\Hunting Rocks.dm"
 #include "code\modules\halo\misc\huragok.dm"
 #include "code\modules\halo\misc\language_teacher.dm"
+#include "code\modules\halo\misc\loot_distributor.dm"
 #include "code\modules\halo\misc\memorial_statue.dm"
 #include "code\modules\halo\misc\Orion Project.dm"
 #include "code\modules\halo\misc\payload.dm"

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -655,6 +655,8 @@
 			return global.lobby_image;
 		if("log_end")
 			return global.log_end;
+		if("loot_distributor")
+			return global.loot_distributor;
 		if("loyalists")
 			return global.loyalists;
 		if("lunchables_drink_reagents_")
@@ -1884,6 +1886,8 @@
 			global.lobby_image=newval;
 		if("log_end")
 			global.log_end=newval;
+		if("loot_distributor")
+			global.loot_distributor=newval;
 		if("loyalists")
 			global.loyalists=newval;
 		if("lunchables_drink_reagents_")
@@ -2785,6 +2789,7 @@
 	"loadout_categories",
 	"lobby_image",
 	"log_end",
+	"loot_distributor",
 	"loyalists",
 	"lunchables_drink_reagents_",
 	"lunchables_drinks_",

--- a/code/modules/halo/misc/loot_distributor.dm
+++ b/code/modules/halo/misc/loot_distributor.dm
@@ -10,7 +10,7 @@ var/global/datum/loot_distributor/loot_distributor = new
 /datum/loot_distributor/proc/get_loot_for_type(var/type_name)
 	var/list/loot_pickfrom = list()
 	loot_pickfrom = loot_list[type_name]
-	if(isnull(loot_pickfrom) || loot_pickfrom.len == 0)
+	if(loot_pickfrom.len == 0)
 		return
 	var/picked = pick(loot_pickfrom)
 	loot_list[type_name] = loot_pickfrom - picked

--- a/code/modules/halo/misc/loot_distributor.dm
+++ b/code/modules/halo/misc/loot_distributor.dm
@@ -1,0 +1,41 @@
+var/global/datum/loot_distributor/loot_distributor = new
+
+//NOTE: WHEN ADDING TO THE LOOT LIST, IT'S BETTER TO ADD VIA A MAP SPECIFIC ITEM SUCH AS OVERMAP OBJECT /New().
+/datum/loot_distributor
+	//Format, "loot_type" = list(loot_typepaths)
+	var/list/loot_list = list(
+	"pizza" = list(/obj/item/pizzabox/margherita,/obj/item/pizzabox/vegetable,/obj/item/pizzabox/mushroom,/obj/item/pizzabox/meat)
+	)
+
+/datum/loot_distributor/proc/get_loot_for_type(var/type_name)
+	var/list/loot_pickfrom = list()
+	loot_pickfrom = loot_list[type_name]
+	if(isnull(loot_pickfrom) || loot_pickfrom.len == 0)
+		return
+	var/picked = pick(loot_pickfrom)
+	loot_list[type_name] = loot_pickfrom - picked
+	return picked
+
+/obj/effect/loot_marker
+	opacity = 0
+	invisibility = 101
+
+	var/loot_type = "generic"
+
+/obj/effect/loot_marker/Initialize()
+	. = INITIALIZE_HINT_QDEL
+	var/loot_to_spawn = loot_distributor.get_loot_for_type(loot_type)
+	if(isnull(loot_to_spawn))
+		return
+	var/obj/spawned_loot = new loot_to_spawn (loc)
+	if(!istype(loc,/turf))
+		loc.contents += spawned_loot
+	do_loot_modifications(spawned_loot)
+	return
+
+/obj/effect/loot_marker/proc/do_loot_modifications(var/obj/loot_spawned)
+	loot_spawned.dir = dir
+
+//Example Subtype//
+/obj/effect/loot_marker/pizza
+	loot_type = "pizza"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< 'f5f208bbc1d891276326c2c86c505fac *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'df2ff3689c8fb6f7459b32a2e574e60a *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '9839c785fcf5413e88dbf19ba6f59ce3 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'f5f208bbc1d891276326c2c86c505fac *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Adds a loot distribution system that uses an identifier string to store a list of loot typepaths.
The distribution system uses a mapped marker to spawn items from the loot list, however, each item can spawn only once. This means that the amount of markers that are mapped in should never exceed the amount of items in each loot list. If more locations need to be added, filler items should be added to the loot list.

Example entry: 
"pizza" = list(/obj/item/pizzabox/margherita,/obj/item/pizzabox/vegetable,/obj/item/pizzabox/mushroom,/obj/item/pizzabox/meat)

Example Marker Define:
/obj/effect/loot_marker/pizza
	loot_type = "pizza"

NOTE: WHEN ADDING TO THE LOOT LIST, IT'S BETTER TO ADD VIA A MAP SPECIFIC ITEM SUCH AS OVERMAP OBJECT /New().