### PR TITLE
plaspistol and general energy weapon changes

### DIFF
--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -22,7 +22,7 @@
 
 /obj/item/weapon/gun/energy/plasmapistol/New()
 	. = ..()
-	overcharge_cost = initial(charge_cost)*(max_shots/2)
+	overcharge_cost = initial(charge_cost)*2
 
 /obj/item/weapon/gun/energy/plasmapistol/attack_self(var/mob/user)
 	if(power_supply.charge >= overcharge_cost)

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -35,11 +35,6 @@
 			update_icon()
 			return 1
 
-/obj/item/weapon/gun/energy/plasmapistol/consume_next_projectile()
-	.  = ..()
-	if(overcharge)
-		set_overcharge(0)
-
 /obj/item/weapon/gun/energy/plasmapistol/proc/set_overcharge(var/new_overcharge = 1, var/mob/user = null)
 	if(new_overcharge != overcharge)
 		if(new_overcharge)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -25,8 +25,7 @@
 		update_icon()
 
 /obj/item/weapon/gun/energy/emp_act(severity)
-	..()
-	update_icon()
+	return //Let's not make the weapons lose all of their power on EMP. They're military grade, they should be vaguely hardened.
 
 /obj/item/weapon/gun/energy/New()
 	..()


### PR DESCRIPTION
Removes the plaspistol reset-on-fire due to it breaking the overcharge functionality.
Modifies the charge-cost of overcharge, making it draw double power (40 shots in overcharge from full instead of 2)
Makes energy weapons unable to be drained via EMP