### PR TITLE
spartan laser fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -267,6 +267,7 @@
 
 		is_charging = 1
 		if (!do_after(user,arm_time,src))
+			is_charging = 0
 			return
 		Fire(A,user,params)
 		is_charging = 0


### PR DESCRIPTION
:cl: XO-11
tweak: Fixes is_charged weapons to not be stuck in a permanant state of charging.
/:cl: