### PR TITLE
Dodge Roll

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1695,6 +1695,7 @@
 #include "code\modules\halo\shuttles\dropship_overmap.dm"
 #include "code\modules\halo\species\ai-squads.dm"
 #include "code\modules\halo\species\brutes.dm"
+#include "code\modules\halo\species\dodge_roll.dm"
 #include "code\modules\halo\species\grunts.dm"
 #include "code\modules\halo\species\kig-yar.dm"
 #include "code\modules\halo\species\orion.dm"

--- a/code/modules/halo/species/brutes.dm
+++ b/code/modules/halo/species/brutes.dm
@@ -44,6 +44,8 @@
 	'code/modules/halo/sounds/species_pain_screams/brutescream7.ogg',
 	'code/modules/halo/sounds/species_pain_screams/brutescream8.ogg')
 
+	per_roll_delay = 3 //Slightly higher per roll delay than a human, because they're a bit bulkier
+
 /datum/species/brutes/equip_survival_gear(var/mob/living/carbon/human/H,var/extendedtank = 1)
 	return
 

--- a/code/modules/halo/species/dodge_roll.dm
+++ b/code/modules/halo/species/dodge_roll.dm
@@ -52,8 +52,6 @@ mob/living/proc/getPerRollDelay()
 	var/obj/vehicles/v = loc
 	if(istype(v))
 		v.exit_vehicle(src)
-	if(client)
-		client.move_delay = max(client.move_delay,world.time + (roll_delay * roll_dist))
 	next_roll_at = world.time + ((roll_delay * roll_dist) + DODGE_ROLL_BASE_COOLDOWN)
 	to_chat(src,"<span class = 'warning'>[name] performs a dodge roll!</span>")
 	for(var/i = 0,i < roll_dist,i++)
@@ -68,6 +66,8 @@ mob/living/proc/getPerRollDelay()
 			m = transform
 		animate(src,transform = turn(m,359/(roll_dist)),time = roll_delay) //We use 359 instead of 360 to ensure the flip-vertically animation doesn't happen
 		setClickCooldown(roll_delay)
+		if(client)
+			client.move_delay = max(client.move_delay,world.time + roll_delay)
 		sleep(roll_delay)
 	animate(src,transform = null,time = 1)
 	return 1

--- a/code/modules/halo/species/dodge_roll.dm
+++ b/code/modules/halo/species/dodge_roll.dm
@@ -46,26 +46,28 @@ mob/living/proc/getPerRollDelay()
 		return 0
 	var/roll_dist = getRollDist()
 	var/roll_delay = getPerRollDelay()
-	if(roll_dist <= 0)
-		to_chat(src,"<span class = 'notice'>You can't dodge roll.</span>")
+	if(roll_dist <= 0 || incapacitated())
+		to_chat(src,"<span class = 'notice'>You can't dodge roll in your current state.</span>")
 		return 0
+	var/obj/vehicles/v = loc
+	if(istype(v))
+		v.exit_vehicle(src)
 	if(client)
 		client.move_delay = max(client.move_delay,world.time + (roll_delay * roll_dist))
-	setClickCooldown(roll_delay * roll_dist)
 	next_roll_at = world.time + ((roll_delay * roll_dist) + DODGE_ROLL_BASE_COOLDOWN)
 	to_chat(src,"<span class = 'warning'>[name] performs a dodge roll!</span>")
 	for(var/i = 0,i < roll_dist,i++)
 		var/turf/step_to = get_step(loc,dir)
-		if(step_to.density == 1)
+		if(step_to.density == 1 || !step(src,dir))
 			visible_message("<span class = 'warning'>[name] rolls into [step_to].</span>")
 			break
-		step(src,dir)
 		var/matrix/m
 		if(isnull(transform))
 			m = matrix()
 		else
 			m = transform
 		animate(src,transform = turn(m,360/(roll_dist)),time = roll_delay)
+		setClickCooldown(roll_delay)
 		sleep(roll_delay)
 	animate(src,transform = null,time = 1)
 	return 1

--- a/code/modules/halo/species/dodge_roll.dm
+++ b/code/modules/halo/species/dodge_roll.dm
@@ -1,0 +1,66 @@
+
+#define DODGE_ROLL_BASE_COOLDOWN 2 SECONDS
+
+/mob/living/verb/rollN()
+	set name = "Roll North"
+	set category = "IC"
+
+	rollDir(1)
+
+/mob/living/verb/rollS()
+	set name = "Roll South"
+	set category = "IC"
+
+	rollDir(2)
+
+/mob/living/verb/rollE()
+	set name = "Roll East"
+	set category = "IC"
+
+	rollDir(4)
+
+/mob/living/verb/rollW()
+	set name = "Roll West"
+	set category = "IC"
+
+	rollDir(8)
+
+/mob/living/proc/getRollDist()
+	return 2
+
+mob/living/proc/getPerRollDelay()
+	return 2
+
+/mob/living/silicon/getRollDist()
+	return 0
+
+/mob/living/carbon/human/getRollDist()
+	return species.roll_distance
+
+/mob/living/carbon/human/getPerRollDelay()
+	return species.per_roll_delay
+
+/mob/living/proc/rollDir(var/dir)
+	if(world.time < next_roll_at)
+		to_chat(src,"<span class = 'notice'>You can't dodge roll again just yet!</span>")
+		return 0
+	var/roll_dist = getRollDist()
+	var/roll_delay = getPerRollDelay()
+	if(roll_dist <= 0)
+		to_chat(src,"<span class = 'notice'>You can't dodge roll.</span>")
+		return 0
+	if(client)
+		client.move_delay = max(client.move_delay,world.time + (roll_delay * roll_dist))
+	next_roll_at = world.time + ((roll_delay * roll_dist) + DODGE_ROLL_BASE_COOLDOWN)
+	animate(src,transform = turn(matrix(),180),time = roll_delay * roll_dist,loop = 2)
+	to_chat(src,"<span class = 'warning'>[name] performs a dodge roll!</span>")
+	for(var/i = 0,i < roll_dist,i++)
+		var/turf/step_to = get_step(loc,dir)
+		if(step_to.density == 1)
+			visible_message("<span class = 'warning'>[name] rolls into [step_to].</span>")
+			break
+		step(src,dir)
+		sleep(roll_delay)
+	return 1
+
+#undef DODGE_ROLL_BASE_COOLDOWN

--- a/code/modules/halo/species/dodge_roll.dm
+++ b/code/modules/halo/species/dodge_roll.dm
@@ -1,5 +1,5 @@
 
-#define DODGE_ROLL_BASE_COOLDOWN 2 SECONDS
+#define DODGE_ROLL_BASE_COOLDOWN 6 SECONDS
 
 /mob/living/verb/rollN()
 	set name = "Roll North"
@@ -51,8 +51,8 @@ mob/living/proc/getPerRollDelay()
 		return 0
 	if(client)
 		client.move_delay = max(client.move_delay,world.time + (roll_delay * roll_dist))
+	setClickCooldown(roll_delay * roll_dist)
 	next_roll_at = world.time + ((roll_delay * roll_dist) + DODGE_ROLL_BASE_COOLDOWN)
-	animate(src,transform = turn(matrix(),180),time = roll_delay * roll_dist,loop = 2)
 	to_chat(src,"<span class = 'warning'>[name] performs a dodge roll!</span>")
 	for(var/i = 0,i < roll_dist,i++)
 		var/turf/step_to = get_step(loc,dir)
@@ -60,7 +60,14 @@ mob/living/proc/getPerRollDelay()
 			visible_message("<span class = 'warning'>[name] rolls into [step_to].</span>")
 			break
 		step(src,dir)
+		var/matrix/m
+		if(isnull(transform))
+			m = matrix()
+		else
+			m = transform
+		animate(src,transform = turn(m,360/(roll_dist)),time = roll_delay)
 		sleep(roll_delay)
+	animate(src,transform = null,time = 1)
 	return 1
 
 #undef DODGE_ROLL_BASE_COOLDOWN

--- a/code/modules/halo/species/dodge_roll.dm
+++ b/code/modules/halo/species/dodge_roll.dm
@@ -66,7 +66,7 @@ mob/living/proc/getPerRollDelay()
 			m = matrix()
 		else
 			m = transform
-		animate(src,transform = turn(m,360/(roll_dist)),time = roll_delay)
+		animate(src,transform = turn(m,359/(roll_dist)),time = roll_delay) //We use 359 instead of 360 to ensure the flip-vertically animation doesn't happen
 		setClickCooldown(roll_delay)
 		sleep(roll_delay)
 	animate(src,transform = null,time = 1)

--- a/code/modules/halo/species/grunts.dm
+++ b/code/modules/halo/species/grunts.dm
@@ -39,6 +39,8 @@
 	'code/modules/halo/sounds/species_pain_screams/gruntscream_6.ogg',
 	'code/modules/halo/sounds/species_pain_screams/gruntscream_7.ogg')
 
+	roll_distance = 1 //Stubby legs mean no long roll
+
 /datum/species/unggoy/create_organs(var/mob/living/carbon/human/H)
 	. = ..()
 	//I guess their leg-boots are kinda organs.

--- a/code/modules/halo/species/kig-yar.dm
+++ b/code/modules/halo/species/kig-yar.dm
@@ -118,6 +118,9 @@
 	'code/modules/halo/sounds/species_pain_screams/kiggyscream_4.ogg',
 	'code/modules/halo/sounds/species_pain_screams/kiggyscream_5.ogg')
 
+	roll_distance = 4
+	per_roll_delay = 1.5 //Slightly faster than a human's dodge roll
+
 /datum/species/kig_yar_skirmisher/get_random_name(var/gender)
 	return pick(GLOB.first_names_kig_yar)
 

--- a/code/modules/halo/species/sangheili.dm
+++ b/code/modules/halo/species/sangheili.dm
@@ -55,6 +55,8 @@
 	'code/modules/halo/sounds/species_pain_screams/elitescream_10.ogg',
 	'code/modules/halo/sounds/species_pain_screams/elitescream_11.ogg')
 
+	roll_distance = 3 //One tile further than a human
+
 /datum/species/sangheili/equip_survival_gear(var/mob/living/carbon/human/H,var/extendedtank = 1)
 	return
 

--- a/code/modules/halo/species/spartan.dm
+++ b/code/modules/halo/species/spartan.dm
@@ -70,6 +70,9 @@
 	equipment_slowdown_multiplier = 0.5
 	ignore_equipment_threshold = 3
 
+	roll_distance = 3
+	per_roll_delay = 1.5 //Slightly faster than a human's dodge roll
+
 /datum/species/spartan/get_random_name(var/gender)
 	var/name = ""
 	if(gender == FEMALE)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -340,7 +340,7 @@
 		var/list/mobs = list()
 		for(var/mob/m in occupants)
 			mobs += m
-		if(!mobs)
+		if(mobs.len == 0)
 			return
 		mob_to_dam = pick(mobs)
 		if(!isnull(mob_to_dam))

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -199,6 +199,9 @@
 	var/list/pain_scream_sounds = list()
 	var/list/scream_sounds_female = list()
 
+	var/roll_distance = 2
+	var/per_roll_delay = 2
+
 	var/default_faction
 
 /datum/species/proc/get_eyes(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -53,3 +53,4 @@
 
 	var/obj/screen/cells = null
 	var/next_scream_at = 0 //For painscreams, used for both simplemobs and humanmobs
+	var/next_roll_at = 0


### PR DESCRIPTION
:cl: XO-11
rscadd: adds a dodge roll ability to all mobs, allowing them to quickly move in one direction. Has a 6 second cooldown. Verbs are in the IC tab, however, it is recommended to macro them to a key combo.
rscadd: normal humans have a 2 tile roll, unggoy have 1, spartans and elites have 3 tiles and skirmishers have 4
/:cl: