### PR TITLE
drm overperformance + sniper nerfs

### DIFF
--- a/code/modules/halo/chemicals/medicine.dm
+++ b/code/modules/halo/chemicals/medicine.dm
@@ -96,7 +96,7 @@
 				w.embedded_objects -= embedded //Removing the embedded item from the wound
 				M.embedded -= embedded
 				M.pinned -= embedded
-				if(M.pinned.len() == 0)
+				if(M.pinned.len == 0)
 					M.anchored = 0
 				M.contents -= embedded
 				embedded.loc = M.loc //And placing it on the ground below

--- a/code/modules/halo/chemicals/medicine.dm
+++ b/code/modules/halo/chemicals/medicine.dm
@@ -94,6 +94,10 @@
 				if(!prob(BIOFOAM_PROB_REMOVE_EMBEDDED))
 					continue
 				w.embedded_objects -= embedded //Removing the embedded item from the wound
+				M.embedded -= embedded
+				M.pinned -= embedded
+				if(M.pinned.len() == 0)
+					M.anchored = 0
 				M.contents -= embedded
 				embedded.loc = M.loc //And placing it on the ground below
 				to_chat(M,"<span class = 'notice'>The [embedded.name] is pushed out of the [w.desc] in your [o.name].</span>")

--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -239,8 +239,9 @@
 	integrity_to_restore += integrity_restored_per_sheet
 
 /obj/item/vehicle_component/proc/repair_with_tool(var/obj/item/tool,var/mob/user)
-	if(tool.type in repair_tools_typepaths)
-		repair_tools_typepaths -= tool.type
+	for(var/tool_type in repair_tools_typepaths)
+		if(istype(tool,tool_type))
+			repair_tools_typepaths -= tool.type
 
 	if(repair_tools_typepaths.len == 0)
 		finalise_repair()

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -259,7 +259,7 @@
 	projectile_type = /obj/item/projectile/bullet/a145_ap/tracerless
 
 /obj/item/projectile/bullet/a145_ap
-	damage = 80
+	damage = 60
 	step_delay = 0.1
 	penetrating = 5
 	armor_penetration = 65
@@ -267,7 +267,7 @@
 	tracer_delay_time = 2 SECONDS
 
 /obj/item/projectile/bullet/a145_ap/tracerless //Modified slightly to provide a downside for using the innie-heavy-sniper-rounds over normal rounds.
-	damage = 75
+	damage = 55
 	armor_penetration = 70
 	tracer_type = null
 	tracer_delay_time = null

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -163,7 +163,7 @@
 	penetrating = 0
 
 /obj/item/projectile/bullet/a762_M392
-	damage = 40
+	damage = 30
 	armor_penetration = 45
 
 /obj/item/weapon/storage/box/m762_ap

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -271,7 +271,7 @@
 	armor_penetration = 70
 	tracer_type = null
 	tracer_delay_time = null
-	pin_range = 3
+	pin_range = 2
 	pin_chance = 70
 
 /obj/effect/projectile/srs99

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -271,7 +271,7 @@
 	armor_penetration = 70
 	tracer_type = null
 	tracer_delay_time = null
-	pin_range = 2
+	pin_range = 3
 	pin_chance = 70
 
 /obj/effect/projectile/srs99

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -267,10 +267,12 @@
 	tracer_delay_time = 2 SECONDS
 
 /obj/item/projectile/bullet/a145_ap/tracerless //Modified slightly to provide a downside for using the innie-heavy-sniper-rounds over normal rounds.
-	damage = 55
+	damage = 50
 	armor_penetration = 70
 	tracer_type = null
 	tracer_delay_time = null
+	pin_range = 3
+	pin_chance = 70
 
 /obj/effect/projectile/srs99
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -44,7 +44,7 @@
 /obj/item/projectile/covenant/beamrifle
 	name = "energy beam"
 	desc = ""
-	damage = 75
+	damage = 55
 	armor_penetration = 65
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "carbine_casing"
@@ -162,7 +162,7 @@
 /obj/item/projectile/bullet/covenant/type51carbine
 	name = "Glowing Projectile"
 	desc = "This projectile leaves a green trail in its wake."
-	damage = 45
+	damage = 40
 	icon = 'code/modules/halo/icons/Covenant_Projectiles.dmi'
 	icon_state = "carbine_casing"
 	check_armour = "energy"

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -61,7 +61,7 @@
 	one_hand_penalty = -1
 	irradiate_non_cov = 15
 	wielded_item_state = "beamrifle-wielded"
-	accuracy = -1
+	accuracy = -5
 	scoped_accuracy = 7
 	advanced_covenant = 1
 

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -61,6 +61,7 @@
 	one_hand_penalty = -1
 	irradiate_non_cov = 15
 	wielded_item_state = "beamrifle-wielded"
+	fire_delay = 10
 	accuracy = -5
 	scoped_accuracy = 7
 	advanced_covenant = 1

--- a/code/modules/halo/weapons/snipers.dm
+++ b/code/modules/halo/weapons/snipers.dm
@@ -17,8 +17,9 @@
 	reload_sound = 'code/modules/halo/sounds/Sniper_Reload_New.wav'
 	one_hand_penalty = -1
 	scoped_accuracy = 7
-	accuracy = -1
+	accuracy = -5
 	screen_shake = 0
+	fire_delay = 10
 	burst = 1
 	wielded_item_state = "SRS99-wielded"
 	w_class = ITEM_SIZE_HUGE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -149,6 +149,16 @@
 
 	return 1
 
+/mob/living/proc/pin_if_possible(var/obj/pinner,var/pin_range)
+	//Handles embedding for non-humans and simple_animals.
+	embed(pinner)
+	var/turf/T = near_wall(dir,pin_range)
+	if(T)
+		src.loc = T
+		visible_message("<span class='warning'>[src] is pinned to the wall by [pinner]!</span>","<span class='warning'>You are pinned to the wall by [pinner]!</span>")
+		src.anchored = 1
+		src.pinned += pinner
+
 //this proc handles being hit by a thrown atom
 /mob/living/hitby(atom/movable/AM as mob|obj,var/speed = THROWFORCE_SPEED_DIVISOR)//Standardization and logging -Sieve
 	if(istype(AM,/obj/))
@@ -197,16 +207,7 @@
 			if(!O || !src) return
 
 			if(O.sharp) //Projectile is suitable for pinning.
-				//Handles embedding for non-humans and simple_animals.
-				embed(O)
-
-				var/turf/T = near_wall(dir,2)
-
-				if(T)
-					src.loc = T
-					visible_message("<span class='warning'>[src] is pinned to the wall by [O]!</span>","<span class='warning'>You are pinned to the wall by [O]!</span>")
-					src.anchored = 1
-					src.pinned += O
+				pin_if_possible(O,1) //The relevant var is used for projectiles.
 
 /mob/living/proc/embed(var/obj/O, var/def_zone=null, var/datum/wound/supplied_wound)
 	O.loc = src

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -149,11 +149,10 @@
 
 	return 1
 
-/mob/living/proc/pin_if_possible(var/obj/pinner,var/pin_range)
+/mob/living/proc/pin_if_possible(var/obj/pinner,var/pin_range,var/pin_dir)
 	//Handles embedding for non-humans and simple_animals.
-	throw_at(get_edge_target_turf(src,dir),1,pin_range)
 	embed(pinner)
-	var/turf/T = near_wall(dir,2)
+	var/turf/T = near_wall(dir,pin_range)
 	if(T)
 		src.loc = T
 		visible_message("<span class='warning'>[src] is pinned to the wall by [pinner]!</span>","<span class='warning'>You are pinned to the wall by [pinner]!</span>")
@@ -200,15 +199,15 @@
 		var/momentum = speed*mass
 
 		if(O.throw_source && momentum >= THROWNOBJ_KNOCKBACK_SPEED)
-			var/dir = get_dir(O.throw_source, src)
+			var/throw_dir = get_dir(O.throw_source, src)
 
 			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
-			src.throw_at(get_edge_target_turf(src,dir),1,momentum)
+			src.throw_at(get_edge_target_turf(src,throw_dir),1,momentum)
 
 			if(!O || !src) return
 
 			if(O.sharp) //Projectile is suitable for pinning.
-				pin_if_possible(O,momentum) //The relevant var is used for projectiles.
+				pin_if_possible(O,2,throw_dir) //The relevant var is used for projectiles.
 
 /mob/living/proc/embed(var/obj/O, var/def_zone=null, var/datum/wound/supplied_wound)
 	O.loc = src

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,9 +151,9 @@
 
 /mob/living/proc/pin_if_possible(var/obj/pinner,var/pin_range,var/pin_dir)
 	//Handles embedding for non-humans and simple_animals.
-	embed(pinner)
 	var/turf/T = near_wall(dir,pin_range)
 	if(T)
+		embed(pinner)
 		src.loc = T
 		visible_message("<span class='warning'>[src] is pinned to the wall by [pinner]!</span>","<span class='warning'>You are pinned to the wall by [pinner]!</span>")
 		src.anchored = 1

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,8 +151,9 @@
 
 /mob/living/proc/pin_if_possible(var/obj/pinner,var/pin_range)
 	//Handles embedding for non-humans and simple_animals.
+	throw_at(get_edge_target_turf(src,dir),1,pin_range)
 	embed(pinner)
-	var/turf/T = near_wall(dir,pin_range)
+	var/turf/T = near_wall(dir,2)
 	if(T)
 		src.loc = T
 		visible_message("<span class='warning'>[src] is pinned to the wall by [pinner]!</span>","<span class='warning'>You are pinned to the wall by [pinner]!</span>")
@@ -207,7 +208,7 @@
 			if(!O || !src) return
 
 			if(O.sharp) //Projectile is suitable for pinning.
-				pin_if_possible(O,1) //The relevant var is used for projectiles.
+				pin_if_possible(O,momentum) //The relevant var is used for projectiles.
 
 /mob/living/proc/embed(var/obj/O, var/def_zone=null, var/datum/wound/supplied_wound)
 	O.loc = src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -194,6 +194,9 @@ var/list/ai_verbs_default = list(
 	if(!our_terminal)
 		to_chat(src,"<span class = 'notice'>No terminal to reset to.</span>")
 		return
+	if(carded)
+		to_chat(src,"<span class = 'notice'>You can't do that whilst carded!</span>")
+		return
 	destroy_eyeobj()
 	switch_to_net_by_name(our_terminal.inherent_network)
 	create_eyeobj(loc.loc)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -961,7 +961,7 @@ mob/proc/yank_out_object()
 	if(!(U.l_hand && U.r_hand))
 		U.put_in_hands(selection)
 
-	for(var/obj/item/weapon/O in pinned)
+	for(var/obj/O in pinned)
 		if(O == selection)
 			pinned -= O
 		if(!pinned.len)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -233,7 +233,7 @@
 			handle_click_empty(user)
 		return 0
 	var/mob/living/carbon/human/h = user
-	if(h.species.can_operate_advanced_covenant == 0 && advanced_covenant == 1)
+	if(istype(h) && h.species.can_operate_advanced_covenant == 0 && advanced_covenant == 1)
 		to_chat(h,"<span class= 'danger'>You don't know how to operate this weapon!</span>")
 		return 0
 	return 1

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -14,8 +14,8 @@
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/a145_ap/tracerless
 	one_hand_penalty = -1
-	accuracy = -2
-	scoped_accuracy = 5 //increased accuracy over the LWAP because only one shot
+	accuracy = -5
+	scoped_accuracy = 10 //increased accuracy over the LWAP because only one shot
 	var/bolt_open = 0
 	wielded_item_state = "heavysniper-wielded" //sort of placeholder
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -44,7 +44,7 @@
 	var/agony = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
 	var/pin_chance = 0
-	var/pin_range = 2
+	var/pin_range = 2 //this is essentially a knockback of
 
 	var/hitscan = 0		// whether the projectile should be hitscan
 	var/step_delay = 0.5	// the delay between iterations if not a hitscan projectile

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -201,10 +201,10 @@
 	else
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [mob_target_zone]!</span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
-	if(pin_chance > 0 && prob(pin_chance))
+	if(pin_chance > 0 && prob(pin_chance) && target_mob.pinned.len == 0)
 		var/obj/item/weapon/material/shard/shrapnel/S = new()
 		S.name = name
-		target_mob.pin_if_possible(S,pin_range)
+		target_mob.pin_if_possible(S,pin_range,get_dir(loc,target_mob))
 
 	//admin logs
 	if(!no_attack_log)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -43,6 +43,8 @@
 	var/drowsy = 0
 	var/agony = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
+	var/pin_chance = 0
+	var/pin_range = 2
 
 	var/hitscan = 0		// whether the projectile should be hitscan
 	var/step_delay = 0.5	// the delay between iterations if not a hitscan projectile
@@ -198,6 +200,11 @@
 		to_chat(target_mob, "<span class='danger'>You've been hit in the [mob_target_zone] by \the [src]!</span>")
 	else
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [mob_target_zone]!</span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+
+	if(pin_chance > 0 && prob(pin_chance))
+		var/obj/item/weapon/material/shard/shrapnel/S = new()
+		S.name = name
+		target_mob.pin_if_possible(S,pin_range)
 
 	//admin logs
 	if(!no_attack_log)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -201,10 +201,10 @@
 	else
 		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [mob_target_zone]!</span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
-	if(pin_chance > 0 && prob(pin_chance) && target_mob.pinned.len == 0)
+	if(pin_chance > 0 && prob(pin_chance) && target_mob.pinned.len == 0 && !isnull(starting))
 		var/obj/item/weapon/material/shard/shrapnel/S = new()
 		S.name = name
-		target_mob.pin_if_possible(S,pin_range,get_dir(loc,target_mob))
+		target_mob.pin_if_possible(S,pin_range,get_dir(starting,target_mob))
 
 	//admin logs
 	if(!no_attack_log)


### PR DESCRIPTION
:cl: XO-11
tweak: Lowers the DMR base damage to 30. The improved AP has already made the DMR a powerful weapon and as such it should not be provided with a higher damage
bugfix: vehicle repair fix
tweak: Sniper nerfs across the board for all factions
rscadd: Pinning chances added to certain weapons
/:cl: