### PR TITLE
overloaded slipspace drive density change

### DIFF
--- a/code/modules/halo/overmap/slipspace_engine.dm
+++ b/code/modules/halo/overmap/slipspace_engine.dm
@@ -60,6 +60,7 @@
 
 /obj/machinery/slipspace_engine/proc/overload_engine(var/mob/user)
 	jump_charging = -1
+	src.density = 0
 	var/obj/core = new core_to_spawn(loc)
 	icon_state = "[initial(icon_state)]_coreremoved"
 	core.attack_hand(user)


### PR DESCRIPTION
:cl: XO-11
tweak: overloaded slipspace drives now have a density of 0, so you can actually reach the slipspace core.
/:cl: