### PR TITLE
HEDP grenade explosion fix

### DIFF
--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -12,7 +12,7 @@
 
 /obj/item/weapon/grenade/frag/m9_hedp/on_explosion(var/turf/O)
 	if(explosion_size)
-		explosion(O, -1, explosion_size, round(explosion_size/2))
+		explosion(O, -1, -1,explosion_size, round(explosion_size*2))
 	do_alt_explosion()
 
 /obj/item/weapon/storage/box/m9_frag


### PR DESCRIPTION
:cl: XO-11
tweak: The HEDP grenade is no longer a tactical nuke.
/:cl: