### PR TITLE
glassing changes

### DIFF
--- a/code/modules/halo/overmap/weapons/Energy_projector.dm
+++ b/code/modules/halo/overmap/weapons/Energy_projector.dm
@@ -197,7 +197,7 @@
 	ship_hit_sound = 'code/modules/halo/sounds/om_proj_hitsounds/eprojector_hit_sound.wav'
 
 /obj/item/projectile/overmap/beam/sector_hit_effects(var/z_level,var/obj/effect/overmap/hit,var/list/hit_bounds)
-	if(get_dist(overmap_fired_by,hit) > 1)
+	if(initial(kill_count) - kill_count > 1)
 		console_fired_by.visible_message("<span class = 'notice'>[console_fired_by] emits a warning: \"Beam impact dissipated due to atmospheric interference. Orbit the object to perform glassing.\"</span>")
 		return
 	hit.glassed += 1

--- a/code/modules/halo/overmap/weapons/Energy_projector.dm
+++ b/code/modules/halo/overmap/weapons/Energy_projector.dm
@@ -200,6 +200,7 @@
 	if(get_dist(overmap_fired_by,hit) > 1)
 		console_fired_by.visible_message("<span class = 'notice'>[console_fired_by] emits a warning: \"Beam impact dissipated due to atmospheric interference. Orbit the object to perform glassing.\"</span>")
 		return
+	hit.glassed += 1
 	for(var/mob/m in GLOB.mobs_in_sectors[hit])
 		to_chat(m,"<span class = 'danger'>A wave of heat washes over you as the atmosphere boils and the ground liquefies. [hit] is being glassed!</span>")
 	var/turf/turf_to_explode = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
@@ -214,7 +215,6 @@
 		if(!istype(turf_to_explode,/turf/simulated/open) && !istype(turf_to_explode,/turf/unsimulated/floor/lava) && !istype(turf_to_explode,/turf/space))
 			new /turf/unsimulated/floor/lava/glassed_turf
 
-	hit.glassed += 1
 
 /obj/effect/projectile/projector_laser_proj
 	icon = 'code/modules/halo/overmap/weapons/pulse_turret_tracers.dmi'

--- a/maps/_gamemodes/invasion/objectives_cov.dm
+++ b/maps/_gamemodes/invasion/objectives_cov.dm
@@ -1,4 +1,6 @@
 
+#define COLONY_GLASSED_AMOUNT_REQUIRED 5 //5 projector hit for glassing to count.
+
 /* COVENANT */
 
 /datum/objective/protect/protect_cov_leader
@@ -158,6 +160,8 @@
 /datum/objective/glass_colony/check_completion()
 	var/datum/game_mode/invasion/game_mode = ticker.mode
 	if(istype(game_mode))
-		if(game_mode.human_colony && game_mode.human_colony.glassed)
+		if(game_mode.human_colony && game_mode.human_colony.glassed >= COLONY_GLASSED_AMOUNT_REQUIRED)
 			return 1
 	return 0
+
+#undef COLONY_GLASSED_AMOUNT_REQUIRED


### PR DESCRIPTION
Makes some changes to the way glassing works, requiring the covenant to use the glassing beam on the colony at least 5 times for it to be considered "glassed" for the invasion-objective.