### PR TITLE
nerfs the effect of emp on doors

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1256,13 +1256,14 @@ About the new airlock wires panel:
 		electronics.one_access = 1
 
 /obj/machinery/door/airlock/emp_act(var/severity)
-	if(prob(20/severity))
-		spawn(0)
-			open()
-	if(prob(40/severity))
-		var/duration = SecondsToTicks(30 / severity)
-		if(electrified_until > -1 && (duration + world.time) > electrified_until)
-			electrify(duration)
+	if(health <= maxhealth/4)
+		if(prob(30/severity))
+			spawn(0)
+				open()
+		else if(prob(50/severity))
+			var/duration = SecondsToTicks(30 / severity)
+			if(electrified_until > -1 && (duration + world.time) > electrified_until)
+				electrify(duration)
 	..()
 
 /obj/machinery/door/airlock/power_change() //putting this is obj/machinery/door itself makes non-airlock doors turn invisible for some reason


### PR DESCRIPTION
:cl: XO-11
tweak: Doors now need to be below 1/4 health for EMPs to effect them.
/:cl: