### PR TITLE
Tweaks to energy weapon stats

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,8 +12,6 @@
 
 	armor_thickness = 20
 
-	armor_thickness_modifiers = list(BURN = 0.5)
-
 /obj/item/clothing/suit/armor/vest/old //just realized these had never been removed
 	name = "armor"
 	desc = "An armored vest that protects against some damage."

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -213,7 +213,7 @@
 		lasting_pain += 10
 	else if(is_dislocated())
 		lasting_pain += 5
-	return pain + lasting_pain + 1.1 * brute_dam + 1.25 * burn_dam
+	return pain + lasting_pain + 1.0 * brute_dam + 1.0 * burn_dam
 
 /obj/item/organ/external/proc/remove_pain(var/amount)
 	if(!can_feel_pain() || robotic >= ORGAN_ROBOT)


### PR DESCRIPTION
:cl: XO-11
tweak: Damage to pain multipliers for both types of damage are now 1.0. (brute: 1.1 -> 1.0,burnL:1.25 -> 1.0)
tweak: Burn damage no longer has an increased per-hit armor strip cap.
/:cl: