### PR TITLE
Enables loadouts for humans on outer colonies

### DIFF
--- a/maps/Exoplanet Research/jobs.dm
+++ b/maps/Exoplanet Research/jobs.dm
@@ -10,6 +10,7 @@
 	access = list(310,311)
 	spawnpoint_override = "Research Facility Spawn"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/researchdirector
 	title = "ONI Research Director"
@@ -21,6 +22,7 @@
 	access = list(310,311)
 	spawnpoint_override = "Research Facility Director Spawn"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 
 /datum/job/ONIGUARD
@@ -33,6 +35,7 @@
 	access = list(311)
 	spawnpoint_override = "Research Facility Security Spawn"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/ONIGUARDS
 	title = "ONI Security Commander"
@@ -44,3 +47,4 @@
 	access = list(311)
 	spawnpoint_override = "Research Facility Security Spawn"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE

--- a/maps/UNSC_Bertels/jobs.dm
+++ b/maps/UNSC_Bertels/jobs.dm
@@ -13,6 +13,7 @@
 	access = list(access_unsc)
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/unscbertels_medical_crew
 	title = "UNSC Bertels Hospital Corpsman"
@@ -24,6 +25,7 @@
 	access = list(access_unsc)
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/unscbertels_co
 	title = "UNSC Bertels Commanding Officer"
@@ -38,6 +40,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	faction_whitelist = "UNSC"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/unscbertels_xo
 	title = "UNSC Bertels Executive Officer"
@@ -50,6 +53,7 @@
 	access = list(access_unsc,144,145,192,access_unsc_bridge,access_unsc_shuttles,access_unsc_armoury,access_unsc_supplies,access_unsc_officers,access_unsc_marine)
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/unsc_ship_iwo
 	title = "UNSC Bertels Infantry Weapons Officer"
@@ -61,6 +65,7 @@
 	access = list(access_unsc,144,145,192,access_unsc_armoury, access_unsc_marine)
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 
 
@@ -80,6 +85,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	open_slot_on_death = 1
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/unsc_ship_marineplatoon
 	title = "UNSC Marine Platoon Leader"
@@ -92,6 +98,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	open_slot_on_death = 1
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 //UNSC BERTELS ODST Jobs
 
@@ -115,6 +122,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	is_whitelisted = 1
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/bertelsODSTO
 	title = "Orbital Drop Shock Trooper Officer"
@@ -133,3 +141,4 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	is_whitelisted = 1
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE

--- a/maps/desert_outpost/jobs.dm
+++ b/maps/desert_outpost/jobs.dm
@@ -7,6 +7,7 @@
 	spawnpoint_override = "Crash Site"
 	spawn_faction = "UNSC"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/stranded/unsc_marine
 	title = "UNSC marine survivor"

--- a/maps/geminus_city/geminus_city_jobs.dm
+++ b/maps/geminus_city/geminus_city_jobs.dm
@@ -15,36 +15,6 @@
 	access = list(access_janitor, access_maint_tunnels, access_research)
 	alt_titles = list("Miner","Doctor","Nurse","Warehouse Worker","Construction Worker","Surgeon","Store Owner","Nightclub Owner","Secretary","Cargo Worker","Bartender","Cook","Chef","Farmer","Judge","Cargo Dock Worker","Lawyer","EMT","Paramedic","Bodyguard","Janitor")
 
-/datum/job/innie_sympathiser
-	title = "Colonist - Insurrectionist Sympathiser"
-	total_positions = 5
-	spawnpoint_override = "Colony Arrival Shuttle"
-	selection_color = "#000000"
-	spawn_faction = "Insurrection"
-	supervisors = " the Colony Mayor and your local insurrection contact"
-	account_allowed = 1
-	generate_email = 1
-	loadout_allowed = TRUE
-	outfit_type = /decl/hierarchy/outfit/job/colonist/innie_sympathiser
-	whitelisted_species = list(/datum/species/human)
-
-	latejoin_at_spawnpoints = FALSE
-	access = list(access_janitor, access_maint_tunnels, access_research)
-
-/datum/job/insurrectionist_recruiter
-	title = "Colonist - Insurrectionist Recruiter"
-	total_positions = 1
-	head_position = 1
-	outfit_type = /decl/hierarchy/outfit/job/colonist/innie_sympathiser
-	whitelisted_species = list(/datum/species/human)
-	account_allowed = 1
-	generate_email = 1
-	loadout_allowed = TRUE
-	spawnpoint_override = "Colony Arrival Shuttle"
-	selection_color = "#000000"
-	spawn_faction = "Insurrection"
-	supervisors = " the Insurrection"
-
 /datum/job/colonist_mayor
 	title = "Mayor"
 	department_flag = COM
@@ -108,7 +78,6 @@
 	account_allowed = 1
 	generate_email = 1
 	economic_modifier = 2
-	loadout_allowed = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cop
 	whitelisted_species = list(/datum/species/human)
 

--- a/maps/geminus_city/geminus_city_spawns.dm
+++ b/maps/geminus_city/geminus_city_spawns.dm
@@ -5,8 +5,6 @@ GLOBAL_LIST_EMPTY(colony_spawns)
 	display_name = "Colony Arrival Shuttle"
 	restrict_job_type = list(\
 		/datum/job/colonist,\
-		/datum/job/innie_sympathiser,\
-		/datum/job/insurrectionist_recruiter,\
 		/datum/job/colonist_mayor,\
 		/datum/job/police,\
 		/datum/job/police_chief\

--- a/maps/geminus_city/innie_jobs.dm
+++ b/maps/geminus_city/innie_jobs.dm
@@ -34,6 +34,7 @@
 	"Insurrectionist Saboteur",\
 	"Insurrectionist Infiltrator")
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/geminus_innie/officer
 	title = "Insurrectionist Officer"


### PR DESCRIPTION
Enables loadouts for all human jobs in outer colonies. Also removes some old unused GC innie jobs. Closes #1721

:cl:
tweak: Loadouts for all human jobs in the Geminus gamemodes have been re-enabled. 
/:cl: