### PR TITLE
Kig-Yar Armor Oversight/bug Fixes

### DIFF
--- a/code/modules/halo/clothing/kigyar_ranger.dm
+++ b/code/modules/halo/clothing/kigyar_ranger.dm
@@ -12,10 +12,10 @@
 		slot_r_hand_str = null,
 		)
 	item_flags = STOPPRESSUREDAMAGE
-	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	body_parts_covered = UPPER_TORSO | LOWER_TORSO | FEET | ARMS | HANDS
 	flags_inv = HIDETAIL
-	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+	cold_protection = UPPER_TORSO | LOWER_TORSO | FEET | ARMS | HANDS
+	heat_protection = UPPER_TORSO | LOWER_TORSO | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
@@ -28,12 +28,12 @@
 	item_state = "Ranger_armor"
 	sprite_sheets = list("Kig-Yar" = 'code/modules/halo/clothing/ranger_kigyar.dmi',"Tvaoan Kig-Yar" = 'code/modules/halo/clothing/ranger_kigyar.dmi')
 	blood_overlay_type = "armor"
-	armor = list(melee = 40, bullet = 45, laser = 65, energy = 55, bomb = 40, bio = 100, rad = 35)
+	armor = list(melee = 40, bullet = 35, laser = 35, energy = 35, bomb = 40, bio = 100, rad = 35)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS
 	flags_inv = HIDETAIL
-	cold_protection = UPPER_TORSO | LOWER_TORSO
-	heat_protection = UPPER_TORSO | LOWER_TORSO
+	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS
+	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	item_icons = list(
@@ -57,7 +57,7 @@
 	heat_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	armor = list(melee = 40, bullet = 45, laser = 45,energy = 45, bomb = 20, bio = 100, rad = 35)
+	armor = list(melee = 40, bullet = 35, laser = 35,energy = 35, bomb = 20, bio = 100, rad = 35)
 	item_icons = list(
 		slot_l_hand_str = null,
 		slot_r_hand_str = null,

--- a/code/modules/halo/species_items/kig-yar.dm
+++ b/code/modules/halo/species_items/kig-yar.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(first_names_kig_yar, world.file2list('code/modules/halo/species
 	icon = 'code/modules/halo/icons/species/jackalclothing.dmi'
 	icon_state = "scouthelm"
 	sprite_sheets = list("Kig-Yar" = 'code/modules/halo/icons/species/jackalclothing.dmi',"Tvaoan Kig-Yar" = 'code/modules/halo/icons/species/skirm_clothing.dmi')
-	armor = list(melee = 50, bullet = 15, laser = 50,energy = 10, bomb = 20, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 55, laser = 40,energy = 40, bomb = 20, bio = 0, rad = 0)
 	species_restricted = list("Kig-Yar")
 	action_button_name = "Toggle Night Vision"
 	flags_inv = null
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(first_names_kig_yar, world.file2list('code/modules/halo/species
 		"Kig-Yar" = 'code/modules/halo/icons/species/jackalclothing.dmi',\
 		"Tvaoan Kig-Yar" = 'code/modules/halo/icons/species/skirm_clothing.dmi')
 	species_restricted = list("Kig-Yar","Tvaoan Kig-Yar")
-	armor = list(melee = 75, bullet = 65, laser = 20, energy = 20, bomb = 45, bio = 25, rad = 20)
+	armor = list(melee = 75, bullet = 65, laser = 40, energy = 40, bomb = 45, bio = 25, rad = 20)
 	armor_thickness_modifiers = list()
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 


### PR DESCRIPTION
Resolves two oversight/bug reports on Kig-Yar armor.
#2145 
#1989 

:cl: RealMAGNUM
tweak: Scout suit and helmet armor has it's defense raised above Ranger  
tweak: Ranger armor is slightly nerfed.
tweak: Ranger armor now requires the full set to be EVA proof. This does not affect suit armor protection location.
/:cl:
