### PR TITLE
Dropship sealing and auto-generated drop markers

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -362,7 +362,7 @@
 	return air_contents
 
 //This proc literally only exists for cryo cells.
-/atom/proc/return_air_for_internal_lifeform()
+/atom/proc/return_air_for_internal_lifeform(var/mob/lifeform)
 	return return_air()
 
 /obj/machinery/atmospherics/unary/cryo_cell/return_air_for_internal_lifeform()

--- a/code/modules/halo/misc/payload.dm
+++ b/code/modules/halo/misc/payload.dm
@@ -97,6 +97,8 @@
 		return
 
 /obj/payload/proc/set_anchor(var/onoff)
+	if(initial(anchored) == 1) //if we started anchored, we shall not change our status
+		return
 	anchored = onoff
 
 /obj/payload/proc/checkdisarm()

--- a/code/modules/halo/vehicles/types/boarding_pod.dm
+++ b/code/modules/halo/vehicles/types/boarding_pod.dm
@@ -8,6 +8,7 @@
 	drop_accuracy = 5
 	occupants = list(8,0)
 	pod_range = 14
+	internal_air = new
 
 	light_color = "#E1FDFF"
 

--- a/code/modules/halo/vehicles/types/boarding_pod.dm
+++ b/code/modules/halo/vehicles/types/boarding_pod.dm
@@ -31,7 +31,7 @@
 		if(istype(t,/turf/unsimulated/floor))
 			valid_points += t
 			continue
-	if(isnull(valid_points))
+	if(isnull(valid_points) || valid_points.len == 0)
 		error("DROP POD FAILED TO LAUNCH: COULD NOT FIND ANY VALID DROP-POINTS")
 		return
 	return pick(valid_points)

--- a/code/modules/halo/vehicles/types/drop_pod.dm
+++ b/code/modules/halo/vehicles/types/drop_pod.dm
@@ -176,7 +176,7 @@
 		return
 	om_targ = potential_om_targ[om_user_choice]
 
-	var/turf/drop_turf = get_drop_turf(get_drop_point(usr,om_targ,om_targ.map_z))
+	var/turf/drop_turf = get_drop_turf(get_drop_point(usr,om_targ))
 	if(isnull(drop_turf))
 		to_chat(usr,"<span class = 'notice'>No valid drop-turfs available.</span>")
 		return
@@ -189,11 +189,11 @@
 		potential_om_targ["[o.name]"] = o
 	return potential_om_targ
 
-/obj/vehicles/drop_pod/overmap/get_drop_point(var/mob/user,var/obj/effect/overmap/om_targ,var/list/om_targ_zs)
+/obj/vehicles/drop_pod/overmap/get_drop_point(var/mob/user,var/obj/effect/overmap/om_targ)
 	var/list/valid_points = list()
 	var/beacons_present = 0
 	for(var/obj/item/drop_pod_beacon/b in world)
-		if(!(b.loc.z  in om_targ_zs))
+		if(!(b.loc.z  in om_targ.map_z))
 			continue
 		if(b.is_active == 1)
 			if(!beacons_present) //If we've not already realised we have beacons, remove all normal drop-pod markers from pick-choice.
@@ -207,7 +207,7 @@
 	if(om_targ.targeting_locations.len > 0)
 		var/chosen_loc_name = input(user,"Pick a location to land the [name]","[name] Landing Selection","Cancel") in om_targ.targeting_locations + list("Cancel")
 		chosen_area = om_targ.targeting_locations[chosen_loc_name]
-	return locate(rand(chosen_area[1],chosen_area[3]),rand(chosen_area[2],chosen_area[4]),pick(om_targ_zs))
+	return locate(rand(chosen_area[1],chosen_area[3]),rand(chosen_area[2],chosen_area[4]),pick(om_targ.map_z))
 
 /obj/vehicles/drop_pod/overmap/post_drop_effects(var/turf/drop_turf)
 	var/obj/effect/overmap/our_om_obj = map_sectors["[drop_turf.z]"]

--- a/code/modules/halo/vehicles/types/pelican.dm
+++ b/code/modules/halo/vehicles/types/pelican.dm
@@ -33,6 +33,7 @@
 	max_speed = 2.25
 	acceleration = 6
 	drag = 3.5
+	internal_air = new
 
 /obj/vehicles/air/pelican/update_object_sprites()
 
@@ -111,6 +112,8 @@
 	max_speed = 2.25
 	acceleration = 6
 	drag = 3.5
+
+	internal_air = new
 
 /obj/vehicles/air/overmap/pelican/unsc
 	faction = "unsc"

--- a/code/modules/halo/vehicles/types/spirit_dropship.dm
+++ b/code/modules/halo/vehicles/types/spirit_dropship.dm
@@ -35,6 +35,8 @@
 	acceleration = 6
 	drag = 3.5
 
+	internal_air = new
+
 /obj/vehicles/air/overmap/spirit_dropship/update_object_sprites()
 	. = ..()
 	if(dir == NORTH || dir == SOUTH)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -22,6 +22,7 @@
 	var/max_speed = 1//What's the lowest number we can go to in terms of delay?
 	var/acceleration = 1 //By how much does our speed change per input?
 	var/braking_mode = 0 //1 = brakes active, -1 = purposefully reducing drag to slide.
+	var/can_space_move = 0
 
 	//Advanced Damage Handling
 	var/datum/component_profile/comp_prof = /datum/component_profile
@@ -433,6 +434,9 @@
 /obj/vehicles/relaymove(var/mob/user, var/direction)
 	if(world.time < next_move_input_at)
 		return 0
+	if(isspace(loc) && !can_space_move)
+		to_chat(user,"<span class = 'notice'>[src] cannot mvoe in space!</span>")
+		return
 	if(movement_destroyed)
 		to_chat(user,"<span class = 'notice'>[src] is in no state to move!</span>")
 		return 0

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -124,9 +124,9 @@
 	if(spawn_datum)
 		spawn_datum = new spawn_datum
 		verbs += /obj/vehicles/proc/toggle_mobile_spawn_deploy
-
-	internal_air.volume = 2500
-	internal_air.temperature = T20C
+	if(internal_air)
+		internal_air.volume = 2500
+		internal_air.temperature = T20C
 
 /obj/vehicles/return_air_for_internal_lifeform(var/mob/living/carbon/human/form)
 	if(!internal_air)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -53,8 +53,19 @@
 
 	var/datum/mobile_spawn/spawn_datum //Setting this makes this a mobile spawn point.
 
+	var/datum/gas_mixture/internal_air = 0//If this is new()'d, the vehicle provides air to the occupants.
+	//I would make it require refilling, but that's likely to just be boring tedium for players.
+
 	light_power = 4
 	light_range = 6
+
+/obj/vehicles/return_air_for_internal_lifeform(var/mob/living/carbon/human/form)
+	if(!internal_air)
+		return
+	if(!istype(form))
+		return
+	internal_air.gas[form.species.breath_type] = 60
+	return internal_air
 
 /obj/vehicles/proc/mobile_spawn_check(var/mob/user)
 	if(spawn_datum.is_spawn_active == 0 && (guns_disabled || movement_destroyed))

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -59,14 +59,6 @@
 	light_power = 4
 	light_range = 6
 
-/obj/vehicles/return_air_for_internal_lifeform(var/mob/living/carbon/human/form)
-	if(!internal_air)
-		return
-	if(!istype(form))
-		return
-	internal_air.gas[form.species.breath_type] = 60
-	return internal_air
-
 /obj/vehicles/proc/mobile_spawn_check(var/mob/user)
 	if(spawn_datum.is_spawn_active == 0 && (guns_disabled || movement_destroyed))
 		to_chat(user,"<span class = 'notice'>[src] is too damaged to lock down.</span>")
@@ -132,6 +124,17 @@
 	if(spawn_datum)
 		spawn_datum = new spawn_datum
 		verbs += /obj/vehicles/proc/toggle_mobile_spawn_deploy
+
+	internal_air.volume = 1
+	internal_air.temperature = T20C
+
+/obj/vehicles/return_air_for_internal_lifeform(var/mob/living/carbon/human/form)
+	if(!internal_air)
+		return
+	if(!istype(form))
+		return
+	internal_air.gas[form.species.breath_type] = 1
+	return internal_air
 
 /obj/vehicles/attack_generic(var/mob/living/simple_animal/attacker,var/damage,var/text)
 	visible_message("<span class = 'danger'>[attacker] [text] [src]</span>")

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -125,7 +125,7 @@
 		spawn_datum = new spawn_datum
 		verbs += /obj/vehicles/proc/toggle_mobile_spawn_deploy
 
-	internal_air.volume = 1
+	internal_air.volume = 2500
 	internal_air.temperature = T20C
 
 /obj/vehicles/return_air_for_internal_lifeform(var/mob/living/carbon/human/form)
@@ -133,7 +133,12 @@
 		return
 	if(!istype(form))
 		return
-	internal_air.gas[form.species.breath_type] = 1
+	internal_air.gas[form.species.breath_type] = 0
+	for(var/gas in internal_air.gas)
+		internal_air.gas[gas] = 100/internal_air.gas.len
+	return internal_air
+
+/obj/vehicles/return_air()
 	return internal_air
 
 /obj/vehicles/attack_generic(var/mob/living/simple_animal/attacker,var/damage,var/text)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -435,7 +435,7 @@
 	if(world.time < next_move_input_at)
 		return 0
 	if(isspace(loc) && !can_space_move)
-		to_chat(user,"<span class = 'notice'>[src] cannot mvoe in space!</span>")
+		to_chat(user,"<span class = 'notice'>[src] cannot move in space!</span>")
 		return
 	if(movement_destroyed)
 		to_chat(user,"<span class = 'notice'>[src] is in no state to move!</span>")

--- a/code/modules/halo/vehicles/vehiclebase_air.dm
+++ b/code/modules/halo/vehicles/vehiclebase_air.dm
@@ -19,6 +19,7 @@
 	active = 0
 
 	can_traverse_zs = 1
+	can_space_move = 1
 
 	var/faction = null //The faction this vehicle belongs to. Setting this will restrict landing to faction-owned and Civilian points only
 

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -57,7 +57,7 @@
 
 	var/datum/gas_mixture/environment
 	if(loc)
-		environment = loc.return_air_for_internal_lifeform()
+		environment = loc.return_air_for_internal_lifeform(src)
 
 	if(environment)
 		breath = environment.remove_volume(volume_needed)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -54,10 +54,9 @@
 	my_pixel_transform.max_pixel_speed = ship_max_speed
 	my_pixel_transform.my_observers = my_observers
 
-	create_dropship_markers()
-
 /obj/effect/overmap/ship/LateInitialize()
 	. = ..()
+	create_dropship_markers()
 	if(my_faction)
 		my_faction.all_ships.Add(src)
 

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -54,6 +54,8 @@
 	my_pixel_transform.max_pixel_speed = ship_max_speed
 	my_pixel_transform.my_observers = my_observers
 
+	create_dropship_markers()
+
 /obj/effect/overmap/ship/LateInitialize()
 	. = ..()
 	if(my_faction)
@@ -63,6 +65,42 @@
 	if(my_faction)
 		my_faction.all_ships.Remove(src)
 	. = ..()
+
+//Creates dropship markers for each z-level, for each cardinal direction.
+/obj/effect/overmap/ship/proc/create_dropship_markers()
+	for(var/i = 0 to map_z.len)
+		for(var/n in list("North","East","South","West"))//1 for each cardinal direction
+			var/using_axis_x = 0 //if this is ticked, the y axis becomes static
+			var/use_opposite_side = 0
+			switch(n)
+				if("North")
+					using_axis_x = 1
+					use_opposite_side = 1
+				if("East")
+					use_opposite_side = 1
+				if("South")
+					using_axis_x = 1
+
+			var/turf/point_at
+			var/z_level = map_z[i]
+			var/midpoint = 0
+			if(using_axis_x)
+				midpoint = (map_bounds[1] + map_bounds[3]) /2
+			else
+				midpoint = (map_bounds[2] + map_bounds[4]) /2
+			if(use_opposite_side) //EAST/SOUTH
+				if(using_axis_x)
+					point_at = locate(midpoint,map_bounds[4],z_level)
+				else
+					point_at = locate(map_bounds[3],midpoint,z_level)
+			else
+				if(using_axis_x)
+					point_at = locate(midpoint,map_bounds[2],z_level)
+				else
+					point_at = locate(map_bounds[1],midpoint,z_level)
+			if(point_at)
+				var/obj/point = new /obj/effect/landmark/dropship_land_point (point_at)
+				point.name = "Level [i+1] - [n]"
 
 /obj/effect/overmap/ship/proc/assign_fleet(var/assign)
 	if(our_fleet == assign)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -82,7 +82,7 @@
 					using_axis_x = 1
 
 			var/turf/point_at
-			var/z_level = map_z[i]
+			var/z_level = map_z[i+1]
 			var/midpoint = 0
 			if(using_axis_x)
 				midpoint = (map_bounds[1] + map_bounds[3]) /2

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -25,8 +25,6 @@
 	var/lock_thrust = 0
 	var/braking = 0
 
-	var/genned_dropship_points = 0
-
 /obj/effect/overmap/ship/New()
 	. = ..()
 	our_fleet = new(src)
@@ -56,6 +54,8 @@
 	my_pixel_transform.max_pixel_speed = ship_max_speed
 	my_pixel_transform.my_observers = my_observers
 
+	create_dropship_markers()
+
 /obj/effect/overmap/ship/LateInitialize()
 	. = ..()
 	if(my_faction)
@@ -68,7 +68,7 @@
 
 //Creates dropship markers for each z-level, for each cardinal direction.
 /obj/effect/overmap/ship/proc/create_dropship_markers()
-	for(var/i = 0 to map_z.len)
+	for(var/i = 1 to map_z.len)
 		for(var/n in list("North","East","South","West"))//1 for each cardinal direction
 			var/using_axis_x = 0 //if this is ticked, the y axis becomes static
 			var/use_opposite_side = 0
@@ -82,7 +82,7 @@
 					using_axis_x = 1
 
 			var/turf/point_at
-			var/z_level = map_z[i+1]
+			var/z_level = map_z[i]
 			var/midpoint = 0
 			if(using_axis_x)
 				midpoint = (map_bounds[1] + map_bounds[3]) /2
@@ -100,7 +100,7 @@
 					point_at = locate(map_bounds[1],midpoint,z_level)
 			if(point_at)
 				var/obj/point = new /obj/effect/landmark/dropship_land_point (point_at)
-				point.name = "Level [i+1] - [n]"
+				point.name = "Level [i] - [n]"
 
 /obj/effect/overmap/ship/proc/assign_fleet(var/assign)
 	if(our_fleet == assign)
@@ -244,9 +244,6 @@
 
 /obj/effect/overmap/ship/process()
 	. = ..()
-	if(!genned_dropship_points)
-		create_dropship_markers()
-		genned_dropship_points = 1
 	if(moving_dir)
 		accelerate(moving_dir)
 		if(!lock_thrust)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -25,6 +25,8 @@
 	var/lock_thrust = 0
 	var/braking = 0
 
+	var/genned_dropship_points = 0
+
 /obj/effect/overmap/ship/New()
 	. = ..()
 	our_fleet = new(src)
@@ -56,7 +58,6 @@
 
 /obj/effect/overmap/ship/LateInitialize()
 	. = ..()
-	create_dropship_markers()
 	if(my_faction)
 		my_faction.all_ships.Add(src)
 
@@ -243,6 +244,9 @@
 
 /obj/effect/overmap/ship/process()
 	. = ..()
+	if(!genned_dropship_points)
+		create_dropship_markers()
+		genned_dropship_points = 1
 	if(moving_dir)
 		accelerate(moving_dir)
 		if(!lock_thrust)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -411,12 +411,11 @@
 		stored_targ = target
 		use_targ = stored_targ
 	. = 1
-	if(burst > 1 || sustain_time > 0)
-		user.visible_message(
-		"<span class='danger'>\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""]!</span>",
-		"<span class='warning'>You fire \the [src]!</span>",
-		"You hear a [fire_sound_text]!"
-		)
+	user.visible_message(
+	"<span class='danger'>\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""]!</span>",
+	"<span class='warning'>You fire \the [src]!</span>",
+	"You hear a [fire_sound_text]!"
+	)
 	for(var/i in 1 to burst)
 		if(!pershot_check(user))
 			break

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -411,7 +411,7 @@
 		stored_targ = target
 		use_targ = stored_targ
 	. = 1
-	if(burst > 1)
+	if(burst > 1 || sustain_time > 0)
 		user.visible_message(
 		"<span class='danger'>\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""]!</span>",
 		"<span class='warning'>You fire \the [src]!</span>",


### PR DESCRIPTION
:cl: XO-11
tweak: Dropships are now sealed to the elements, generating and holding their own atmosphere. Boarding pods also have this.
tweak: Every ship And certain ship-like objects like the odp now have dropship landing points generated on each cardinal direction of each level of the contained map.
tweak: minor fixes to kigyar nv and closets
tweak: makes scan-progress msg transmit on SQUAD comms
tweak: needler tracking balance
bugfix: wraith cannon npc fix
tweak:  plasma nade rebuff now deals 65 explosion damage 
tweak: 30 second payload disarm
/:cl: