### PR TITLE
Flagship Update Quickfixes and minor whitelist changes

### DIFF
--- a/code/modules/halo/factions/objectives/objectives_innie.dm
+++ b/code/modules/halo/factions/objectives/objectives_innie.dm
@@ -42,7 +42,7 @@
 	short_text = "Protect Flagship"
 	explanation_text = "Protect your flagship. From there you can launch the campaign to take over Geminus and beyond!"
 	target_faction_name = "Insurrection"
-	overmap_type = 0
+	overmap_type = 1
 	lose_points = 100
 
 /datum/objective/protect_colony/innie

--- a/maps/CRS_Unyielding_Transgression/jobs.dm
+++ b/maps/CRS_Unyielding_Transgression/jobs.dm
@@ -13,6 +13,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#800080"
+	faction_whitelist = "Covenant"
 	outfit_type = /decl/hierarchy/outfit/huragok_cov
 
 /datum/job/covenant/AI
@@ -226,6 +227,7 @@
 	selection_color = "#800080"
 	outfit_type = /decl/hierarchy/outfit/unggoy/ultra
 	access = list(230,250)
+	faction_whitelist = "Covenant"
 	whitelisted_species = list(/datum/species/unggoy)
 
 /datum/job/covenant/unggoy_deacon


### PR DESCRIPTION
:cl: XO-11
tweak: Unggoy Ultra is now whitelisted.
tweak: Huragok is now whitelisted.
tweak: The URF flagship *should* actually be picked up by the objectives system now.
/:cl: