### PR TITLE
Migrate DB tables to UTF-8 for 513 support

### DIFF
--- a/sql/migrate/V005_Update_Charset.sql
+++ b/sql/migrate/V005_Update_Charset.sql
@@ -1,0 +1,34 @@
+--Halostation Table
+ALTER TABLE `death` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_admin` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_admin_log` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_ban` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_feedback` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_player` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_poll_option` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_poll_question` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_poll_textreply` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_poll_vote` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `erro_privacy` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `library` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `population` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `ranks` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `schema_version` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `whitelist` CONVERT TO CHARACTER SET utf8mb4;  
+
+ALTER TABLE `death` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_admin` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_admin_log` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_ban` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_feedback` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_player` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_poll_option` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_poll_question` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_poll_textreply` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_poll_vote` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `erro_privacy` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `library` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `population` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `ranks` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `schema_version` COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `whitelist` COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
Adds database migration file.

We'll need to run Flyway to apply the migrations once this code is in.

🆑 CaelAislinn
bugfix: Dropships should be able to load cargo and other vehicles again
/🆑
