### PR TITLE
Parry changes

### DIFF
--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -2,6 +2,7 @@
 	name = "weapon"
 	icon = 'icons/obj/weapons.dmi'
 	hitsound = "swing_hit"
+	var/parry_projectiles = 0
 
 /obj/item/weapon/Bump(mob/M as mob)
 	spawn(0)
@@ -12,21 +13,26 @@
 	var/obj/item/damage_source = dam_source
 	if(!attacker)
 		return 0
-	if(istype(damage_source,/obj/item/projectile))
-		return 0
 	//Checks done, Parrycode starts here.//
 	if(attacker.a_intent == "help") //We don't need to block helpful actions.
 		return 0
 	var/parry_chance_divisor = 1
+	var/force_half_damage = 0
 	var/obj/item/weapon/gun/this_weapon = src
 	if(istype(this_weapon) && this_weapon.one_hand_penalty == -1 && !this_weapon.is_held_twohanded(user))//Ensure big twohanded guns are worse at parrying when not twohanded.
 		parry_chance_divisor = 2
+	if(istype(damage_source,/obj/item/projectile))
+		if(parry_projectiles)
+			parry_chance_divisor = 4
+			force_half_damage = 1
+		else
+			return 0
 	if(!prob((BASE_WEAPON_PARRYCHANCE * (w_class - 1))/parry_chance_divisor)) //Do our base parrychance calculation.
 		return 0
 	if(!damage_source || damage_source == attacker)
 		visible_message("<span class = 'danger'>[user] counters [attacker]'s unarmed attack with their [src.name]!</span>")
 		attack(attacker,user,pick("l_arm","r_arm","chest"))
-		return 1
+		force_half_damage = 1
 	else
 		visible_message("<span class = 'danger'>[user] parries [attacker]'s [damage_source.name] with their [src.name]</span>")
 		playsound(loc, hitsound, 50, 1, -1)
@@ -43,12 +49,19 @@
 		item_to_disintegrate = src
 		mob_holding_disintegrated = user
 
-	if(isnull(item_to_disintegrate) || isnull(mob_holding_disintegrated))
+	if(isnull(item_to_disintegrate) || isnull(mob_holding_disintegrated) && !force_half_damage)
 		return 1
 
-	if(istype(item_to_disintegrate,/obj/item/weapon/gun) && !prob(BASE_PARRY_PLASMA_DESTROY))
-		visible_message("<span class = 'danger'>[item_to_disintegrate == damage_source ? "[user]":"[attacker]" ]</span>")
-		return 1
+	if(!isnull(item_to_disintegrate) && istype(item_to_disintegrate,/obj/item/weapon/gun) && !prob(BASE_PARRY_PLASMA_DESTROY))
+		force_half_damage = 1
+
+	if(force_half_damage)
+		to_chat(user,"<span class = 'warning'>[src] fails to fully deflect [attacker]'s attack!</span>")
+		var/orig_force = item_to_disintegrate.force
+		item_to_disintegrate.force /= 2
+		spawn(2)
+			item_to_disintegrate.force = orig_force
+		return 0
 
 	visible_message("<span class = 'danger'>[item_to_disintegrate == damage_source ? "[user]" : "[attacker]"] cuts through [mob_holding_disintegrated]'s [item_to_disintegrate.name] with their [item_to_disintegrate == damage_source ? "[src.name]" : "[damage_source.name]"], rendering it useless!</span>")
 	mob_holding_disintegrated.drop_from_inventory(item_to_disintegrate)

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -14,7 +14,7 @@
 	if(!attacker)
 		return 0
 	//Checks done, Parrycode starts here.//
-	if(attacker.a_intent == "help") //We don't need to block helpful actions.
+	if(istype(attacker,/mob/living) && damage < 5 && (attacker.a_intent == "help" || attacker.a_intent == "grab")) //We don't need to block helpful actions. (Or grabs)
 		return 0
 	var/parry_chance_divisor = 1
 	var/force_half_damage = 0
@@ -57,10 +57,17 @@
 
 	if(force_half_damage)
 		to_chat(user,"<span class = 'warning'>[src] fails to fully deflect [attacker]'s attack!</span>")
+		var/obj/item/projectile/proj = item_to_disintegrate
 		var/orig_force = item_to_disintegrate.force
-		item_to_disintegrate.force /= 2
-		spawn(2)
-			item_to_disintegrate.force = orig_force
+		if(istype(proj))
+			orig_force = proj.damage
+			proj.damage /= 2
+			spawn(2)
+				proj.damage = orig_force
+		else
+			item_to_disintegrate.force /= 2
+			spawn(2)
+				item_to_disintegrate.force = orig_force
 		return 0
 
 	visible_message("<span class = 'danger'>[item_to_disintegrate == damage_source ? "[user]" : "[attacker]"] cuts through [mob_holding_disintegrated]'s [item_to_disintegrate.name] with their [item_to_disintegrate == damage_source ? "[src.name]" : "[damage_source.name]"], rendering it useless!</span>")

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -11,10 +11,10 @@
 
 /obj/item/weapon/handle_shield(var/mob/user, var/damage, var/atom/dam_source = null, var/mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	var/obj/item/damage_source = dam_source
-	if(!attacker)
+	if(!attacker && isnull(damage_source))
 		return 0
 	//Checks done, Parrycode starts here.//
-	if(istype(attacker,/mob/living) && damage < 5 && (attacker.a_intent == "help" || attacker.a_intent == "grab")) //We don't need to block helpful actions. (Or grabs)
+	if(attacker && istype(attacker,/mob/living) && damage < 5 && (attacker.a_intent == "help" || attacker.a_intent == "grab")) //We don't need to block helpful actions. (Or grabs)
 		return 0
 	var/parry_chance_divisor = 1
 	var/force_half_damage = 0
@@ -33,10 +33,13 @@
 		visible_message("<span class = 'danger'>[user] counters [attacker]'s unarmed attack with their [src.name]!</span>")
 		attack(attacker,user,pick("l_arm","r_arm","chest"))
 		force_half_damage = 1
-	else
+	else if (attacker)
 		visible_message("<span class = 'danger'>[user] parries [attacker]'s [damage_source.name] with their [src.name]</span>")
 		playsound(loc, hitsound, 50, 1, -1)
 		playsound(loc, damage_source.hitsound, 50, 1, -1)
+	else
+		visible_message("<span class = 'danger'>[user] deflects [damage_source] with their [src]!</span>")
+		playsound(loc, hitsound, 50, 1, -1)
 
 	var/obj/item/item_to_disintegrate
 	var/mob/living/mob_holding_disintegrated

--- a/code/modules/halo/misc/armourspecials/shields.dm
+++ b/code/modules/halo/misc/armourspecials/shields.dm
@@ -71,7 +71,9 @@
 		mob_overlay.overlays += shieldoverlay
 
 /datum/armourspecials/shields/handle_shield(mob/m,damage,atom/damage_source)
-
+	var/mob/living/attacker = damage_source
+	if(istype(attacker) && damage < 5 && (attacker.a_intent == "help" || attacker.a_intent == "grab")) //We don't need to block helpful actions. (Or grabs)
+		return 0
 	if(take_damage(damage))
 		connectedarmour.armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0) //This is needed because shields don't work if armour absorbs the blow instead.
 

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -29,6 +29,7 @@
 		"Jiralhanae" = null,\
 		"Sangheili" = null\
 		)
+	parry_projectiles = 1
 
 /obj/item/weapon/melee/energy/elite_sword/New()
 	. = ..()
@@ -168,6 +169,7 @@
 	active_throwforce = 12
 	edge = 0
 	sharp = 0
+	parry_projectiles = 0
 
 /obj/item/weapon/melee/energy/elite_sword/dagger/activate(mob/living/user)
 	..()


### PR DESCRIPTION
Makes successful, non melting gun-parries still do half damage.
Adds a variable to enable projectile parrying.
Enables said variable on the energy sword.