### PR TITLE
Marine Helmet Sprite Fixes

### DIFF
--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -64,25 +64,25 @@
 	icon = ITEM_INHAND
 	icon_override = MARINE_OVERRIDE
 	item_state = "CH252 Helmet B"
-	icon_state = "helmet_b"
+	icon_state = "helmet_novisor_b"
 	body_parts_covered = HEAD|EYES
 
 /obj/item/clothing/head/helmet/marine/medic/brown
-	name = "Brown Camo CH251 Helmet"
+	name = "Brown Camo CH251 Helmet Medic"
 	desc = "The standard issue combat helmet worn by the members of the UNSC Marine Corps, UNSC Army, and UNSC Air Force. Has an inbuilt VISOR for eye protection."
 	icon = ITEM_INHAND
 	icon_override = MARINE_OVERRIDE
 	item_state = "CH252 Helmet Medic B"
-	icon_state = "helmet medic-b_obj"
+	icon_state = "helmet novisor medic-b_obj"
 	body_parts_covered = HEAD|EYES
 
 /obj/item/clothing/head/helmet/marine/medic/brownvisor
-	name = "Brown Camo CH251 Helmet"
+	name = "Brown Camo CH251-V Helmet Medic"
 	desc = "The standard issue combat helmet worn by the members of the UNSC Marine Corps, UNSC Army, and UNSC Air Force. Has an inbuilt VISOR for eye protection."
 	icon = ITEM_INHAND
 	icon_override = MARINE_OVERRIDE
 	item_state = "CH252 Visor Helmet Medic B"
-	icon_state = "helmet medic-b_obj"
+	icon_state = "helmet medic_obj"
 	body_parts_covered = HEAD|EYES
 
 /obj/item/clothing/head/helmet/marine/brownvisor
@@ -236,7 +236,7 @@
 	icon_state = "marinemask"
 	item_state = "marinemask"
 	w_class = ITEM_SIZE_SMALL
-	body_parts_covered = HEAD|FACE
+	body_parts_covered = HEAD
 	flags_inv = HIDEEARS|BLOCKHAIR
 
 /obj/item/clothing/suit/space/void/unsc


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Guprei
tweak: The brown visorless Marine helmet and brown medic helmets all now have the correct sprites for their icon and onmob states
tweak: You are now able to eat through Marine masks
/:cl:
