### PR TITLE
'nade changes

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -117,7 +117,7 @@
 	if(alt_explosion_range == -1)
 		return 0
 
-	for(var/mob/living/m in range(alt_explosion_range,src.loc))
+	for(var/mob/living/m in range(alt_explosion_range,loc))
 		var/mult = 1
 		if(get_dist(m,loc) > 0)
 			mult = multiplier_non_direct

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -17,7 +17,6 @@
 	var/alt_explosion_damage_max = 500 //The amount of armour + shield piercing damage done when grenade is stuck inside someone.
 	var/multiplier_non_direct = 0.5 //The multiplier to apply to the alt explosion max damage if the grenade is not directly on top of or inside someone.
 	var/alt_explosion_range = -1 //if set to -1, no armor bypass explosion
-	var/alt_explosion_type = BURN //Supports BRUTE or BURN
 
 /obj/item/weapon/grenade/proc/clown_check(var/mob/living/user)
 	if((CLUMSY in user.mutations) && prob(50))
@@ -115,16 +114,15 @@
 	return
 
 /obj/item/weapon/grenade/proc/do_alt_explosion()
-	if(alt_explosion_range != -1)
-		for(var/mob/living/m in range(alt_explosion_range,loc))
-			var/mult = 1
-			if(get_dist(m,loc) > 0)
-				mult = multiplier_non_direct
-			switch(alt_explosion_type)
-				if(BRUTE)
-					m.adjustBruteLoss(alt_explosion_damage_max*mult)
-				if(BURN)
-					m.adjustFireLoss(alt_explosion_damage_max*mult)
+	if(alt_explosion_range == -1)
+		return 0
+
+	for(var/mob/living/m in range(alt_explosion_range,src.loc))
+		var/mult = 1
+		if(get_dist(m,loc) > 0)
+			mult = multiplier_non_direct
+		m.adjustFireLoss(alt_explosion_damage_max*mult)
+	return 1
 
 /obj/item/weapon/grenade/attack_hand()
 	walk(src, null, null)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -12,6 +12,12 @@
 	var/active = 0
 	var/det_time = 50
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
+	var/can_adjust_timer = 1
+
+	var/alt_explosion_damage_max = 500 //The amount of armour + shield piercing damage done when grenade is stuck inside someone.
+	var/multiplier_non_direct = 0.5 //The multiplier to apply to the alt explosion max damage if the grenade is not directly on top of or inside someone.
+	var/alt_explosion_range = -1 //if set to -1, no armor bypass explosion
+	var/alt_explosion_type = BURN //Supports BRUTE or BURN
 
 /obj/item/weapon/grenade/proc/clown_check(var/mob/living/user)
 	if((CLUMSY in user.mutations) && prob(50))
@@ -90,7 +96,7 @@
 
 
 /obj/item/weapon/grenade/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(isscrewdriver(W))
+	if(isscrewdriver(W) && can_adjust_timer)
 		switch(det_time)
 			if (1)
 				det_time = 10
@@ -107,6 +113,18 @@
 		add_fingerprint(user)
 	..()
 	return
+
+/obj/item/weapon/grenade/proc/do_alt_explosion()
+	if(alt_explosion_range != -1)
+		for(var/mob/living/m in range(alt_explosion_range,loc))
+			var/mult = 1
+			if(get_dist(m,loc) > 0)
+				mult = multiplier_non_direct
+			switch(alt_explosion_type)
+				if(BRUTE)
+					m.adjustBruteLoss(alt_explosion_damage_max*mult)
+				if(BURN)
+					m.adjustFireLoss(alt_explosion_damage_max*mult)
 
 /obj/item/weapon/grenade/attack_hand()
 	walk(src, null, null)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -125,7 +125,6 @@
 	..()
 	hold.can_hold = list(
 		/obj/item/ammo_casing,
-		/obj/item/weapon/grenade,
 		/obj/item/weapon/material/hatchet/tacknife,
 		/obj/item/weapon/material/kitchen/utensil/knife,
 		/obj/item/weapon/material/knife,

--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -180,7 +180,7 @@
 	item_state = "UNSC Marine Ammo Belt"
 	storage_slots = 6
 
-	can_hold = list(/obj/item/ammo_magazine,/obj/item/ammo_box,/obj/item/weapon/grenade/frag/m9_hedp,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/chem_grenade/incendiary)
+	can_hold = list(/obj/item/ammo_magazine,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/weapon/storage/belt/marine_medic
 	name = "Medical Supplies Storage Belt"

--- a/code/modules/halo/species_items/grunt_outfits.dm
+++ b/code/modules/halo/species_items/grunt_outfits.dm
@@ -9,7 +9,6 @@
 	uniform = /obj/item/clothing/under/unggoy_internal
 	belt = /obj/item/weapon/gun/energy/plasmapistol
 	mask = /obj/item/clothing/mask/rebreather
-	l_pocket = /obj/item/weapon/grenade/plasma
 	r_pocket = /obj/item/weapon/grenade/plasma
 
 /decl/hierarchy/outfit/unggoy/post_equip(mob/living/carbon/human/H)
@@ -60,5 +59,4 @@
 
 	suit = /obj/item/clothing/suit/armor/special/unggoy_combat_harness/deacon
 	mask = /obj/item/clothing/mask/rebreather/unggoy_deacon
-	l_pocket = /obj/item/weapon/grenade/plasma/heavy_plasma
 	back = /obj/item/weapon/tank/methane/unggoy_internal/blue

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -10,7 +10,6 @@
 	arm_sound = 'code/modules/halo/sounds/Plasmanadethrow.ogg'
 	alt_explosion_range = 1
 	alt_explosion_damage_max = 300
-	alt_explosion_type = BURN
 
 /obj/item/weapon/grenade/plasma/activate(var/mob/living/carbon/human/h)
 	if(istype(h) && istype(h.species,/datum/species/unggoy) && prob(1))
@@ -43,5 +42,5 @@
 	do_alt_explosion()
 	if(istype(mob_containing))
 		mob_containing.contents -= src
-		loc = null
-		qdel(src)
+	loc = null
+	qdel(src)

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -5,10 +5,12 @@
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "plasmagrenade"
 	throw_speed = 0.2
-	throw_range = 7
-	var/alt_explosion_damage_max = 500 //The amount of damage done when grenade is stuck inside someone
-	var/alt_explosion_range = 1
+	det_time = 30
+	can_adjust_timer = 0
 	arm_sound = 'code/modules/halo/sounds/Plasmanadethrow.ogg'
+	alt_explosion_range = 1
+	alt_explosion_damage_max = 300
+	alt_explosion_type = BURN
 
 /obj/item/weapon/grenade/plasma/activate(var/mob/living/carbon/human/h)
 	if(istype(h) && istype(h.species,/datum/species/unggoy) && prob(1))
@@ -28,21 +30,6 @@
 		A.visible_message("<span class = 'danger'>[src.name] sticks to [L.name]!</span>")
 
 /obj/item/weapon/grenade/plasma/detonate()
-	var/mob/living/carbon/human/mob_containing = loc
-	if(istype(mob_containing))
-		mob_containing.adjustFireLoss(alt_explosion_damage_max)
-		to_chat(mob_containing,"<span class = 'danger'>[src] explodes! The immense heat burns through your flesh...</span>")
-
-		for(var/obj/item/organ/external/o in mob_containing.bad_external_organs)
-			for(var/datum/wound/w in o.wounds)
-				for(var/obj/embedded in w.embedded_objects)
-					if(embedded == src)
-						w.embedded_objects -= embedded //Removing the embedded item from the wound
-	else
-		for(var/mob/living/hit_mob in range(alt_explosion_range,src))
-			hit_mob.adjustFireLoss(alt_explosion_damage_max/2)
-			to_chat(hit_mob,"<span class = 'danger'>[src] explodes! Heat from the explosion washes over your body...</span>")
-
 	var/turf/epicenter = get_turf(src)
 	//the custom sfx itself
 	for(var/mob/M in GLOB.player_list)
@@ -52,17 +39,9 @@
 			// If inside the blast radius + world.view - 2
 			if(dist <= round(alt_explosion_range + world.view - 2, 1))
 				M.playsound_local(epicenter, 'code/modules/halo/sounds/Plasmanadedetonate.ogg', 100, 1)
-
-	mob_containing.contents -= src
-	loc = null
-	qdel(src)
-
-/obj/item/weapon/grenade/plasma/heavy_plasma
-	name = "Type-1 Antipersonnel Grenade - Modified"
-	desc = "When activated, the coating of this grenade becomes a powerful adhesive, sticking to anyone it is thrown at. \
-	It seems to be heavier than a normal Type-1, and you doubt you could throw it very far."
-
-	throw_range = 1
-
-	alt_explosion_damage_max = 150
-	alt_explosion_range = 1
+	var/mob/living/carbon/human/mob_containing = loc
+	do_alt_explosion()
+	if(istype(mob_containing))
+		mob_containing.contents -= src
+		loc = null
+		qdel(src)

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -9,7 +9,7 @@
 	can_adjust_timer = 0
 	arm_sound = 'code/modules/halo/sounds/Plasmanadethrow.ogg'
 	alt_explosion_range = 1
-	alt_explosion_damage_max = 300
+	alt_explosion_damage_max = 500
 
 /obj/item/weapon/grenade/plasma/activate(var/mob/living/carbon/human/h)
 	if(istype(h) && istype(h.species,/datum/species/unggoy) && prob(1))

--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -5,11 +5,16 @@
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	icon_state = "M9 HEDP"
 	num_fragments = 100
+	can_adjust_timer = 0
+	det_time = 30
+	alt_explosion_range = 2
+	alt_explosion_damage_max = 70
+	alt_explosion_type = BRUTE
 
 /obj/item/weapon/grenade/frag/m9_hedp/on_explosion(var/turf/O)
 	if(explosion_size)
-		explosion(O, -1, -1, explosion_size, round(explosion_size/2), 0, guaranteed_damage = 60, guaranteed_damage_range = 2)
-
+		explosion(O, -1, explosion_size, round(explosion_size/2))
+	do_alt_explosion()
 
 /obj/item/weapon/storage/box/m9_frag
 	name = "box of M9 frag grenades (WARNING)"

--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -9,7 +9,6 @@
 	det_time = 30
 	alt_explosion_range = 2
 	alt_explosion_damage_max = 70
-	alt_explosion_type = BRUTE
 
 /obj/item/weapon/grenade/frag/m9_hedp/on_explosion(var/turf/O)
 	if(explosion_size)


### PR DESCRIPTION
:cl: XO-11
tweak: Makes grenade explosions consistently ignore armor and shields.
tweak: Covenant and UNSC grenades apply this effect.
tweak: Being on-top of or having the grenade in your inventory increases the damage greatly.
tweak: Ammunition belts and bandoliers no longer accept grenades.
/:cl: