### PR TITLE
Neural lace rejuv

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -237,8 +237,9 @@
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
 	H.mob_size = mob_size
+	var/obj/item/organ/internal/stack/s = H.GetLace()
 	for(var/obj/item/organ/organ in H.contents)
-		if(((organ in H.organs) || (organ in H.internal_organs)) && !istype(organ,/obj/item/organ/internal/stack)) //Preserve neural laces / cortical stacks.
+		if(!istype(organ,/obj/item/organ/internal/stack) && ((organ in H.organs) || (organ in H.internal_organs))) //Preserve neural laces / cortical stacl
 			qdel(organ)
 
 	if(H.organs)                  H.organs.Cut()
@@ -272,6 +273,11 @@
 
 	for(var/obj/item/organ/O in (H.organs|H.internal_organs))
 		O.owner = H
+
+	if(s && isnull(H.internal_organs_by_name["stack"]))
+		H.internal_organs_by_name["stack"] = s
+		H.internal_organs += s
+		s.owner = H
 
 	H.sync_organ_dna()
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -238,7 +238,7 @@
 
 	H.mob_size = mob_size
 	for(var/obj/item/organ/organ in H.contents)
-		if((organ in H.organs) || (organ in H.internal_organs))
+		if(((organ in H.organs) || (organ in H.internal_organs)) && !istype(organ,/obj/item/organ/internal/stack)) //Preserve neural laces / cortical stacks.
 			qdel(organ)
 
 	if(H.organs)                  H.organs.Cut()


### PR DESCRIPTION
an admin facing fix that allows them to use rejuvenate and species-switch without deleting inbuilt neural laces.