### PR TITLE
Allows the option to disable error logging when unable to load a file

### DIFF
--- a/code/_helpers/files.dm
+++ b/code/_helpers/files.dm
@@ -1,13 +1,15 @@
 //checks if a file exists and contains text
 //returns text as a string if these conditions are met
-/proc/return_file_text(filename)
+/proc/return_file_text(filename, var/log_error = 1)
 	if(fexists(filename) == 0)
-		error("File not found ([filename])")
+		if(log_error)
+			error("File not found ([filename])")
 		return
 
 	var/text = file2text(filename)
 	if(!text)
-		error("File empty ([filename])")
+		if(log_error)
+			error("File empty ([filename])")
 		return
 
 	return text

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -58,8 +58,8 @@
 	return num_list
 
 // Splits the text of a file at seperator and returns them in a list.
-/proc/file2list(filename, seperator="\n")
-	return splittext(return_file_text(filename),seperator)
+/proc/file2list(filename, seperator="\n", var/log_error = 1)
+	return splittext(return_file_text(filename, log_error),seperator)
 
 // Turns a direction into text
 /proc/num2dir(direction)

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -8,7 +8,7 @@ var/list/whitelist = list()
 	return 1
 
 /proc/load_whitelist()
-	var/list/whitelist_base = file2list(WHITELISTFILE)
+	var/list/whitelist_base = file2list(WHITELISTFILE, log_error = 0)
 	if(!whitelist_base.len)	whitelist = null
 	whitelist = list()
 	for(var/value in whitelist_base) //Added some code to handle jobs.


### PR DESCRIPTION
See commit. I've also disabled error logging for loading data/whitelist.txt which will allow #1564 to pass Travis. 

Longer term we should switch away from text whitelist and to db whitelist, but that's a bit of work to get it setup and working that I'm not up for right now. 