### PR TITLE
Tweaks after packwar testing

### DIFF
--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -9,6 +9,8 @@
 	var/datum/lock/lock
 	var/initial_lock_value //for mapping purposes. Basically if this value is set, it sets the lock to this value.
 
+/obj/machinery/door/unpowered/simple/process()
+	return PROCESS_KILL
 
 /obj/machinery/door/unpowered/simple/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	TemperatureAct(exposed_temperature)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -12,6 +12,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	mouse_opacity = 0
 	unacidable = 1//So effect are not targeted by alien acid.
 	pass_flags = PASSTABLE | PASSGRILLE
+	dont_block_lighting = 0
 
 /datum/effect/effect/system
 	var/number = 3

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -94,8 +94,8 @@
 	icon_state = "Needler Shot"
 	embed = 1
 	sharp = 1
-	armor_penetration = 20
-	var/shards_to_explode = 6
+	armor_penetration = 0
+	var/shards_to_explode = 8
 	var/shard_name = "Needle shrapnel"
 	var/mob/locked_target
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -48,10 +48,11 @@
 		light.destroy()
 		light = null
 	return ..()
-	
+
+/atom/var/dont_block_lighting = 0
 /atom/set_opacity()
 	. = ..()
-	if(.)
+	if(. && !dont_block_lighting)
 		var/turf/T = loc
 		if(istype(T))
 			T.handle_opacity_change(src)


### PR DESCRIPTION
- Unpowered simple doors no longer process. The only change is that saloon doors won't auto close
- Effects won't trigger lighting updates. This shouldn't result in any weird behaviour and will probably mean they no longer block lighting eg via dense smoke
- Nerfs needlers to fix the Eluxor dual needler rush in Packwar

The lighting change is the big one. This seems to address most of the lag issues in Packwar

:cl: Cael_Aislinn
tweak: Nerfs needlers so they require 8 shards to supercombine and have no armour penetration down from 20
bugfix: Significantly optimises packwar by preventing geysers from triggering lighting updates. There might be some improvements to other gamemodes
/:cl: