### PR TITLE
npc combat ship null runtime fix

### DIFF
--- a/code/modules/halo/overmap/combat_npc_ship.dm
+++ b/code/modules/halo/overmap/combat_npc_ship.dm
@@ -71,6 +71,8 @@
 
 		//check if they're a hostile faction
 		var/datum/faction/their_faction = ship.my_faction
+		if(isnull(their_faction))
+			continue
 		if(their_faction.name in my_faction.enemy_factions)
 			targets += ship
 


### PR DESCRIPTION
fixes a runtime that occured when attempting to scan a target with no assigned faction.
:cl: XO-11
tweak: npc ship targeting should actually work now.
/:cl: