### PR TITLE
overall capship weapon nerfs

### DIFF
--- a/code/modules/halo/overmap/weapons/Energy_projector.dm
+++ b/code/modules/halo/overmap/weapons/Energy_projector.dm
@@ -235,7 +235,7 @@
 	icon_state = ""
 	alpha = 0
 	damage = 900
-	penetrating = 8
+	penetrating = 3
 	step_delay = 0.0 SECONDS
 	kill_count = 999 //so it doesn't despawn before cutting through the ship
 	tracer_type = /obj/effect/projectile/projector_laser_proj

--- a/code/modules/halo/overmap/weapons/MAC.dm
+++ b/code/modules/halo/overmap/weapons/MAC.dm
@@ -271,17 +271,15 @@
 //MAC SHIPHIT PROJECTILE//
 /obj/item/projectile/mac_round
 	name = "MAC Slug"
-	penetrating = 2
+	penetrating = 1
 	var/warned = 0
 
 /obj/item/projectile/mac_round/check_penetrate(var/atom/impacted)
 	. = ..()
 	var/increase_from_damage = (damage/250)
 	if(increase_from_damage > 2)
-		increase_from_damage = (increase_from_damage-2)/4
-	else
-		increase_from_damage = 0
-	explosion(impacted,3 + increase_from_damage,5 + increase_from_damage,7 + increase_from_damage,10 + increase_from_damage, adminlog = 0)
+		increase_from_damage *= 0.25
+	explosion(impacted,2 + increase_from_damage,4 + increase_from_damage,5 + increase_from_damage,6 + increase_from_damage, adminlog = 0)
 	if(!warned)
 		warned = 1
 		var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]


### PR DESCRIPTION
nerfs the penetration of both the MAC and the Energy Projector. Also nerfs damage values.

This is due to complaints about weapon lethality mostly being linked to these two main weapons.

:cl: XO-11
tweak: Various governmental bodies on both the UNSC and Covenant sides have conspired to reduce the effectiveness of their ship's main weapons. Energy Projector and MAC rounds will do less damage.
/:cl: