### PR TITLE
Another Darkness bugfix attempt

### DIFF
--- a/code/modules/halo/overmap/base_npc_ships.dm
+++ b/code/modules/halo/overmap/base_npc_ships.dm
@@ -223,7 +223,6 @@
 		sleep(10) //A small sleep to ensure the above message is printed before the loading operation commences.
 		var/z_to_load_at = shipmap_handler.get_next_usable_z()
 		shipmap_handler.un_free_map(z_to_load_at)
-		world.maxz = z_to_load_at
 		create_lighting_overlays_zlevel(z_to_load_at)
 		map_sectors["[z_to_load_at]"] = src
 		maploader.load_map(link,z_to_load_at)

--- a/code/modules/halo/overmap/base_npc_ships.dm
+++ b/code/modules/halo/overmap/base_npc_ships.dm
@@ -223,12 +223,13 @@
 		sleep(10) //A small sleep to ensure the above message is printed before the loading operation commences.
 		var/z_to_load_at = shipmap_handler.get_next_usable_z()
 		shipmap_handler.un_free_map(z_to_load_at)
+		world.maxz = z_to_load_at
+		create_lighting_overlays_zlevel(z_to_load_at)
 		map_sectors["[z_to_load_at]"] = src
 		maploader.load_map(link,z_to_load_at)
 		var/obj/effect/landmark/map_data/md = new(locate(1,1,z_to_load_at))
 		src.link_zlevel(md)
 		map_z += z_to_load_at //The above proc will increase the maxz by 1 to accomodate the new map. This deals with that.
-		create_lighting_overlays_zlevel(z_to_load_at)
 	cargo_init()
 	damage_spawned_ship()
 	GLOB.processing_objects += src

--- a/code/modules/halo/overmap/npc_shipmap_handler.dm
+++ b/code/modules/halo/overmap/npc_shipmap_handler.dm
@@ -42,4 +42,5 @@ var/global/datum/npc_ship_map_handler/shipmap_handler = new
 		return pick(free_ship_map_zs)
 	else
 		max_z_cached += 1
+		world.maxz = max_z_cached
 		return max_z_cached


### PR DESCRIPTION
title
Moves the z-level expansion to before mapfile load.
Moves lighting overlay generation to after z-level expansion but before mapfile load.