### PR TITLE
Add medicine for ear damage

### DIFF
--- a/code/modules/halo/medicine/combat.dm
+++ b/code/modules/halo/medicine/combat.dm
@@ -36,6 +36,16 @@
 
 	starts_with = list(/datum/reagent/oxycodone = 10)
 
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/otomax
+	name = "otomax autoinjector"
+	desc = "Contains chemicals that reduce ear damage"
+	band_color = COLOR_YELLOW
+
+	amount_per_transfer_from_this = 10
+	volume = 10
+
+	starts_with = list(/datum/reagent/otomax = 10)
+
 /obj/item/stack/medical/compression
 	name = "compression bandages"
 	singular_name = "compression bandage"

--- a/code/modules/halo/medicine/combat.dm
+++ b/code/modules/halo/medicine/combat.dm
@@ -49,7 +49,7 @@
 /obj/item/stack/medical/compression
 	name = "compression bandages"
 	singular_name = "compression bandage"
-	desc = "Special bandages designed reduce the severity of arterial bleeding"
+	desc = "Special bandages designed to reduce the severity of arterial bleeding"
 	amount = 8
 
 	icon_state = "brutepack" //todo: change this?

--- a/code/modules/halo/medicine/firstaid.dm
+++ b/code/modules/halo/medicine/firstaid.dm
@@ -49,6 +49,7 @@
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/painkiller = 3,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/antibiotic = 2,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/necrosis,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/otomax,
 		/obj/item/stack/medical/compression,
 		/obj/item/stack/medical/splint,
 		/obj/item/device/healthanalyzer

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -171,7 +171,7 @@
 	else if(ear_damage < 25)
 		adjustEarDamage(-0.05, -1)	// having ear damage impairs the recovery of ear_deaf
 	else if(ear_damage < 100)
-		adjustEarDamage(-0.05, 0)	// deafness recovers slowly over time, unless ear_damage is over 100. TODO meds that heal ear_damage
+		adjustEarDamage(-0.05, 0)	// deafness recovers slowly over time, unless ear_damage is over 100.
 
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -296,6 +296,27 @@
 			if(E.damage > 0)
 				E.damage = max(E.damage - 5 * removed, 0)
 
+/datum/reagent/otomax
+	name = "Otomax"
+	description = "Heals ear damage"
+	taste_description = "earwax"
+	reagent_state = LIQUID
+	color = "#EEDC82"
+	overdose = 15
+	scannable = 1
+	flags = IGNORE_MOB_SIZE
+
+/datum/reagent/otomax/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.adjustEarDamage(-1, -1)
+
+/datum/reagent/otomax/overdose(var/mob/living/carbon/M, var/alien)
+	..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
+		if(E && istype(E))
+			E.take_damage(5)
+
 /datum/reagent/peridaxon
 	name = "Peridaxon"
 	description = "Used to encourage recovery of internal organs and nervous systems. Medicate cautiously."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -350,6 +350,12 @@
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/hydrazine = 1, /datum/reagent/dylovene = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/otomax
+	name = "Otomax"
+	result = /datum/reagent/otomax
+	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/hydrazine = 1, /datum/reagent/potassium = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/ethylredoxrazine
 	name = "Ethylredoxrazine"
 	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/dylovene = 1, /datum/reagent/carbon = 1)


### PR DESCRIPTION
I thought we already had this as mentioned on #2069 but apparently not.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: bloxgate
rscadd: Ear damage medicine. Made from 1 part carbon, 1 part hydrazine, and 1 part potassium
rscadd: UNSC field medkits now have Otomax autoinjectors
spellcheck: Fixed a typo in compression bandage description
/:cl:
