### PR TITLE
Fixed flashlight attachment, for UNSC.

### DIFF
--- a/code/modules/halo/weapons/rifles.dm
+++ b/code/modules/halo/weapons/rifles.dm
@@ -36,7 +36,7 @@
 		)
 
 	attachment_slots = list("barrel","underbarrel rail","upper rail","upper stock", "stock")
-	attachments_on_spawn = list(/obj/item/weapon_attachment/ma5_stock_cheekrest,/obj/item/weapon_attachment/ma5_stock_butt,/obj/item/weapon_attachment/ma5_upper)
+	attachments_on_spawn = list(/obj/item/weapon_attachment/ma5_stock_cheekrest,/obj/item/weapon_attachment/ma5_stock_butt,/obj/item/weapon_attachment/ma5_upper,/obj/item/weapon_attachment/light/ma5_flashlight)
 
 /obj/item/weapon/gun/projectile/ma5b_ar/can_use_when_prone()
 	return 1

--- a/code/modules/projectiles/attachments/lights.dm
+++ b/code/modules/projectiles/attachments/lights.dm
@@ -2,6 +2,7 @@
 /obj/item/weapon_attachment/light
 	name = "flashlight attachment"
 	desc = "An attachment designed to provide light."
+	weapon_slot = "underbarrel rail"
 
 	var/on = 0
 	var/intensity = 4


### PR DESCRIPTION
:cl: Ashvor
bugfix: Fixed the flashlight attachment so it mounts on the under rail of UNSC Weapons. Now properly spawns on the MA5B Assault rifle by default. Can be replaced with under barrel grip.
/:cl: