### PR TITLE
Adds Foot Coverage to Elites

### DIFF
--- a/code/modules/halo/species_items/sangheili.dm
+++ b/code/modules/halo/species_items/sangheili.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_INIT(last_names_sangheili, world.file2list('code/modules/halo/specie
 	sprite_sheets = list("Sangheili" = SANGHEILI_ARMOUR_ICON)
 	species_restricted = list("Sangheili")
 	item_flags = NOSLIP // Because marines get it.
-	body_parts_covered = LEGS
+	body_parts_covered = LEGS|FEET
 	armor = list(melee = 40, bullet = 60, laser = 5, energy = 5, bomb = 45, bio = 0, rad = 0)
 
 /obj/item/clothing/gloves/thick/sangheili


### PR DESCRIPTION
:cl: Real-MAGNUM
bugfix: Makes the leg armor for Sangheili cover the previously unarmored feet.
/:cl:

closes #2161 