### PR TITLE
Enable effects dont block lighting optimisation

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -12,7 +12,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	mouse_opacity = 0
 	unacidable = 1//So effect are not targeted by alien acid.
 	pass_flags = PASSTABLE | PASSGRILLE
-	dont_block_lighting = 0
+	dont_block_lighting = 1
 
 /datum/effect/effect/system
 	var/number = 3


### PR DESCRIPTION
Whoops

:cl: Cael_Aislinn
bugfix: Effects no longer trigger lighting updates to optimise lighting recalculations 
tweak: Nerfs needlers so they require 8 shards to supercombine and have no armour penetration down from 20
/:cl: