### PR TITLE
disables ODP map loading

### DIFF
--- a/code/modules/halo/machinery/boarding_beacon_launcher.dm
+++ b/code/modules/halo/machinery/boarding_beacon_launcher.dm
@@ -14,7 +14,7 @@
 	ship_damage_projectile = /obj/item/projectile/boarding_beacon
 
 /obj/item/projectile/overmap/boarding_beacon/on_impact(var/obj/effect/overmap/ship/npc_ship/ship)
-	if(istype(ship) && ship.unload_at == 0)
+	if(istype(ship) && !istype(ship,/obj/effect/overmap/ship/npc_ship/automated_defenses) && ship.unload_at == 0)
 		ship.load_mapfile()
 	. = ..()
 

--- a/code/modules/halo/overmap/automated_defense.dm
+++ b/code/modules/halo/overmap/automated_defense.dm
@@ -20,7 +20,7 @@
 	GLOB.overmap_tiles_uncontrolled -= range(defense_range*2,src)
 
 /obj/effect/overmap/ship/npc_ship/automated_defenses/can_board() //Now you can board them, any time you want!
-	return 1
+	return 0
 
 /obj/effect/overmap/ship/npc_ship/automated_defenses/take_projectiles(var/obj/item/projectile/overmap/proj,var/add_proj = 1)
 	. = ..()


### PR DESCRIPTION
Due to the lag brought on by loading ODP shipmaps, it will have to be disabled.