### PR TITLE
Neural lace ids

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -14,9 +14,18 @@
 
 /atom/movable/proc/GetAccess()
 	var/obj/item/weapon/card/id/id = GetIdCard()
-	return id ? id.GetAccess() : list()
+	var/obj/item/organ/internal/stack/lace = GetLace()
+	var/list/access_combo = list()
+	if(id)
+		access_combo |= id.GetAccess()
+	if(lace)
+		access_combo |= lace.access
+	return access_combo
 
 /atom/movable/proc/GetIdCard()
+	return null
+
+/atom/movable/proc/GetLace()
 	return null
 
 /obj/proc/check_access(obj/item/I)
@@ -215,8 +224,11 @@
 		if(id)
 			return id
 
+/mob/living/carbon/human/GetLace()
+	return internal_organs_by_name["stack"]
+
 /mob/living/carbon/human/GetAccess()
-	. = list()
+	. = ..()
 	for(var/item_slot in HUMAN_ID_CARDS)
 		var/obj/item/I = item_slot
 		if(I)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -47,6 +47,8 @@
 	var/list/whitelisted_species = list()		//job can only be filled by these species
 	var/open_slot_on_death = 0
 
+	var/lace_access = 0 //Forces the job to have a neural lace, so we can store the access in it instead of in the ID..
+
 /datum/job/New()
 	..()
 	if(prob(100-availablity_chance))	//Close positions, blah blah.

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -406,6 +406,11 @@ var/global/datum/controller/occupations/job_master
 			//Equip job items.
 			job.setup_account(H)
 			job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch)
+			if(job.lace_access && isnull(H.GetLace()))
+				H.create_stack(job.access)
+				var/obj/item/weapon/card/id/my_id = H.GetIdCard()
+				if(my_id) //If we're using lace access storage, null out our ID's accesses.
+					my_id.access = list()
 			job.apply_fingerprints(H)
 
 			if(H.char_rank && H.char_rank.accessory)

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -1,7 +1,9 @@
-/mob/living/carbon/human/proc/create_stack()
+/mob/living/carbon/human/proc/create_stack(var/list/access_init = list())
 	set waitfor=0
 	sleep(10)
-	internal_organs_by_name[BP_STACK] = new /obj/item/organ/internal/stack(src,1)
+	var/obj/item/organ/internal/stack/s = new(src,1)
+	s.access = access_init
+	internal_organs_by_name[BP_STACK] = s
 	to_chat(src, "<span class='notice'>You feel a faint sense of vertigo as your neural lace boots.</span>")
 
 /obj/item/organ/internal/stack
@@ -18,6 +20,7 @@
 	var/invasive
 	var/default_language
 	var/list/languages = list()
+	var/list/access = list()
 	var/datum/mind/backup
 
 /obj/item/organ/internal/stack/emp_act()

--- a/maps/Exoplanet Research/jobs.dm
+++ b/maps/Exoplanet Research/jobs.dm
@@ -11,6 +11,7 @@
 	spawnpoint_override = "Research Facility Spawn"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/researchdirector
 	title = "ONI Research Director"
@@ -24,7 +25,7 @@
 	spawnpoint_override = "Research Facility Director Spawn"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
-
+	lace_access = TRUE
 
 /datum/job/ONIGUARD
 	title = "ONI Security Guard"
@@ -38,6 +39,7 @@
 	spawnpoint_override = "Research Facility Security Spawn"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/ONIGUARDS
 	title = "ONI Security Commander"
@@ -51,3 +53,4 @@
 	spawnpoint_override = "Research Facility Security Spawn"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE

--- a/maps/UNSC_Bertels/jobs.dm
+++ b/maps/UNSC_Bertels/jobs.dm
@@ -16,6 +16,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/unscbertels_medical_crew
 	title = "Hospital Corpsman"
@@ -30,6 +31,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/unscbertels_co
 	title = "Commanding Officer"
@@ -47,6 +49,7 @@
 	faction_whitelist = "UNSC"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/unscbertels_xo
 	title = "Executive Officer"
@@ -62,6 +65,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
+	lace_access = TRUE
 
 /datum/job/unsc_ship_iwo
 	title = "Infantry Weapons Officer"
@@ -76,7 +80,7 @@
 	spawnpoint_override = "UNSC Base Spawns"
 	whitelisted_species = list(/datum/species/human)
 	loadout_allowed = TRUE
-
+	lace_access = TRUE
 
 
 //UNSC Ship Marine Jobs
@@ -98,6 +102,7 @@
 	loadout_allowed = TRUE
 	account_allowed = 1
 	economic_modifier = 0.5
+	lace_access = TRUE
 
 /datum/job/unsc_ship_marineplatoon
 	title = "UNSC Marine Platoon Leader"
@@ -113,6 +118,7 @@
 	loadout_allowed = TRUE
 	account_allowed = 1
 	economic_modifier = 1
+	lace_access = TRUE
 
 //UNSC Ship ODST Jobs
 
@@ -139,6 +145,7 @@
 	loadout_allowed = TRUE
 	account_allowed = 1
 	economic_modifier = 1
+	lace_access = TRUE
 
 /datum/job/bertelsODSTO
 	title = "Orbital Drop Shock Trooper Officer"
@@ -160,3 +167,4 @@
 	loadout_allowed = TRUE
 	account_allowed = 1
 	economic_modifier = 1
+	lace_access = TRUE


### PR DESCRIPTION
Removes accesses from IDs and adds them to neural laces.
:cl: XO-11
rscadd: Neural Laces are now mandatory in the UNSC. Your access is now stored on the lace.
/:cl: