### PR TITLE
Overmap ship work (and a slipspace drive buff

### DIFF
--- a/code/modules/halo/overmap/base_npc_ships.dm
+++ b/code/modules/halo/overmap/base_npc_ships.dm
@@ -51,6 +51,8 @@
 
 	var/list/cargo_containers = list()
 
+	var/ignore_target_civs = 1
+
 /obj/effect/overmap/ship/npc_ship/proc/pick_ship_icon()
 	var/list/icons_pickfrom = icons_pickfrom_list
 	icon = pick(icons_pickfrom)
@@ -129,12 +131,11 @@
 		if(!have_lang)
 			var/new_message = ""
 			var/datum/language/default = m.get_default_language()
-			var/iter
-			for(iter = 0; iter <= lentext(message)/2; iter++)
-			if(!isnull(default))
-				new_message += pick(default.syllables)
-			else
-				new_message += pick("a","e","i","o","u")
+			for(var/iter = 0, iter <= lentext(message)/2, iter++)
+				if(!isnull(default))
+					new_message += pick(default.syllables)
+				else
+					new_message += pick("a","e","i","o","u")
 			message = new_message
 		to_chat(m,"<span class = 'radio'>\[[channel]\] [name]: \"[message]\" \[[x]:[y]\]</span>")
 

--- a/code/modules/halo/overmap/slipspace_engine.dm
+++ b/code/modules/halo/overmap/slipspace_engine.dm
@@ -58,8 +58,9 @@
 
 /obj/machinery/slipspace_engine/proc/overload_engine(var/mob/user)
 	jump_charging = -1
-	new core_to_spawn(loc)
+	var/obj/core = new core_to_spawn(loc)
 	icon_state = "[initial(icon_state)]_coreremoved"
+	core.attack_hand(user)
 
 /obj/machinery/slipspace_engine/proc/user_overload_engine(var/mob/user)
 	if(isnull(core_to_spawn))
@@ -260,12 +261,6 @@
 	explodetype = /datum/explosion/slipspace_core
 	seconds_to_explode = 300 //5 minutes to explode.
 	seconds_to_disarm = 120 // 2 minutes to disarm.
-
-/obj/payload/slipspace_core/Initialize()
-	. = ..()
-	explode_at = world.time + seconds_to_explode SECONDS
-	exploding = 1
-	GLOB.processing_objects += src
 
 /obj/payload/slipspace_core/attack_hand(var/mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/halo/overmap/slipspace_engine.dm
+++ b/code/modules/halo/overmap/slipspace_engine.dm
@@ -256,9 +256,10 @@
 //CORE PAYLOADS//
 /obj/payload/slipspace_core
 	name = "Slipspace Core"
-	desc = "The core of a slipspace device, detached and armed. Slipspace cores are unstable and cannot be disarmed."
+	desc = "The core of a slipspace device, detached and armed."
 	explodetype = /datum/explosion/slipspace_core
-	seconds_to_explode = 300 //5 minutes
+	seconds_to_explode = 300 //5 minutes to explode.
+	seconds_to_disarm = 120 // 2 minutes to disarm.
 
 /obj/payload/slipspace_core/Initialize()
 	. = ..()
@@ -266,13 +267,19 @@
 	exploding = 1
 	GLOB.processing_objects += src
 
-/obj/payload/slipspace_core/attack_hand(var/attacker)
-	to_chat(attacker,"<span class = 'danger'>[src] is armed and beeping. </span>")
+/obj/payload/slipspace_core/attack_hand(var/mob/living/carbon/human/user)
+	. = ..()
+	if(exploding && !disarming)
+		for(var/mob/player in GLOB.mobs_in_sectors[map_sectors["[z]"]])
+			to_chat(player,"<span class = 'danger'>UNSTABLE SLIPSPACE SIGNATURE DETECTED AT [x],[y],[z]. STABALISE SIGNATURE OR SUPERSTRUCTURE FAILURE WILL BE IMMINENT.</span>")
 
 /datum/explosion/slipspace_core/New(var/obj/payload/b)
 	if(config.oni_discord)
 		message2discord(config.oni_discord, "Alert: slipspace core detonation detected. [b.name] @ ([b.loc.x],[b.loc.y],[b.loc.z])")
-	explosion(100, -1, -1, -1, 0)
+	var/obj/effect/overmap/om = map_sectors["[b.z]"]
+	if(isnull(om))
+		return
+	om.pre_superstructure_failing()
 
 /obj/payload/slipspace_core/cov
 	icon = 'code/modules/halo/icons/machinery/covenant/slipspace_drive.dmi'

--- a/code/modules/halo/overmap/weapons/flood/flood_projectiles.dm
+++ b/code/modules/halo/overmap/weapons/flood/flood_projectiles.dm
@@ -6,6 +6,7 @@
 	icon_state = "spores"
 
 	ship_damage_projectile = /obj/item/projectile/flood_pod_onmap
+	damage = 250
 
 /obj/item/projectile/overmap/flood_pod/sector_hit_effects(var/z_level,var/obj/effect/overmap/hit,var/list/hit_bounds)
 	var/turf/turf_to_hit = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
@@ -14,7 +15,7 @@
 	spawned.loc = turf_to_hit
 
 /obj/item/projectile/flood_pod_onmap
-	damage = 200
+	damage = 250
 	penetrating = 5
 	invisibility = 101
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -259,7 +259,10 @@ var/list/points_of_interest = list()
 	if(superstructure_failing == -1)
 		return
 	if(superstructure_failing == 1)
-		//TODO: Special messages/other effects whilst the superstructure fails.
+		if(hull_segments.len == 0)
+			return
+		var/obj/explode_at = pick(hull_segments)
+		explosion(explode_at.loc,2,4,6,8, adminlog = 0)
 		return
 	var/list/superstructure_strength = get_superstructure_strength()
 	if(isnull(superstructure_strength))

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -15,6 +15,8 @@
 	var/engines_state = 1 //global on/off toggle for all engines
 	var/thrust_limit = 1 //global thrust limit for all engines, 0..1
 
+	var/displaying_faction = 1
+
 /obj/effect/overmap/ship/Initialize()
 	. = ..()
 	for(var/datum/ship_engine/E in ship_engines)


### PR DESCRIPTION
🆑 XO-11
tweak: buffs flood pod projectile damage
rscadd: modifies NPC ships to fight with other different-faction ships.
rscadd: ships should no longer speak sangheili when it's not appropriate.
tweak: buffs slipspace drives to automatically cause superstructure failure. Slipspace drives can now be disarmed (takes 2 minutes). 
tweak: Superstructure failure now causes areas around hull segments to explode as the ship collapses. If random explosions are happening, you should probably evacuate the ship asap.
/🆑 