### PR TITLE
removes bugged "capture innies" objective

### DIFF
--- a/code/modules/halo/factions/objectives/objectives_unsc.dm
+++ b/code/modules/halo/factions/objectives/objectives_unsc.dm
@@ -35,7 +35,7 @@
 
 //todo: oni agent job role
 
-/datum/objective/capture_innies
+/*/datum/objective/capture_innies
 	short_text = "Capture Insurrectionists for ONI interrogation"
 	explanation_text = "The Insurrection worsens every year. Put some on ice in ONI cryopods for later black site interrogation. Kill the rest"
 	var/points_per_capture = 50
@@ -48,7 +48,7 @@
 	win_points += minds_captured.len * points_per_capture
 	win_points += minds_killed.len * points_per_kill
 	return win_points > 0
-
+*/
 /datum/objective/retrieve/artifact/unsc
 	short_text = "Secure the alien artifact"
 	explanation_text = "ONI reports a high value unidentified alien artifact in the sector. It must be secured by the UNSC to prevent falling into the wrong hands."

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -60,7 +60,7 @@
 		/datum/objective/overmap/unsc_ship,\
 		/datum/objective/retrieve/artifact/unsc,\
 		/datum/objective/protect/leader,\
-		/datum/objective/capture_innies,\
+//		/datum/objective/capture_innies,
 		/datum/objective/retrieve/steal_ai/cole_protocol,\
 		/datum/objective/retrieve/nav_data/cole_protocol,\
 		/datum/objective/overmap/unsc_cov_ship,\
@@ -292,15 +292,14 @@
 /datum/game_mode/outer_colonies/handle_mob_death(var/mob/M, var/unsc_capture = 0)
 	. = ..()
 
-	if(M.mind.assigned_role in list("Insurrectionist","Insurrectionist Commander","Insurrectionist Officer") || M.mind.faction == "Insurrectionist")
+/*	if(M.mind.assigned_role in list("Insurrectionist","Insurrectionist Commander","Insurrectionist Officer") || M.mind.faction == "Insurrectionist")
 		var/datum/faction/unsc/unsc = locate() in factions
-		if(unsc)
-			var/datum/objective/capture_innies/capture_innies = locate() in unsc.all_objectives
+		if(unsc)			var/datum/objective/capture_innies/capture_innies = locate() in unsc.all_objectives
 			if(capture_innies)
 				if(unsc_capture)
 					capture_innies.minds_captured.Add(M.mind)
 				else
-					capture_innies.minds_killed.Add(M.mind)
+					capture_innies.minds_killed.Add(M.mind)*/
 
 	if(M.mind)
 		for(var/datum/faction/F in factions)

--- a/maps/_gamemodes/invasion/gamemode_reclamation.dm
+++ b/maps/_gamemodes/invasion/gamemode_reclamation.dm
@@ -23,8 +23,8 @@
 /datum/game_mode/outer_colonies/reclamation/setup_objectives()
 	. = ..()
 
-	var/datum/objective/capture_innies/obj = locate() in GLOB.UNSC.all_objectives
-	obj.fake = 1
+/*	var/datum/objective/capture_innies/obj = locate() in GLOB.UNSC.all_objectives
+	obj.fake = 1*/
 
 	var/datum/objective/colony_capture/unsc/obj2 = locate() in GLOB.UNSC.all_objectives
 	obj2.fake = 1


### PR DESCRIPTION
I have no idea how I would fix this, so let's disable it for now so the unsc don't permenantly win by capturing one innie