### PR TITLE
Overmind and hostile mob tweaks

### DIFF
--- a/code/modules/halo/NPC/npc_overmind.dm
+++ b/code/modules/halo/NPC/npc_overmind.dm
@@ -24,8 +24,9 @@ var/global/datum/npc_overmind/flood/flood_overmind = new
 	var/targets_reported //Used for REPORT_CONTACT to determine severity
 	var/report_target //Used for REPORT_RECLAIM_EQUIP types
 	var/obj/reporter_assault_point // Used for REPORT_CASUALTY
+	var/reporter_loc //Used for REPORT_CASUALTY
 
-/datum/npc_report/New(var/type,var/reporter,var/report_obj_target,var/num_targets,var/reporter_assault)
+/datum/npc_report/New(var/type,var/reporter,var/report_obj_target,var/num_targets,var/reporter_assault,var/reporter_location)
 	report_type = type
 	reporter_mob = reporter
 	if(report_obj_target)
@@ -34,6 +35,8 @@ var/global/datum/npc_overmind/flood/flood_overmind = new
 		targets_reported = num_targets
 	if(reporter_assault)
 		reporter_assault_point = reporter_assault
+	if(reporter_location)
+		reporter_loc = reporter_location
 
 /datum/npc_overmind
 
@@ -57,7 +60,7 @@ var/global/datum/npc_overmind/flood/flood_overmind = new
 
 	var/form_squad_searchrange = SQUADFORM_SEARCHRANGE
 
-/datum/npc_overmind/proc/create_report(var/report_type,var/mob/reporter,var/target_num = null,var/report_targ = null,var/reporter_assault_point = null)
+/datum/npc_overmind/proc/create_report(var/report_type,var/mob/reporter,var/target_num = null,var/report_targ = null,var/reporter_assault_point = null,var/reporter_loc)
 	reports += new /datum/npc_report (report_type,reporter,report_targ,target_num,reporter_assault_point)
 
 /datum/npc_overmind/proc/get_taskpoint_assigned(var/mob/m)
@@ -163,8 +166,10 @@ var/global/datum/npc_overmind/flood/flood_overmind = new
 	if(isnull(valid_squadmembers) || valid_squadmembers.len == 0)
 		squad_assigned.Cut()
 		return
-	create_taskpoint_assign(pick(valid_squadmembers),report.reporter_assault_point,"reinforcement",max(1,report.targets_reported/SINGLESQUAD_MAXTARGET_HANDLE),form_squad_searchrange*3)
+	var/reporter_taskpoint = create_taskpoint(report.reporter_loc)
+	create_taskpoint_assign(pick(valid_squadmembers),reporter_taskpoint,"reinforcement",max(1,report.targets_reported/SINGLESQUAD_MAXTARGET_HANDLE),form_squad_searchrange*3)
 	update_taskpoint_timeout(report.reporter_assault_point)
+	update_taskpoint_timeout(reporter_taskpoint)
 
 /datum/npc_overmind/proc/process_reports()
 	for(var/datum/npc_report/report in reports)

--- a/code/modules/halo/flood/flood.dm
+++ b/code/modules/halo/flood/flood.dm
@@ -156,8 +156,9 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 	return 0
 
 /mob/living/simple_animal/hostile/flood/infestor/proc/infest_airlocks_nearby()
-	for(var/obj/machinery/door/airlock/door in view(2,src))
-		if(door.stat & BROKEN || door.welded == 1)
+	for(var/obj/machinery/door/door in view(2,src))
+		var/obj/machinery/door/airlock/door_airlock = door
+		if(door.stat & BROKEN || (istype(door_airlock) && door_airlock.welded == 1))
 			continue
 		visible_message("<span class = 'danger'>[name] leaps at [door], burrowing into the access control mechanisms...</span>")
 		adjustBruteLoss(1)
@@ -165,7 +166,7 @@ GLOBAL_LIST_EMPTY(live_flood_simplemobs)
 		spawn(AIRLOCK_INFEST_TIME)
 			door.visible_message("<spanc class = 'danger>[door] sprouts tendrils of biomass from its control console, fully opening and then bolting.</span>")
 			door.open(1,1)
-		return 1//Only one airlock per loop.
+		return 1//Only one door per loop.
 	return 0
 
 /mob/living/simple_animal/hostile/flood/infestor/proc/infect_mob(var/mob/living/carbon/human/h)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -82,7 +82,7 @@
 
 	if(our_overmind && !isnull(T))
 		var/list/targlist = ListTargets(7)
-		our_overmind.create_report(1,src,null,targlist.len,assault_target)
+		our_overmind.create_report(1,src,null,targlist.len,assault_target,loc)
 	return T
 
 
@@ -194,7 +194,7 @@
 /mob/living/simple_animal/hostile/death(gibbed, deathmessage, show_dead_message)
 	if(our_overmind)
 		var/list/targlist = ListTargets(7)
-		our_overmind.create_report(5,src,null,targlist.len,assault_target)
+		our_overmind.create_report(5,src,null,targlist.len,assault_target,loc)
 	..(gibbed, deathmessage, show_dead_message)
 	stop_automated_movement = 0
 	walk(src, 0)
@@ -280,7 +280,11 @@ GLOBAL_LIST_INIT(hostile_attackables, list(\
 	/obj/structure/closet,\
 	/obj/structure/table,\
 	/obj/structure/grille,\
-	/obj/structure/barricade
+	/obj/structure/girder,\
+	/obj/structure/tanktrap,\
+	/obj/structure/barricade,\
+	/obj/structure/barricadeunsc,\
+	/obj/structure/sandbag
 ))
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()


### PR DESCRIPTION
Makes the overmind call troops to the location of a casualty and not the original taskpoint.
Adds some more structures to the list of hostile-mob-attackables.
Allows infestors to infest all types of doors, including blast doors.