### PR TITLE
Firefight Ammo Fixes

### DIFF
--- a/maps/_gamemodes/firefight/resupply_crates.dm
+++ b/maps/_gamemodes/firefight/resupply_crates.dm
@@ -31,9 +31,9 @@
 /obj/structure/closet/crate/random/unsc_guns
 	name = "Weapons Capsule"
 	possible_spawns = list(\
-		/obj/item/weapon/gun/projectile/ma5b_ar = /obj/item/ammo_magazine/m762_ap,\
+		/obj/item/weapon/gun/projectile/ma5b_ar = /obj/item/ammo_magazine/m762_ap/MA5B,\
 		/obj/item/weapon/gun/projectile/m7_smg = /obj/item/ammo_magazine/m5,\
-		/obj/item/weapon/gun/projectile/shotgun/pump/m90_ts = /obj/item/weapon/storage/box/shotgunshells)
+		/obj/item/weapon/gun/projectile/shotgun/pump/m90_ts = /obj/item/ammo_box/shotgun)
 
 /obj/structure/closet/crate/random/unsc_guns/WillContain()
 	return list(/obj/item/weapon/gun/projectile/m6d_magnum,\


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Closes #2422 
<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Guprei
tweak: Replaces M118 mags for firefight with MA5B mags. Reloading is now possible.
tweak: Replaced shotgun shell box with the shotgun shell ammo box, enabling faster reloads and more ammo
/:cl:
