### PR TITLE
various species speed changes

### DIFF
--- a/code/modules/halo/species/kig-yar.dm
+++ b/code/modules/halo/species/kig-yar.dm
@@ -90,9 +90,9 @@
 	unarmed_types = list(/datum/unarmed_attack/bird_punch)
 	appearance_flags = HAS_SKIN_TONE | HAS_HAIR_COLOR
 
-	pain_mod = 0.8
-	brute_mod = 1.2
-	slowdown = -1.5
+	pain_mod = 0.9
+	brute_mod = 1.1
+	slowdown = -1.0
 
 	total_health = 200
 	pixel_offset_x = -4

--- a/code/modules/halo/species/orion.dm
+++ b/code/modules/halo/species/orion.dm
@@ -6,7 +6,7 @@
 	total_health = 220 //Slightly more health then a normal human
 	metabolism_mod = 1.15 //Slightly faster metabolism
 	darksight = 3 //Slightly better night vision!
-	slowdown = -0.9 //Increased move speed
+	slowdown = -0.4 //Increased move speed, between elite and spartan
 	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)
 	unarmed_types = list(/datum/unarmed_attack/spartan_punch)
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_EYE_COLOR

--- a/code/modules/halo/species/sangheili.dm
+++ b/code/modules/halo/species/sangheili.dm
@@ -20,7 +20,7 @@
 	appearance_flags = HAS_SKIN_TONE
 	brute_mod = 0.9
 	pain_mod = 0.75 //Pain has quarter an effect on them
-	slowdown = -0.5
+	slowdown = -0.3
 	explosion_effect_mod = 0.5
 	can_force_door = 1
 	pixel_offset_x = -8

--- a/code/modules/halo/species/sanshyuum.dm
+++ b/code/modules/halo/species/sanshyuum.dm
@@ -20,8 +20,9 @@ GLOBAL_LIST_INIT(sanshyuum_titles, world.file2list('code/modules/halo/species_it
 	additional_langs = list("Janjur Qomi","Galactic Common")
 	spawn_flags = SPECIES_CAN_JOIN
 	item_icon_offsets = list(list(0,2),list(0,2),null,list(0,2),null,null,null,list(0,2),null)
-	total_health = 150		//weaker than a human
-	slowdown = 2			//slight slowdown
+	total_health = 200		//weaker than a human
+	brute_mod = 1.2
+	slowdown = 0.5			//slight slowdown
 	equipment_slowdown_multiplier = 2
 	default_faction = "Covenant"
 

--- a/code/modules/halo/species/spartan.dm
+++ b/code/modules/halo/species/spartan.dm
@@ -17,7 +17,7 @@
 	brute_mod = 0.8 //Lower amount of brute damage taken than sangheili
 	pain_mod = 0.6 //Lower pain damage taken than sangheili
 	item_icon_offsets = list(list(1,0),list(1,0),null,list(1,0),null,null,null,list(1,0),null)
-	slowdown = -0.75
+	slowdown = -0.5
 	can_force_door = 1
 	additional_langs = list("Sign Language")
 	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)

--- a/code/modules/halo/species/yanmee.dm
+++ b/code/modules/halo/species/yanmee.dm
@@ -25,7 +25,7 @@ Huragok Engineers. Their flight makes them hard to hit during combat and their n
 	flags = NO_MINOR_CUT
 	darksight = 4
 	brute_mod = 1.2
-	slowdown = -0.7
+	slowdown = -0.5
 	gluttonous = GLUT_ANYTHING
 	pixel_offset_x = -1
 	default_faction = "Covenant"


### PR DESCRIPTION
:cl: XO-11
tweak: Any species with a speed buff will find they have become less speedy. This is to allow normal roles to compete with power roles.
tweak: Kig-Yar tvoans have been hit hard by this speed debuff, bringing them down by 0.5 instead of the normal 0.2 reduction. Tvoans have been provided with lower brute modifiers to compensate, however, the pain modifier has also changed.
/:cl: