### PR TITLE
overmap events and lingering ship effects

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1772,6 +1772,7 @@
 #include "code\modules\halo\overmap\npc_ship_playercontrol.dm"
 #include "code\modules\halo\overmap\npc_ship_requests.dm"
 #include "code\modules\halo\overmap\npc_shipmap_handler.dm"
+#include "code\modules\halo\overmap\overmap_effects.dm"
 #include "code\modules\halo\overmap\player_shuttles.dm"
 #include "code\modules\halo\overmap\req_console_ships.dm"
 #include "code\modules\halo\overmap\shipyards.dm"

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -258,7 +258,7 @@
 /obj/effect/meteor/big
 	name = "large meteor"
 	icon_state = "large"
-	hits = 6
+	hits = 3
 	heavy = 1
 	dropamt = 3
 
@@ -270,7 +270,7 @@
 /obj/effect/meteor/flaming
 	name = "flaming meteor"
 	icon_state = "flaming"
-	hits = 5
+	hits = 2
 	heavy = 1
 	meteordrop = /obj/item/weapon/ore/phoron
 
@@ -324,7 +324,7 @@
 	name = "tunguska meteor"
 	icon_state = "flaming"
 	desc = "Your life briefly passes before your eyes the moment you lay them on this monstrosity."
-	hits = 10
+	hits = 5
 	hitpwr = 1
 	heavy = 1
 	meteordrop = /obj/item/weapon/ore/diamond	// Probably means why it penetrates the hull so easily before exploding.

--- a/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
+++ b/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(first_names_jiralhanae, world.file2list('code/modules/halo/cove
 	pixel_offset_x = -12
 	item_icon_offsets = list(list(10,4),list(10,4),null,list(6,2),null,null,null,list(6,2),null)
 	unarmed_types = list(/datum/unarmed_attack/brute_punch)
-	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)
+	inherent_verbs = list()
 
 	equipment_slowdown_multiplier = 0.3
 

--- a/code/modules/halo/covenant/species/sangheili/sangheili.dm
+++ b/code/modules/halo/covenant/species/sangheili/sangheili.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(last_names_sangheili, world.file2list('code/modules/halo/covena
 	can_force_door = 1
 	pixel_offset_x = -8
 	item_icon_offsets = list(list(9,1),list(9,1),null,list(6,1),null,null,null,list(6,1),null)
-	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)
+	inherent_verbs = list()
 	default_faction = "Covenant"
 	unarmed_types = list(/datum/unarmed_attack/elite_punch)
 

--- a/code/modules/halo/overmap/automated_defense.dm
+++ b/code/modules/halo/overmap/automated_defense.dm
@@ -18,10 +18,10 @@
 	anchored = 1
 
 /obj/effect/overmap/ship/npc_ship/automated_defenses/Initialize()
+	occupy_range = defense_range * 2
 	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(defense_range*2,src)
 
-/obj/effect/overmap/ship/npc_ship/automated_defenses/can_board() //Now you can board them, any time you want!
+/obj/effect/overmap/ship/npc_ship/automated_defenses/can_board()
 	return 0
 
 /obj/effect/overmap/ship/npc_ship/automated_defenses/take_projectiles(var/obj/item/projectile/overmap/proj,var/add_proj = 1)

--- a/code/modules/halo/overmap/overmap_effects.dm
+++ b/code/modules/halo/overmap/overmap_effects.dm
@@ -1,0 +1,142 @@
+
+#define GAS_CLOUD_EMP_CHANCE 30
+#define OVERCHARGE_EXPLOSION_CHANCE 20
+
+/obj/effect/overmap/hazard
+	var/list/hazard_datums = list()
+	occupy_range = 1
+
+/obj/effect/overmap/hazard/Crossed(var/obj/effect/overmap/ship/crosser)
+	if(!istype(crosser))
+		return
+	for(var/datum in hazard_datums)
+		var/datum/overmap_effect/curr = locate(datum) in crosser.active_effects
+		if(curr)
+			curr.calc_lifetime()
+		else
+			curr = new datum (crosser)
+
+/obj/effect/overmap/hazard/random
+	name = "Unknown Hazard"
+	icon_state = "event"
+
+/obj/effect/overmap/hazard/random/Initialize()
+	. = ..()
+	hazard_datums += pick(typesof(/datum/overmap_effect) -  /datum/overmap_effect)
+
+/datum/overmap_effect
+	var/effect_name = "Effect"
+	var/announcement_text = null //Should the ship / sector alert the occupants to this taking place and what message should we display.
+	var/obj/effect/overmap/target
+	var/lifetime = 5 MINUTES
+	var/live_until = 0
+
+/datum/overmap_effect/New(var/effect_targ)
+	. = ..()
+	if(!effect_targ)
+		return INITIALIZE_HINT_QDEL
+	target = effect_targ
+	calc_lifetime()
+	if(announcement_text)
+		do_announcement()
+	if(!effect_created())
+		return INITIALIZE_HINT_QDEL
+	target.active_effects += src
+
+/datum/overmap_effect/proc/calc_lifetime()
+	live_until = world.time + lifetime
+
+/datum/overmap_effect/proc/do_announcement(var/text_display = announcement_text)
+	for(var/z_level in target.map_z)
+		for(var/mob/player in GLOB.mobs_in_sectors[map_sectors["[z_level]"]])
+			to_chat(player,"<span class = 'danger'>[text_display]</span>")
+
+/datum/overmap_effect/proc/effect_created()
+
+/datum/overmap_effect/proc/process_effect()
+	if(world.time >= live_until)
+		return 0
+	return 1
+
+/obj/item/projectile/overmap/meteor
+	name = "you shouldn't see this"
+	damage = 250
+	var/obj/asteroid_spawn = null
+
+/obj/item/projectile/overmap/meteor/New(var/loc,var/ast_type)
+	. = ..()
+	asteroid_spawn = ast_type
+
+/obj/item/projectile/overmap/meteor/do_z_level_proj_spawn(var/z_level,var/obj/effect/overmap/ship/overmap_object_hit)
+	var/list/start_co_ords
+	var/list/end_co_ords
+	if(overmap_object_hit.fore_dir == EAST || WEST)
+		start_co_ords = generate_co_ords_x_start(overmap_object_hit.map_bounds)
+		end_co_ords = generate_co_ords_x_end(start_co_ords,overmap_object_hit.map_bounds)
+	else if(overmap_object_hit.fore_dir == NORTH || SOUTH)
+		start_co_ords = generate_co_ords_y_start(overmap_object_hit.map_bounds)
+		end_co_ords = generate_co_ords_y_end(start_co_ords,overmap_object_hit.map_bounds)
+	var/turf/proj_spawn_loc = locate(start_co_ords[1],start_co_ords[2],z_level)
+	var/turf/proj_end_loc = locate(end_co_ords[1],end_co_ords[2],z_level)
+
+	var/obj/roid = new asteroid_spawn (proj_spawn_loc)
+	walk_towards(roid,proj_end_loc,1)
+	return 1
+
+/datum/overmap_effect/asteroids
+	effect_name = "Asteroid Field"
+	announcement_text = "We have entered an asteroid field. Brace for meteorite impact."
+	lifetime = 2 MINUTES
+
+/datum/overmap_effect/asteroids/process_effect()
+	. = ..()
+	if(!.)
+		return
+	var/obj/asteroid = pick(typesof(/obj/effect/meteor) - /obj/effect/meteor/tunguska)
+	var/obj/item/projectile/overmap/om_proj = new /obj/item/projectile/overmap/meteor (target.loc,asteroid)
+	om_proj.starting = target.loc
+	om_proj.on_impact(target)
+	return 1
+
+/datum/overmap_effect/gas_cloud
+	effect_name = "Gas Cloud"
+	announcement_text = "We have entered a vision-obscuring gas cloud. Hostiles will have a harder time hitting us. Brace for periodic EMP effects."
+	lifetime = 2 MINUTES
+
+/datum/overmap_effect/gas_cloud/process_effect()
+	. = ..()
+	if(!.)
+		return
+	if(prob(GAS_CLOUD_EMP_CHANCE))
+		var/turf/emp_center = locate(rand(target.map_bounds[1],target.map_bounds[3]),rand(target.map_bounds[2],target.map_bounds[4]),pick(target.map_z))
+		empulse(emp_center, rand(2, 7), rand(7, 14))
+	return 1
+
+/datum/overmap_effect/engine_overcharge
+	effect_name = "engine overcharge"
+	announcement_text = "Engine power output spiking. Speed safeties overridden, acceleration potential increased beyond safe measures. Brace for ship-wide damage."
+	lifetime = 2 MINUTES
+	var/oldmax = 0
+
+/datum/overmap_effect/engine_overcharge/effect_created()
+	var/obj/effect/overmap/ship/targ_ship = target
+	if(!istype(targ_ship))
+		return 0
+	oldmax = targ_ship.ship_max_speed
+	targ_ship.ship_max_speed *= 1.5
+	targ_ship.my_pixel_transform.set_new_maxspeed(targ_ship.ship_max_speed)
+	return 1
+
+/datum/overmap_effect/engine_overcharge/process_effect()
+	. = ..()
+	if(!.)
+		var/obj/effect/overmap/ship/targ_ship = target
+		targ_ship.ship_max_speed = oldmax
+		targ_ship.my_pixel_transform.set_new_maxspeed(targ_ship.ship_max_speed)
+		return
+	if(prob(OVERCHARGE_EXPLOSION_CHANCE))
+		var/turf/explode_center = locate(rand(target.map_bounds[1],target.map_bounds[3]),rand(target.map_bounds[2],target.map_bounds[4]),pick(target.map_z))
+		explosion(explode_center,-1,1,5,10)
+
+#undef GAS_CLOUD_EMP_CHANCE
+#undef OVERCHARGE_EXPLOSION_CHANCE

--- a/code/modules/halo/overmap/overmap_effects.dm
+++ b/code/modules/halo/overmap/overmap_effects.dm
@@ -102,10 +102,17 @@
 	effect_name = "Gas Cloud"
 	announcement_text = "We have entered a vision-obscuring gas cloud. Hostiles will have a harder time hitting us. Brace for periodic EMP effects."
 	lifetime = 2 MINUTES
+	var/olddodge = 0
+
+/datum/overmap_effect/gas_cloud/effect_created()
+	olddodge = target.weapon_miss_chance
+	target.weapon_miss_chance = max(25,target.weapon_miss_chance * 1.5)
+	return 1
 
 /datum/overmap_effect/gas_cloud/process_effect()
 	. = ..()
 	if(!.)
+		target.weapon_miss_chance = olddodge
 		return
 	if(prob(GAS_CLOUD_EMP_CHANCE))
 		var/turf/emp_center = locate(rand(target.map_bounds[1],target.map_bounds[3]),rand(target.map_bounds[2],target.map_bounds[4]),pick(target.map_z))

--- a/code/modules/halo/overmap/weapons/overmap_projectile.dm
+++ b/code/modules/halo/overmap/weapons/overmap_projectile.dm
@@ -116,7 +116,7 @@
 
 	if(!istype(overmap_object))
 		return 0
-	if(!(starting in range(1,impacted)) && prob(overmap_object.weapon_miss_chance * (1- accuracy/100))) //accuracy = 1 means miss chance is multiplied by 0.99
+	if(!(starting in trange(1,impacted)) && prob(overmap_object.weapon_miss_chance * (1- accuracy/100))) //accuracy = 1 means miss chance is multiplied by 0.99
 		visible_message("<span class = 'warning'>[src] flies past [impacted].</span>")
 		return 0
 	if(istype(impacted,/obj/effect/overmap/ship/npc_ship))

--- a/code/modules/halo/unsc/spartan.dm
+++ b/code/modules/halo/unsc/spartan.dm
@@ -20,7 +20,7 @@
 	slowdown = -0.5
 	can_force_door = 1
 	additional_langs = list("Sign Language")
-	inherent_verbs = list(/mob/living/carbon/human/proc/dual_wield_weapons)
+	inherent_verbs = list()
 	unarmed_types = list(/datum/unarmed_attack/spartan_punch)
 
 	metabolism_mod = 1.25 //Faster metabolism

--- a/maps/Exoplanet Mining/overmap.dm
+++ b/maps/Exoplanet Mining/overmap.dm
@@ -2,7 +2,4 @@
 	name = "PYK-248"
 	icon = 'maps/Exoplanet Mining/sector_icon.dmi'
 	icon_state = "mining_asteroid"
-
-/obj/effect/overmap/sector/exo_mining/LateInitialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(28,src)
+	occupy_range = 28

--- a/maps/Exoplanet Research/overmap.dm
+++ b/maps/Exoplanet Research/overmap.dm
@@ -14,6 +14,8 @@
 
 	parent_area_type = /area/exo_research_facility/sublevel1/interior
 
+	occupy_range = 28
+
 /obj/effect/overmap/sector/exo_research/New()
 	. = ..()
 	loot_distributor.loot_list["artifactRandom"] = list(/obj/machinery/artifact/forerunner_artifact,null,null,null)
@@ -56,10 +58,6 @@
 	/obj/item/weapon/gun/energy/laser/sentinel_beam/detached,\
 	/obj/item/weapon/gun/energy/laser/sentinel_beam/detached,\
 	null,null,null)
-
-/obj/effect/overmap/sector/exo_research/LateInitialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(28,src)
 
 /obj/effect/loot_marker/gauntlet_loot
 	loot_type = "gauntletLoot"

--- a/maps/faction_bases/Cassius_Station/Cassius_Station.dm
+++ b/maps/faction_bases/Cassius_Station/Cassius_Station.dm
@@ -20,10 +20,7 @@
 
 	map_bounds = list(37,117,114,68) //Format: (TOP_LEFT_X,TOP_LEFT_Y,BOTTOM_RIGHT_X,BOTTOM_RIGHT_Y)
 
-/obj/effect/overmap/ship/unsc_cassius/Initialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(7,src)
-
+	occupy_range = 7
 
 /area/faction_base/unsc/upperlevel
 	name = "UNSC Cassius Station (Upper)"

--- a/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
+++ b/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
@@ -22,6 +22,4 @@
 
 	map_bounds = list(23,106,140,32) //Format: (TOP_LEFT_X,TOP_LEFT_Y,BOTTOM_RIGHT_X,BOTTOM_RIGHT_Y)
 
-/obj/effect/overmap/ship/unsc_odp_cassius/Initialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(7,src)
+	occupy_range = 7

--- a/maps/first_contact/mapdef.dm
+++ b/maps/first_contact/mapdef.dm
@@ -21,5 +21,6 @@
 	overmap_size= 50
 
 	use_overmap = 1
+	overmap_event_tokens = 25
 
 	map_admin_faxes = list("Ministry of Tranquility (General)","Ministry of Resolution (War Matters)","Ministry of Fervent Intercession (Internal Affairs)")

--- a/maps/geminus_city/geminus_city_map.dm
+++ b/maps/geminus_city/geminus_city_map.dm
@@ -21,6 +21,7 @@
 	company_name  = "United Nations Space Command"
 	company_short = "UNSC"
 	overmap_size= 125
+	overmap_event_tokens = 50
 
 	use_overmap = 1
 

--- a/maps/geminus_city/geminus_city_overmap.dm
+++ b/maps/geminus_city/geminus_city_overmap.dm
@@ -15,13 +15,11 @@
 
 	parent_area_type = /area/planets/Geminus
 
+	occupy_range = 28
+
 /obj/effect/overmap/sector/geminus_city/New()
 	. = ..()
 	loot_distributor.loot_list["artifactRandom"] = list(/obj/machinery/artifact/forerunner_artifact,null,null,null,null,null,null,null,null,null)
-
-/obj/effect/overmap/sector/geminus_city/LateInitialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(28,src)
 
 /obj/effect/loot_marker/artifact_spawn
 	loot_type = "artifactRandom"

--- a/maps/ks7_elmsville/overmap.dm
+++ b/maps/ks7_elmsville/overmap.dm
@@ -9,6 +9,8 @@
 
 	map_bounds = list(1,150,150,1) //Format: (TOP_LEFT_X,TOP_LEFT_Y,BOTTOM_RIGHT_X,BOTTOM_RIGHT_Y)
 
+	occupy_range = 28
+
 /obj/effect/overmap/sector/exo_depot/New()
 	. = ..()
 	/*loot_distributor.loot_list += list(\
@@ -78,10 +80,6 @@
 	/mob/living/simple_animal/hostile/pirate_defender/civ,/mob/living/simple_animal/hostile/pirate_defender/civ,/mob/living/simple_animal/hostile/pirate_defender/civ,
 	null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null
 	)
-
-/obj/effect/overmap/sector/exo_depot/LateInitialize()
-	. = ..()
-	GLOB.overmap_tiles_uncontrolled -= range(28,src)
 
 //dummy path so this compiles
 /obj/effect/overmap/sector/exo_research

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -82,6 +82,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/evac_controller_type = /datum/evacuation_controller
 	var/use_overmap = 0		//If overmap should be used (including overmap space travel override)
 	var/overmap_size = 20		//Dimensions of overmap zlevel if overmap is used.
+	var/overmap_event_tokens = 0 //How many event type tokens do we generate and place on the overmap
 	var/overmap_z = 0		//If 0 will generate overmap zlevel on init. Otherwise will populate the zlevel provided.
 	var/overmap_event_areas = 0 //How many event "clouds" will be generated
 


### PR DESCRIPTION
adds a system to handle lingering effects on ships. implementing a few of the effects as overmap encounterable events, activatable when crossed over.
:cl: XO-11
tweak: adds a bit more spice to the overmap in the form of events. Will it boost your speed? Hide you in a gas cloud with periodic EMPs? Who knows.
/:cl: