### PR TITLE
Revert "Revert "Gives Murmillo's common""

### DIFF
--- a/code/modules/halo/species_items/skirmisher_outfits.dm
+++ b/code/modules/halo/species_items/skirmisher_outfits.dm
@@ -30,7 +30,7 @@
 	suit = /obj/item/clothing/suit/armor/special/skirmisher/murmillo
 	belt = /obj/item/weapon/gun/energy/plasmapistol
 	l_hand = /obj/item/weapon/melee/blamite/dagger
-	l_pocket = /obj/item/weapon/melee/energy/elite_sword/dagger
+	l_pocket = /obj/item/language_learner/unggoy_to_common
 	head = /obj/item/clothing/head/helmet/kigyar/skirmisher/murmillo
 	gloves = /obj/item/clothing/gloves/skirmisher_shield_gauntlets
 	shoes = /obj/item/clothing/shoes/skirmisher/murmillo


### PR DESCRIPTION
:cl: CaelAislinn
maptweak: Various map fixes to Operation Red Flag including improved nav waypoints and an accessible bridge
bugfix: Ready up bug on Operation: Red Flag should be fixed
wip: Armour abilities are now separate installable devices
rscadd: As of October 2019 spaceships use a Newtonian flight model Apply thrust to move in a direction and alter your heading any time.
bugfix: The Covenant and UNSC can now load Forerunner artifacts onto their dropships machinery and structures can now be loaded as well eg weapon charging racks.
tweak: Vehicle code has been partially rewritten and cargo or vehicle loading will work slightly differently Report bugs on the github
bugfix: Significantly optimises packwar by preventing geysers from triggering lighting updates There might be some improvements to other gamemodes
experiment: End round movie titles no longer have randomised names
tweak: Murmillos have unlocked the secrets of the human language!
/:cl: