### PR TITLE
Added different spawn() delay code for grenade primers. (PR Ver.2 Elec. Boogalo)

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -82,7 +82,9 @@
 	active = 1
 	playsound(loc, arm_sound, 75, 0, -3)
 
-	spawn(det_time)
+	spawn()
+		for(var/i=0, i<det_time, i++)
+			sleep(1-clamp(max(0,world.tick_usage-100)*0.01,0,0.5))
 		detonate()
 		return
 

--- a/html/changelogs/GameMaster85-PR.yml
+++ b/html/changelogs/GameMaster85-PR.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/GameMaster85-PR.yml
+++ b/html/changelogs/GameMaster85-PR.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: Unknown
+author: GameMaster85
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -33,5 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - rscadd: "Made grenade timers follow realtime more closely instead of server time. Hands will roll."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Fixes #2351 and potentially fixes #1437

Added the delay for closer real-time emulation on grenade primers. This will cause more hands to roll if cooked compared to before, but the primers will lag with the server if each tick is experiencing 150% use or more, to prevent hands from rolling too hard.

**Note that this PR isn't heavily tested and needs to be done in the situation that warrants it. I'll do my best to test it locally and comment further on it. I suggest not accepting the PR yet until it's confirmed tested properly by either me or someone else.**

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: GameMaster85
rscadd: Made grenade timers follow realtime more closely instead of server time. Hands will roll.
/:cl:
