### PR TITLE
Boarding pod drop pod

### DIFF
--- a/code/controllers/voting/vote_types.dm
+++ b/code/controllers/voting/vote_types.dm
@@ -178,6 +178,7 @@
 	. = ..()
 
 	if(.[1] == "End Round Early")
+		ticker.mode.declare_completion()
 		evacuation_controller.finish_evacuation()
 
 

--- a/code/modules/halo/machinery/boarding_beacon_launcher.dm
+++ b/code/modules/halo/machinery/boarding_beacon_launcher.dm
@@ -30,7 +30,7 @@
 /obj/item/projectile/overmap/boarding_beacon/sector_hit_effects(var/z_level,var/obj/effect/overmap/hit,var/list/hit_bounds)
 	var/turf/beacon_on = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
 	var/obj/item/drop_pod_beacon/beacon = new /obj/item/drop_pod_beacon/invis (beacon_on)
-	beacon.faction_tag = drop_beacon_faction
+	beacon.faction_tag = console_fired_by:drop_beacon_faction
 	beacon.activate()
 
 /obj/item/projectile/boarding_beacon

--- a/code/modules/halo/machinery/boarding_beacon_launcher.dm
+++ b/code/modules/halo/machinery/boarding_beacon_launcher.dm
@@ -7,6 +7,7 @@
 	density = 1
 	fired_projectile = /obj/item/projectile/overmap/boarding_beacon
 	fire_sound = 'code/modules/halo/sounds/deck_gun_fire.ogg'
+	fire_delay = 1 SECOND
 	var/drop_beacon_faction = "UNSC" //The faction to assign to the drop pod beacon we create on hitting a planet.
 
 /obj/machinery/overmap_weapon_console/boarding_beacon_launcher/innie

--- a/code/modules/halo/machinery/boarding_beacon_launcher.dm
+++ b/code/modules/halo/machinery/boarding_beacon_launcher.dm
@@ -1,12 +1,21 @@
 /obj/machinery/overmap_weapon_console/boarding_beacon_launcher
 	name = "Boarding Beacon Launcher"
-	desc = "Launches disposable boarding-beacons at a selected target. Sensitive location data on each beacon requires that they self-destruct after 30 seconds."
+	desc = "Launches disposable boarding-beacons at a selected target. Firing at a planet will instead create drop-pod beacons. Sensitive location data on each beacon requires that they self-destruct after 30 seconds."
 	icon = 'code/modules/halo/machinery/boarding_beacon_console.dmi'
 	icon_state = "base"
 	anchored = 1
 	density = 1
 	fired_projectile = /obj/item/projectile/overmap/boarding_beacon
 	fire_sound = 'code/modules/halo/sounds/deck_gun_fire.ogg'
+	var/drop_beacon_faction = "UNSC" //The faction to assign to the drop pod beacon we create on hitting a planet.
+
+/obj/machinery/overmap_weapon_console/boarding_beacon_launcher/innie
+	drop_beacon_faction = "Insurrection"
+
+/obj/machinery/overmap_weapon_console/boarding_beacon_launcher/covenant
+	drop_beacon_faction = "Covenant"
+	icon = 'code/modules/halo/icons/machinery/covenant/consoles.dmi'
+	icon_state = "covie_console"
 
 /obj/item/projectile/overmap/boarding_beacon
 	icon = 'code/modules/halo/machinery/boarding_beacon_proj.dmi'
@@ -17,6 +26,12 @@
 	if(istype(ship) && !istype(ship,/obj/effect/overmap/ship/npc_ship/automated_defenses) && ship.unload_at == 0)
 		ship.load_mapfile()
 	. = ..()
+
+/obj/item/projectile/overmap/boarding_beacon/sector_hit_effects(var/z_level,var/obj/effect/overmap/hit,var/list/hit_bounds)
+	var/turf/beacon_on = locate(rand(hit_bounds[1],hit_bounds[3]),rand(hit_bounds[2],hit_bounds[4]),z_level)
+	var/obj/item/drop_pod_beacon/beacon = new /obj/item/drop_pod_beacon/invis (beacon_on)
+	beacon.faction_tag = drop_beacon_faction
+	beacon.activate()
 
 /obj/item/projectile/boarding_beacon
 	name = "boarding beacon"

--- a/code/modules/halo/overmap/weapons/overmap_weapon.dm
+++ b/code/modules/halo/overmap/weapons/overmap_weapon.dm
@@ -12,6 +12,8 @@
 	var/currently_tracked_proj = null
 	var/list/loaded_ammo = list()
 	var/list/linked_devices = list() //Handled on a weapon-by-weapon basis
+	var/fire_delay = 0 //This is used if anything else isn't handling this.
+	var/next_fire_at
 	ai_access_level = 4
 
 /obj/machinery/overmap_weapon_console/attack_ai(var/mob/living/silicon/ai/ai)
@@ -94,6 +96,7 @@
 	return 0
 
 /obj/machinery/overmap_weapon_console/proc/fire_projectile(var/atom/target,var/mob/user,var/directly_above = 0)
+	next_fire_at = world.time + fire_delay
 	var/obj/om_obj = map_sectors["[z]"]
 	var/obj/item/projectile/overmap/new_projectile = new fired_projectile (om_obj.loc,src)
 	new_projectile.damage += get_linked_device_damage_mod()
@@ -133,6 +136,9 @@
 		return 0
 	if(direction_locked && (get_dir(overmap_sector,target) != overmap_sector.dir)) //Direction lock check.
 		to_chat(user,"<span class = 'warning'>Weapon is locked to direction of ship. Realign ship to fire.</span>")
+		return 0
+	if(world.time < next_fire_at)
+		to_chat(user,"<span class = 'warning'>You can't fire this again yet.</span>")
 		return 0
 	if(!consume_loaded_ammo(user))
 		return 0

--- a/code/modules/halo/weapons/drop_pod_beacon.dm
+++ b/code/modules/halo/weapons/drop_pod_beacon.dm
@@ -24,14 +24,20 @@
 		return
 
 /obj/item/drop_pod_beacon/attack_self(var/mob/user)
+	activate(user)
+
+/obj/item/drop_pod_beacon/proc/activate(var/mob/user = null)
 	if(is_active == 1)
-		to_chat(user,"<span class = 'notice'>[name] is already active!</span>")
+		if(user)
+			to_chat(user,"<span class = 'notice'>[name] is already active!</span>")
 		return
 	if(is_active == -1)
-		to_chat(user,"<span class = 'notice'>[name] has ran out of charge!</span>")
+		if(user)
+			to_chat(user,"<span class = 'notice'>[name] has ran out of charge!</span>")
 		return
 
-	user.visible_message("<span class = 'notice'>[user] primes [src], activating the tracking module!</span>")
+	if(user)
+		user.visible_message("<span class = 'notice'>[user] primes [src], activating the tracking module!</span>")
 	GLOB.processing_objects += src
 	icon_state = "[initial(icon_state)]_on"
 	is_active = 1
@@ -45,3 +51,8 @@
 	if(is_active == -1)
 		message = "burnt out!"
 	to_chat(examiner,"It is [message]")
+
+/obj/item/drop_pod_beacon/invis
+	time_to_expire = 1 MINUTE
+	invisibility = 101
+	alpha = 0

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -6,6 +6,7 @@
 	extended_round_description = "In an outer colony on the edge of human space, an insurrection is brewing. Meanwhile an alien threat lurks in the void."
 	probability = 1
 	ship_lockdown_duration = 10 MINUTES
+	required_players = 6
 	var/safe_expire_warning = 0
 	var/list/factions = list(/datum/faction/unsc, /datum/faction/covenant, /datum/faction/insurrection,/datum/faction/human_civ)
 	var/list/overmap_hide = list()

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -164,6 +164,8 @@
 	return (round_end_reasons.len >= end_conditions_required)
 
 /datum/game_mode/outer_colonies/declare_completion()
+	if(round_end_reasons.len == 0)
+		round_end_reasons += "the round ended early"
 
 	var/announce_text = ""
 

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -4,7 +4,6 @@
 	config_tag = "outer_colonies"
 	round_description = "In an outer colony on the edge of human space, an insurrection is brewing. Meanwhile an alien threat lurks in the void."
 	extended_round_description = "In an outer colony on the edge of human space, an insurrection is brewing. Meanwhile an alien threat lurks in the void."
-	required_players = 15
 	probability = 1
 	ship_lockdown_duration = 10 MINUTES
 	var/safe_expire_warning = 0

