### PR TITLE
ship spawn console poplocking

### DIFF
--- a/code/modules/halo/factions/_faction.dm
+++ b/code/modules/halo/factions/_faction.dm
@@ -31,6 +31,7 @@
 	var/destroyed_reason = null
 	var/list/ship_types = list()
 	var/list/npc_ships = list()
+	var/list/player_ships = list()
 	var/list/faction_reputation = list()
 	var/leader_name
 	var/datum/computer_file/data/com/faction_contact_data

--- a/code/modules/halo/overmap/npc_ship_playercontrol.dm
+++ b/code/modules/halo/overmap/npc_ship_playercontrol.dm
@@ -5,3 +5,6 @@
 	available_ship_requests.Cut()
 	available_ship_requests = list(new /datum/npc_ship_request/player_controlled)
 	load_mapfile()
+	if(my_faction)
+		my_faction.player_ships += src
+		my_faction.npc_ships -= src

--- a/maps/npc_ships/req_console_ships/unsc_trooptransport.dmm
+++ b/maps/npc_ships/req_console_ships/unsc_trooptransport.dmm
@@ -1,7 +1,6 @@
 "aa" = (/turf/space,/area/space)
 "ab" = (/obj/structure/rearm_repair_station/human,/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
 "aN" = (/obj/effect/floor_decal/industrial/warning/dust{tag = "icon-warning_dust (EAST)"; icon_state = "warning_dust"; dir = 4},/turf/simulated/wall/r_wall,/area/om_ships/req_console_ship)
-"bh" = (/obj/structure/lattice,/obj/structure/lattice,/turf/space,/area/space)
 "ce" = (/obj/machinery/vending/dinnerware,/turf/simulated/floor/tiled,/area/om_ships/req_console_ship)
 "cy" = (/obj/machinery/vending/coffee,/turf/simulated/floor/tiled,/area/om_ships/req_console_ship)
 "cJ" = (/obj/effect/floor_decal/industrial/warning/dust/corner,/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
@@ -136,7 +135,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaagEzZEdEdqXqXgJqXCNEdEdgJqXqXFcFcFcvdFcFcFcqXhdHzHz
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDivoEdEdtDqXEdEdEdEdEdEdqXFcFccJojojojojTYWthdhdhdhdhdhdhdhdtshdhdhdqXhdVwhdqXqXMTqXZaolFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaGuEdIXEdWVEdEdEdEdEdEdWVFcFcAEFcFcFcFcIDlsViUxlHkzRycysrceqXhdlbhdqXXihdhdhdhdhdhdMTFcFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslsqXqXqXqXZaqXqXqXqXFcFcAEFcFcFcFcIDlsqXqXqXlslslslslsqXZaqXqXqXWFMIZFKGhdhdhdqXFcFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsabFcAEFcXfFcFcIDlsrubhaaaaaaaaaaaaruruqXqXqXqXqXqXqXqXqXMTqXqXqXqXaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsabFcAEFcXfFcFcIDlsruruaaaaaaaaaaaaruruqXqXqXqXqXqXqXqXqXMTqXqXqXqXaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsFcAEFcFcFcFcIDlsruaaaaaaaaaaaaaaaaruruaaaaaaaaqXFcFclqFcqXaaruaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaMolslslslsaNFcFcFcFcIDlslslslslslsrulslslslslslslslslsqXFcFcFcFcqXqXlslsaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaMolslstlMyMyMyAWuPlslslslsaaaaaaaaaalslslslslslslslsnyFcFcFclslslslsaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/maps/npc_ships/req_console_ships/urf_trooptransport.dmm
+++ b/maps/npc_ships/req_console_ships/urf_trooptransport.dmm
@@ -6,7 +6,6 @@
 "ah" = (/obj/machinery/door/airlock/halo/innie_ship_preset,/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
 "ai" = (/obj/effect/landmark/dropship_land_point/innie{name = "Transport Shuttle Port Hangar"},/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
 "aN" = (/obj/effect/floor_decal/industrial/warning/dust{tag = "icon-warning_dust (EAST)"; icon_state = "warning_dust"; dir = 4},/turf/simulated/wall/r_wall,/area/om_ships/req_console_ship)
-"bh" = (/obj/structure/lattice,/obj/structure/lattice,/turf/space,/area/space)
 "cJ" = (/obj/effect/floor_decal/industrial/warning/dust/corner,/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
 "cN" = (/obj/effect/floor_decal/industrial/warning/dust{tag = "icon-warning_dust (NORTH)"; icon_state = "warning_dust"; dir = 1},/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
 "dr" = (/obj/machinery/light/spot{dir = 2},/turf/simulated/floor/plating,/area/om_ships/req_console_ship)
@@ -136,7 +135,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaagEPkSISIqXqXTlqXChSISITlqXqXFcFcFcvdFcFcFcqXSIZgZg
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDivoSISICkqXSISISISISISIqXFcFccJojojojojTYaeSISISISISISISISIypqkqkqkqXSIZXSIqXqXEvqXZaAwFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaGuSIIPSIUzSISISISISISIUzFcFcAEFcFcFcFcIDlsOLLjhcWdeKHEFZEVqXqXLcqXqXChSISISISISISIEvFcFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslsqXqXqXqXZaqXqXqXqXFcFcAEFcFcFcFcIDlsqXqXqXlslslslslsqXZaqXqXqXoaicLfCkSISISIqXFcFcshaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsadFcAEFcaiFcFcIDlsrubhaaaaaaaaaaaaruruqXqXqXqXqXqXqXqXqXacqXqXqXqXaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsadFcAEFcaiFcFcIDlsruruaaaaaaaaaaaaruruqXqXqXqXqXqXqXqXqXacqXqXqXqXaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalslslslslslslslslslslsFcAEFcFcFcFcIDlsruaaaaaaaaaaaaaaaaruruaaaaaaaaqXFcFclqFcqXaaruaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaMolslslslsaNFcFcFcFcIDlslslslslslsrulslslslslslslslslsqXFcFcFcFcqXqXlslsaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaMolslstlMyMyMyAWuPlslslslsaaaaaaaaaalslslslslslslslsnyFcFcFclslslslsaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Pop-Locks ship spawning, with a new ship becoming available when the previous one dies or overall population increases by another 3.
:cl: XO-11
tweak: Ship requisition consoles no longer have infinite ships to spawn, instead it is limited by current server population. Minimum 1 ship.
/:cl: