### PR TITLE
ODST Air Tank Revert

### DIFF
--- a/code/modules/halo/clothing/odst.dm
+++ b/code/modules/halo/clothing/odst.dm
@@ -66,7 +66,6 @@
 	icon_override = ODST_OVERRIDE
 	blood_overlay_type = "armor"
 	armor = list(melee = 55, bullet = 50, laser = 55, energy = 45, bomb = 40, bio = 100, rad = 25)
-	allowed = list(/obj/item/weapon/tank)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO | ARMS | LEGS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL


### PR DESCRIPTION
Reverts a portion of #2188 that made it so ONLY the air tank could be worn on the suit slot.