--- a/maps/npc_ships/req_console_ships/cov_podcarrier.dmm
+++ b/maps/npc_ships/req_console_ships/cov_podcarrier.dmm
@@ -73,6 +73,7 @@
 "bD" = (/obj/structure/closet/secure_closet/freezer/fridge{icon = 'code/modules/halo/icons/storage/covenant/crate.dmi'; icon_broken = "Covie Crate Closed"; icon_closed = "Covie Crate Closed"; icon_locked = "Covie Crate Closed"; icon_off = "Covie Crate Closed"; icon_opened = "Covie Crate Open"; icon_state = "Covie Crate Closed"},/obj/structure/closet/walllocker/emerglocker/covvie/north,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "cO" = (/obj/machinery/vending/dinnerware{icon = 'code/modules/halo/icons/machinery/covenant/covendor.dmi'; icon_deny = "covendor-deny"; icon_vend = null},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "do" = (/obj/machinery/photocopier/faxmachine{department = "CRS Unyielding Transgression"; icon = 'code/modules/halo/icons/machinery/covenant/consoles.dmi'; icon_state = "covie_console"; name = "Superluminal Communications Array"; tag = "icon-covie_console"},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
+"ec" = (/obj/machinery/overmap_weapon_console/boarding_beacon_launcher/covenant,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "eO" = (/obj/structure/closet/secure_closet/freezer/meat{icon = 'code/modules/halo/icons/storage/covenant/crate.dmi'; icon_broken = "Covie Crate Closed"; icon_closed = "Covie Crate Closed"; icon_locked = "Covie Crate Closed"; icon_off = "Covie Crate Closed"; icon_opened = "Covie Crate Open"; icon_state = "Covie Crate Closed"},/obj/structure/sink/kitchen{pixel_y = 22},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "hI" = (/obj/machinery/light/covenant/north,/obj/machinery/telecomms/relay/long_range_emergency{icon = 'code/modules/halo/icons/machinery/covenant/consoles.dmi'; icon_state = "covie_console"},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "im" = (/obj/effect/hull_segment,/turf/simulated/wall/covenant/reinforced,/area/om_ships/req_console_ship)
@@ -80,7 +81,6 @@
 "pw" = (/obj/structure/closet/walllocker/emerglocker/covvie/south,/obj/machinery/door/airlock/covenant/cov_ship_preset,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "zw" = (/obj/vehicles/drop_pod/escape_pod/covenant/east,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "Ch" = (/obj/structure/table/marble,/obj/machinery/microwave{color = "#ff99ff"},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
-"CZ" = (/obj/machinery/overmap_weapon_console/boarding_beacon_launcher{icon = 'code/modules/halo/icons/machinery/covenant/consoles.dmi'; icon_state = "covie_console"},/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "Hz" = (/obj/machinery/vending/armory/covenant/kigyar/food,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "JX" = (/obj/structure/closet/walllocker/emerglocker/covvie/south,/obj/structure/closet/crate/covenant{name = "Supraluminal Communications Equipment"},/obj/item/weapon/pen,/obj/item/weapon/pen,/obj/item/weapon/card/id{desc = "Superluminal Communications Array Authentication Disk"; icon = 'code/modules/halo/covenant/Cards.dmi'; icon_state = "sangzealot_id"; name = "Superluminal Auth Disk."; tag = "icon-pinkGold"},/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/obj/item/weapon/paper,/turf/simulated/floor/covenant{tag = "icon-cov_floor"; icon_state = "cov_floor"},/area/om_ships/req_console_ship)
 "Lb" = (/obj/machinery/vending/armory/covenant/sangheili/food,/turf/simulated/floor/covenant{icon_state = "cov_floor"},/area/om_ships/req_console_ship)
@@ -107,7 +107,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaababababababadaeadababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaaaaaaaabafafafabCZadadadadabafafafababababaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaaaaaaaabafafafabecadadadadabafafafababababaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaababagafafabadadadadadabahafafababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaabababaaaaaaaaaaaaaaaaababababadadadaiadadadbhadaiadadadajadadababababababababadadadabababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababababakakoxakakadadadakakakakoxakakMyadajadababababababzwadadababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -121,7 +121,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaababababimababababababababakcOTVLbHzakakajakakbubvas
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababababakakoxakakadadadakakakakoxakakhIadajadababababababadadadababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaabababaaaaaaaaaaaaaaaaababababadadadbwadadadaGadbwadadadajadadababababababababzwadadabababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababaaaaaaaaaaaaaaababafafafabadadadadadabafafafababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaaaaaaaabagafafabCZadadadadabahafafababababaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaaaaaaaabagafafabecadadadadabahafafababababaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababababaaaaababababababadbxadababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabababaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
:cl: XO-11
tweak: boarding beacon launchers now create drop pod beacons that last for 1 minute when fired at a planet. Use this in conjunction with the scanning console to set a target area and perform risky depp strike drops against enemy forces.
/:cl: