### PR TITLE
Fix runtime causing Travis failure on Geminus

### DIFF
--- a/maps/ONI_Prowler/ONI_Prowler_Deck_1.dmm
+++ b/maps/ONI_Prowler/ONI_Prowler_Deck_1.dmm
@@ -78,7 +78,7 @@
 "bz" = (/obj/machinery/telecomms/relay/long_range_emergency,/turf/simulated/floor/plating,/area/corvette/onifox/communications)
 "bA" = (/obj/machinery/power/apc/infinite,/turf/simulated/wall/r_wall,/area/corvette/onifox/communications)
 "bB" = (/obj/structure/table/woodentable,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/obj/item/weapon/pen,/turf/simulated/floor/tiled/dark,/area/corvette/onifox/Bridge)
-"bC" = (/obj/structure/table/woodentable,/obj/machinery/light{dir = 1},/obj/machinery/photocopier/faxmachine,/obj/item/weapon/card/id/gold,/turf/simulated/floor/tiled/dark,/area/corvette/onifox/Bridge)
+"bC" = (/obj/structure/table/woodentable,/obj/machinery/light{dir = 1},/obj/machinery/photocopier/faxmachine,/obj/item/weapon/card/id/oni,/turf/simulated/floor/tiled/dark,/area/corvette/onifox/Bridge)
 "bD" = (/obj/structure/closet/wall_medical{pixel_x = 32},/turf/simulated/floor/tiled/dark,/area/corvette/onifox/Bridge)
 "bE" = (/obj/structure/table/steel_reinforced,/turf/simulated/floor/tiled,/area/corvette/onifox/Crewmess)
 "bF" = (/obj/structure/cable/blue{icon_state = "1-2"},/turf/simulated/floor/tiled,/area/corvette/onifox/Crewmess)


### PR DESCRIPTION
:cl: bloxgate
maptweak: UNSC Aegis now has an ONI ID instead of a Gold ID
/:cl:

Hopefully has the nice side effect of fixing a bug that's making Travis fail
