### PR TITLE
Many changes

### DIFF
--- a/code/modules/halo/machinery/slipspace_engine.dm
+++ b/code/modules/halo/machinery/slipspace_engine.dm
@@ -268,9 +268,8 @@
 /datum/explosion/slipspace_core/New(var/obj/payload/b)
 	if(config.oni_discord)
 		message2discord(config.oni_discord, "@here, slipspace core detonation detected. [b.name] @ ([b.loc.x],[b.loc.y],[b.loc.z])")
-	spawn(0)
-		explosion(100, -1, -1, -1, 255)
-		qdel(b)
+	explosion(100, -1, -1, -1, 255)
+	qdel(src)
 
 /obj/payload/slipspace_core/cov
 	icon = 'code/modules/halo/icons/machinery/covenant/slipspace_drive.dmi'

--- a/code/modules/halo/misc/payload.dm
+++ b/code/modules/halo/misc/payload.dm
@@ -144,12 +144,11 @@
 /datum/explosion/New(var/obj/payload/b)
 	if(config.oni_discord)
 		message2discord(config.oni_discord, "@here, nuclear detonation detected. [b.name] @ ([b.loc.x],[b.loc.y],[b.loc.z])")
-	spawn(0)
-		explosion(b.loc,b.strength*50,b.strength*70,b.strength*80,b.strength*80)
-		for(var/mob/living/m in range(50,b.loc))
-			to_chat(m,"<span class = 'userdanger'>A shockwave slams into you! You feel yourself falling apart...</span>")
-			m.gib() // Game over.
-		qdel(b)
+	explosion(b.loc,b.strength*50,b.strength*70,b.strength*80,b.strength*80)
+	for(var/mob/living/m in range(50,b.loc))
+		to_chat(m,"<span class = 'userdanger'>A shockwave slams into you! You feel yourself falling apart...</span>")
+		m.gib() // Game over.
+		qdel(src) 
 
 /datum/explosion/nuclearexplosion/New(var/obj/payload/b)
 	radiation_repository.radiate(b.loc,1000,10000)

--- a/code/modules/halo/overmap/base_npc_ships.dm
+++ b/code/modules/halo/overmap/base_npc_ships.dm
@@ -224,12 +224,10 @@
 		shipmap_handler.un_free_map(z_to_load_at)
 		map_sectors["[z_to_load_at]"] = src
 		maploader.load_map(link,z_to_load_at)
-		create_lighting_overlays_zlevel(z_to_load_at)
 		var/obj/effect/landmark/map_data/md = new(locate(1,1,z_to_load_at))
 		src.link_zlevel(md)
 		map_z += z_to_load_at //The above proc will increase the maxz by 1 to accomodate the new map. This deals with that.
-		spawn(10)
-			create_lighting_overlays_zlevel(z_to_load_at) //Wait a tick, then do the overlays again.
+		create_lighting_overlays_zlevel(z_to_load_at)
 	cargo_init()
 	damage_spawned_ship()
 	unload_at = world.time + NPC_SHIP_LOSE_DELAY

--- a/code/modules/halo/overmap/weapons/overmap_projectile.dm
+++ b/code/modules/halo/overmap/weapons/overmap_projectile.dm
@@ -8,11 +8,6 @@
 	var/sound/ship_hit_sound //This sound is played across the entire impacted ship when the overmap projectile spawns the ship_damage_projectile
 	accuracy = 100
 
-/obj/item/projectile/overmap/New(var/obj/spawner)
-	if(map_sectors["[spawner.z]"])
-		overmap_fired_by = map_sectors["[spawner.z]"]
-		console_fired_by = spawner
-
 /obj/item/projectile/overmap/Move(var/newloc,var/dir)
 	if(istype(newloc,/turf/unsimulated/map/edge))
 		qdel(src)

--- a/code/modules/halo/overmap/weapons/overmap_weapon.dm
+++ b/code/modules/halo/overmap/weapons/overmap_weapon.dm
@@ -85,10 +85,12 @@
 
 /obj/machinery/overmap_weapon_console/proc/fire_projectile(var/atom/target,var/mob/user,var/directly_above = 0)
 	var/obj/om_obj = map_sectors["[z]"]
-	var/obj/item/projectile/new_projectile = new fired_projectile (om_obj.loc,om_obj)
+	var/obj/item/projectile/overmap/new_projectile = new fired_projectile (om_obj.loc)
 	new_projectile.damage += get_linked_device_damage_mod()
-	new_projectile.permutated = map_sectors["[z]"] //Ensuring we don't hit ourselves somehow
+	new_projectile.permutated += om_obj //Ensuring we don't hit ourselves somehow
 	new_projectile.firer = user
+	new_projectile.overmap_fired_by = om_obj
+	new_projectile.console_fired_by = src
 	if(directly_above)
 		new_projectile.on_impact(target)
 		qdel(new_projectile)

--- a/code/modules/halo/species_items/sangheili.dm
+++ b/code/modules/halo/species_items/sangheili.dm
@@ -185,6 +185,10 @@ GLOBAL_LIST_INIT(last_names_sangheili, world.file2list('code/modules/halo/specie
 		if(h.l_hand == src || h.r_hand == src)
 			return 1
 	return 0
+
+/obj/item/weapon/melee/energy/elite_sword/g_dagger/get_species_leap_dist(var/mob/living/carbon/human/mob)
+	return 2
+
 /obj/item/weapon/melee/energy/elite_sword/g_dagger/dropped()
 	if(!inhand_check())
 		creator_dagger.on_dagger_dropped()

--- a/code/modules/halo/vehicles/scorpion.dm
+++ b/code/modules/halo/vehicles/scorpion.dm
@@ -13,7 +13,7 @@
 	comp_prof = /datum/component_profile/scorpion
 
 	vehicle_move_delay = 5
-	exposed_positions = list("passenger" = 40,"gunner" = 10)
+	exposed_positions = list("passenger" = 40,"gunner" = 5)
 
 	occupants = list(4,1)
 

--- a/code/modules/halo/vehicles/wraith.dm
+++ b/code/modules/halo/vehicles/wraith.dm
@@ -13,7 +13,7 @@
 	comp_prof = /datum/component_profile/wraith
 
 	vehicle_move_delay = 4.75
-	exposed_positions = list("gunner" = 10)
+	exposed_positions = list("gunner" = 5)
 
 	occupants = list(0,1)
 

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -200,6 +200,8 @@
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "needle"
 
+#define RIFLENEEDLE_TRACK_DIST 5
+
 /obj/item/projectile/bullet/covenant/needles/rifleneedle
 	name = "Rifle Needle"
 	damage = 30
@@ -210,6 +212,13 @@
 	tracer_delay_time = 0.5 SECONDS
 	invisibility = 101
 
+/obj/item/projectile/bullet/covenant/needles/rifleneedle/Move()
+	if(kill_count - initial(kill_count) > RIFLENEEDLE_TRACK_DIST)
+		locked_target = null
+	. = ..()
+
 /obj/effect/projectile/bullet/covenant/needles/rifleneedle
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "needlerifle_trail"
+
+#undef RIFLENEEDLE_TRACK_DIST

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -6,7 +6,7 @@
 	icon_state = "plasmagrenade"
 	throw_speed = 1.2
 	throw_range = 4
-	var/alt_explosion_damage_max = 60 //The amount of damage done when grenade is stuck inside someone
+	var/alt_explosion_damage_max = 100 //The amount of damage done when grenade is stuck inside someone
 	var/alt_explosion_range = 2
 	arm_sound = 'code/modules/halo/sounds/Plasmanadethrow.ogg'
 
@@ -62,5 +62,5 @@
 
 	throw_range = 1
 
-	alt_explosion_damage_max = 100
+	alt_explosion_damage_max = 150
 	alt_explosion_range = 1

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -16,7 +16,7 @@
 	var/icon_state_deployed = "T1EW-deployed"
 	force = 1
 	throwforce = 1
-	active_force = 65
+	active_force = 75
 	active_throwforce = 12
 	var/hits_burn_mobs = 1
 	edge = 0

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -177,8 +177,8 @@
 	..()
 	w_class = ITEM_SIZE_SMALL
 
-/obj/item/weapon/melee/energy/elite_sword/dagger/get_species_leap_dist()
-	return 0
+/obj/item/weapon/melee/energy/elite_sword/dagger/get_species_leap_dist(var/mob/living/carbon/human/mob)
+	return ESWORD_LEAP_DIST
 
 /obj/item/weapon/melee/energy/elite_sword/dagger/change_misc_variables(var/deactivate = 0)
 	if(deactivate)

--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -5,6 +5,11 @@
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	icon_state = "M9 HEDP"
 
+/obj/item/weapon/grenade/frag/m9_hedp/on_explosion(var/turf/O)
+	if(explosion_size)
+		explosion(O, -1, -1, explosion_size, round(explosion_size/2), 0, guaranteed_damage = 60, guaranteed_damage_range = 1)
+
+
 /obj/item/weapon/storage/box/m9_frag
 	name = "box of M9 frag grenades (WARNING)"
 	desc = "<B>WARNING: These devices are extremely dangerous and can cause serious bodily laceration or death.</B>"

--- a/maps/first_contact/maps/UNSC_Bertels/UNSC_Bertels_Deck_2.dmm
+++ b/maps/first_contact/maps/UNSC_Bertels/UNSC_Bertels_Deck_2.dmm
@@ -230,7 +230,7 @@
 "ev" = (/obj/structure/cable/blue{icon_state = "2-4"},/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinemesshall)
 "ew" = (/obj/structure/cable/blue{icon_state = "0-8"},/obj/machinery/power/apc{dir = 4; name = "APC"; pixel_x = 24; pixel_y = 0},/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinemesshall)
 "ex" = (/obj/machinery/vending/armory/hybrid,/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinearmory)
-"ey" = (/obj/machinery/door/airlock/halo{name = "Heavy Weapons Requisition Room"; req_access = list(308)},/turf/simulated/wall/r_wall,/area/corvette/unscbertels/deck2/marinearmory)
+"ey" = (/obj/machinery/door/airlock/halo{name = "Heavy Weapons Requisition Room"; req_access = list(308)},/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinearmory)
 "ez" = (/obj/machinery/light/colored/green,/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinearmory)
 "eA" = (/obj/structure/cable/blue{icon_state = "2-4"},/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinearmory)
 "eB" = (/obj/structure/cable/blue{icon_state = "4-8"},/turf/simulated/floor/tiled,/area/corvette/unscbertels/deck2/marinearmory)


### PR DESCRIPTION
makes the internal and normal energy daggers have a 2 tile lunge range

Makes the needle rifle only track for 5 tiles

removes the wall from the bertels IWO office door

Buffs plasnade to 100 on-stick damage / 50 aoe damage.

Buffs frag nade with a 1 tile, 60 damage aura on explode.

Buffs esword damage to 75.

Makes another attempt at fixing the damned dynamic-loaded ship lighting overlays