### PR TITLE
Fix a runtime caused by null variables in the attachment system

### DIFF
--- a/code/modules/projectiles/attachment_system.dm
+++ b/code/modules/projectiles/attachment_system.dm
@@ -46,6 +46,8 @@
 /obj/item/weapon_attachment/proc/remove_attachment_effects(var/obj/item/weapon/gun/gun)
 
 /obj/item/weapon_attachment/proc/get_attribute_mods(var/obj/item/gun_caller)
+	if(isnull(cached_profile))
+		return list(0,0,0)
 	if(!(gun_caller.name == cached_profile.weapon_name))
 		var/datum/attachment_profile/profile = get_attachment_profile(gun_caller)
 		if(isnull(profile))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -589,9 +589,10 @@
 	var/cumulative_slowdownmod = 0
 	for(var/obj/item/weapon_attachment/attachment in get_attachments())
 		var/list/attrib_mods = attachment.get_attribute_mods(src)
-		cumulative_dispmod += attrib_mods[1]
-		cumulative_accmod += attrib_mods[2]
-		cumulative_slowdownmod += attrib_mods[3]
+		if(!isnull(attrib_mods))
+			cumulative_dispmod += attrib_mods[1]
+			cumulative_accmod += attrib_mods[2]
+			cumulative_slowdownmod += attrib_mods[3]
 
 	dispersion += cumulative_dispmod
 	accuracy += cumulative_accmod


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: bloxgate
bugfix: Fix a runtime in the attachment system
/:cl:
