### PR TITLE
 More minor grunt QOL changes as outlined in balance request. 

### DIFF
--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -144,7 +144,6 @@
 	species_restricted = list("Unggoy")
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 5, bio = 0, rad = 0)
 	
-	body_parts_covered =
 
 /obj/item/clothing/under/unggoy_thrall
 	name = "Unggoy thrall robe"

--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -172,6 +172,8 @@
 	icon_override = GRUNT_GEAR_ICON
 	icon_state = "combatharness_major"
 	item_state = "combatharness_major"
+	
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 

--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -20,7 +20,7 @@
 	item_state_slots = list(slot_l_hand_str = "armor", slot_r_hand_str = "armor")
 	icon_state = "combatharness_minor"
 
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS //Essentially, the entire body besides the head
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS| //Essentially, the entire body besides the head
 
 	flags_inv = HIDESUITSTORAGE|HIDEBACK
 	armor = list(melee = 45, bullet = 40, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
@@ -173,8 +173,6 @@
 	icon_state = "combatharness_major"
 	item_state = "combatharness_major"
 	
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 
 
@@ -252,6 +250,10 @@
 	item_state = "blank"
 
 	canremove = 0
+	
+	armor = list(melee = 55 bullet = 45 laser = 15energy = 15 bomb = 45 bio = 0, rad = 0)
+	
+	body_parts_covered = FEET
 
 /obj/item/clothing/shoes/grunt_gloves
 	name = "Natural Armor"
@@ -261,6 +263,10 @@
 	item_state = "blank"
 
 	canremove = 0
+	
+	armor = list(melee = 55 bullet = 45 laser = 15 energy = 15 bomb = 45 bio = 0, rad = 0)
+	
+	body_parts_covered = HANDS
 
 
 #undef GRUNT_GEAR_ICON

--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -143,6 +143,8 @@
 	item_state_slots = list(slot_l_hand_str = "armor", slot_r_hand_str = "armor")
 	species_restricted = list("Unggoy")
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 5, bio = 0, rad = 0)
+	
+	body_parts_covered =
 
 /obj/item/clothing/under/unggoy_thrall
 	name = "Unggoy thrall robe"
@@ -185,9 +187,9 @@
 	item_state = "combatharness_ultra"
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
-
-	//totalshields = 100
-	//specials = list(/datum/armourspecials/shields/unggoy)
+	
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
+	
 
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/specops
 	name = "Unggoy Combat Harness (Spec-Ops)"
@@ -201,6 +203,8 @@
 	specials = list(/datum/armourspecials/cloaking)
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
+	
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
 
 
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/deacon
@@ -225,6 +229,8 @@
 	icon_state = "combatharness_honour"
 	item_state = "combatharness_honour"
 	totalshields = 100 //Pretty much just a distinguishing feature.
+	
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
 
 	specials = list(/datum/armourspecials/shields/unggoy)
 

--- a/code/modules/halo/species_items/grunt.dm
+++ b/code/modules/halo/species_items/grunt.dm
@@ -20,7 +20,7 @@
 	item_state_slots = list(slot_l_hand_str = "armor", slot_r_hand_str = "armor")
 	icon_state = "combatharness_minor"
 
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS| //Essentially, the entire body besides the head
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS| //Essentially, the entire body besides the head
 
 	flags_inv = HIDESUITSTORAGE|HIDEBACK
 	armor = list(melee = 45, bullet = 40, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
@@ -176,6 +176,8 @@
 	
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|
+
 
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/ultra
 	name = "Unggoy Combat Harness (Ultra)"
@@ -187,7 +189,7 @@
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 	
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|
 	
 
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/specops
@@ -203,7 +205,7 @@
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 	
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|
 
 
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/deacon
@@ -217,6 +219,8 @@
 
 	armor = list(melee = 45, bullet = 45, laser = 20, energy = 20, bomb = 60, bio = 0, rad = 0)
 
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|
+
 
 	specials = list(/datum/armourspecials/shields/unggoy)
 
@@ -229,7 +233,7 @@
 	item_state = "combatharness_honour"
 	totalshields = 100 //Pretty much just a distinguishing feature.
 	
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS||ARMS|
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|
 
 	specials = list(/datum/armourspecials/shields/unggoy)
 
@@ -256,7 +260,7 @@
 
 	canremove = 0
 	
-	armor = list(melee = 55 bullet = 45 laser = 15energy = 15 bomb = 45 bio = 0, rad = 0)
+	armor = list(melee = 55 bullet = 50 laser = 20 energy = 20 bomb = 60 bio = 0, rad = 0)
 	
 	body_parts_covered = FEET
 
@@ -269,7 +273,7 @@
 
 	canremove = 0
 	
-	armor = list(melee = 55 bullet = 45 laser = 15 energy = 15 bomb = 45 bio = 0, rad = 0)
+	armor = list(melee = 55 bullet = 50 laser = 20 energy = 20 bomb = 60 bio = 0, rad = 0)
 	
 	body_parts_covered = HANDS
 

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -83,7 +83,7 @@
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "Needler"
 	item_state = "needler"
-	slot_flags = SLOT_BELT||SLOT_HOLSTER
+	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
 	fire_sound = 'code/modules/halo/sounds/needlerfire.ogg'
 	magazine_type = /obj/item/ammo_magazine/needles
 	handle_casings = CLEAR_CASINGS

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -83,7 +83,7 @@
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "Needler"
 	item_state = "needler"
-	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
+
 	fire_sound = 'code/modules/halo/sounds/needlerfire.ogg'
 	magazine_type = /obj/item/ammo_magazine/needles
 	handle_casings = CLEAR_CASINGS

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -83,7 +83,7 @@
 	icon = 'code/modules/halo/icons/Covenant Weapons.dmi'
 	icon_state = "Needler"
 	item_state = "needler"
-
+	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
 	fire_sound = 'code/modules/halo/sounds/needlerfire.ogg'
 	magazine_type = /obj/item/ammo_magazine/needles
 	handle_casings = CLEAR_CASINGS


### PR DESCRIPTION
I removed all armor values for hands/feet the unggoy harness had, and added it to natural armor. This should give unggoy the incredibly small advantage of keeping their hand and foot armor even when their harness is damaged, as well as very slightly stronger armor in those areas overall. The justification is that trying to cut those areas in melee would be difficult, as it's covered by barbs and is extremely hard. 
The needler change is to make more kigyar/grunts take the weapon, as it's inability to fit on a back slot along with covenant's limited storage made it so you couldn't store it without giving up a belt, which is almost downright mandatory due to the lack of backpacks.  


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: EpicFatGamerNuts
tweak: moved armor values to natural armor from harness
tweak: slightly buffed said armor values
tweak: needler can fit on back 
/:cl:
