### PR TITLE
prophet throne spritefix and co's sword/magnum

### DIFF
--- a/code/modules/halo/abilities/dodge_roll.dm
+++ b/code/modules/halo/abilities/dodge_roll.dm
@@ -40,7 +40,7 @@ mob/living/proc/getPerRollDelay()
 /mob/living/carbon/human/getPerRollDelay()
 	return species.per_roll_delay
 
-/mob/living/proc/rollDir(var/dir)
+/mob/living/proc/rollDir(var/dir_roll)
 	if(world.time < next_roll_at)
 		to_chat(src,"<span class = 'notice'>You can't dodge roll again just yet!</span>")
 		return 0
@@ -53,6 +53,9 @@ mob/living/proc/getPerRollDelay()
 	if(istype(v))
 		v.exit_vehicle(src)
 	next_roll_at = world.time + ((roll_delay * roll_dist) + DODGE_ROLL_BASE_COOLDOWN)
+	doRoll(dir_roll,roll_dist,roll_delay)
+
+/mob/living/proc/doRoll(var/dir_roll,var/roll_dist,var/roll_delay)
 	to_chat(src,"<span class = 'warning'>[name] performs a dodge roll!</span>")
 	var/tableroll = 1
 	if(pass_flags & PASSTABLE)
@@ -60,8 +63,8 @@ mob/living/proc/getPerRollDelay()
 	if(tableroll)
 		pass_flags |= PASSTABLE
 	for(var/i = 0,i < roll_dist,i++)
-		var/turf/step_to = get_step(loc,dir)
-		if(step_to.density == 1 || !step(src,dir))
+		var/turf/step_to = get_step(loc,dir_roll)
+		if(step_to.density == 1 || !step(src,dir_roll))
 			visible_message("<span class = 'warning'>[name] rolls into [step_to].</span>")
 			if(tableroll)
 				pass_flags &= ~PASSTABLE
@@ -80,5 +83,13 @@ mob/living/proc/getPerRollDelay()
 	if(tableroll)
 		pass_flags &= ~PASSTABLE
 	return 1
+
+/mob/living/carbon/human/doRoll(var/dir_roll,var/roll_dist,var/roll_delay)
+	if(species.handle_dodge_roll(src,dir_roll,roll_dist,roll_delay))
+		return
+	. = ..()
+
+/datum/species/proc/handle_dodge_roll(var/mob/roller,var/rolldir)
+	return 0
 
 #undef DODGE_ROLL_BASE_COOLDOWN

--- a/code/modules/halo/custom_ai_objects/dumb_ai_chip.dm
+++ b/code/modules/halo/custom_ai_objects/dumb_ai_chip.dm
@@ -31,7 +31,7 @@
 		if(!command.our_ai)
 			command.output_to = src
 			command.our_ai = ai
-		command_names[command] = i
+		command_names[command.name] = command
 	var/choice = input(user,"Prime for what command?","Command priming","Cancel") in command_names + list("Cancel")
 	if(choice == "Cancel")
 		return

--- a/code/modules/halo/flood/flood_spawn.dm
+++ b/code/modules/halo/flood/flood_spawn.dm
@@ -83,6 +83,7 @@
 	F = new spawn_type(spawn_turf)
 	F.flood_spawner = src
 	live_flood.Add(F)
+	owner.visible_message("<span class = 'danger'>[owner] writhes and produces [F].</span>")
 	return 1
 
 /datum/flood_spawner/proc/flood_die(var/mob/living/simple_animal/hostile/flood/F)

--- a/code/modules/halo/overmap/weapons/MAC.dm
+++ b/code/modules/halo/overmap/weapons/MAC.dm
@@ -255,6 +255,8 @@
 
 /obj/item/projectile/mac_round/check_penetrate(var/atom/impacted)
 	. = ..()
+	if(istype(impacted,/obj/effect/shield))
+		return 0
 	var/increase_from_damage = round(damage/250)
 	if(increase_from_damage > 2)
 		increase_from_damage -= 2

--- a/code/modules/halo/unsc/jobs/officers_outfits.dm
+++ b/code/modules/halo/unsc/jobs/officers_outfits.dm
@@ -4,6 +4,8 @@
 	uniform = /obj/item/clothing/under/unsc/co
 	l_ear = /obj/item/device/radio/headset/unsc/commander
 	shoes = /obj/item/clothing/shoes/brown
+	back = /obj/item/weapon/material/machete/officersword
+	belt = /obj/item/weapon/gun/projectile/m6d_magnum/CO_magnum
 	starting_accessories = list(/obj/item/clothing/accessory/rank/fleet/officer/o6)
 
 /decl/hierarchy/outfit/job/unsc/executive_officer
@@ -11,4 +13,5 @@
 	l_ear = /obj/item/device/radio/headset/unsc/officer
 	uniform = /obj/item/clothing/under/unsc/grey
 	shoes = /obj/item/clothing/shoes/brown
+	back = /obj/item/weapon/material/machete/officersword
 	starting_accessories = list(/obj/item/clothing/accessory/rank/fleet/officer/o4)

--- a/code/modules/halo/vehicles/supply_pods.dm
+++ b/code/modules/halo/vehicles/supply_pods.dm
@@ -55,7 +55,6 @@
 
 /obj/vehicles/drop_pod/supply_pod/enter_as_position(var/mob/user,var/position = "passenger")
 	to_chat(user,"<span class = 'notice'>[src] does not have any seats for people.</span>")
-	return
 
 /obj/vehicles/drop_pod/overmap/supply_pod/post_drop_effects(var/turf/drop_turf)
 	anchored = 1

--- a/code/modules/halo/vehicles/types/prophet_chair.dm
+++ b/code/modules/halo/vehicles/types/prophet_chair.dm
@@ -23,16 +23,20 @@
 	light_color = "#C1CEFF"
 
 /obj/vehicles/prophet_throne/update_object_sprites()
-	underlays.Cut()
 	overlays.Cut()
 	var/list/offsets_to_use = sprite_offsets["[dir]"]
 	var/list/drivers = get_occupants_in_position("driver")
 	if(!(isnull(offsets_to_use) || isnull(drivers) || drivers.len == 0))
 		var/image/driver_image = image(pick(drivers))
+		driver_image.plane = ABOVE_HUMAN_PLANE
+		driver_image.layer = VEHICLE_LOAD_LAYER
 		driver_image.pixel_x = offsets_to_use[1]
 		driver_image.pixel_y = offsets_to_use[2]
 		overlays += driver_image
-		driver_image.overlays += image(icon,null,"chair-front")
+		var/image/front = image(icon,null,"chair-front")
+		front.plane = ABOVE_HUMAN_PLANE
+		front.layer = VEHICLE_LOAD_LAYER
+		overlays += front
 
 /obj/item/vehicle_component/health_manager/throne
 	integrity = 500

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -828,6 +828,14 @@
 				if(150 to 250)					nutrition_icon.icon_state = "nutrition3"
 				else							nutrition_icon.icon_state = "nutrition4"
 
+		if(isSynthetic() && cells)
+			var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
+			if (istype(C))
+				var/chargeNum = Clamp(ceil(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
+				cells.icon_state = "charge[chargeNum]"
+			else
+				cells.icon_state = "charge-empty"
+
 		if(pressure)
 			pressure.icon_state = "pressure[pressure_alert]"
 		if(toxin)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -613,11 +613,13 @@
 
 // Check if we should die.
 /mob/living/carbon/human/proc/handle_death_check()
-	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
-		if(!brain || (brain.status & ORGAN_DEAD))
-			return TRUE
-	return species.handle_death_check(src)
+	. = species.handle_death_check(src)
+	if(!.)
+		if(should_have_organ(BP_BRAIN))
+			var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
+			if(!brain || (brain.status & ORGAN_DEAD))
+				return TRUE
+	return
 
 //DO NOT CALL handle_statuses() from this proc, it's called from living/Life() as long as this returns a true value.
 /mob/living/carbon/human/handle_regular_status_updates()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -826,14 +826,6 @@
 				if(150 to 250)					nutrition_icon.icon_state = "nutrition3"
 				else							nutrition_icon.icon_state = "nutrition4"
 
-		if(isSynthetic())
-			var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
-			if (istype(C))
-				var/chargeNum = Clamp(ceil(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
-				cells.icon_state = "charge[chargeNum]"
-			else
-				cells.icon_state = "charge-empty"
-
 		if(pressure)
 			pressure.icon_state = "pressure[pressure_alert]"
 		if(toxin)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -265,6 +265,9 @@
 	H.organs_by_name = list()
 	H.internal_organs_by_name = list()
 
+	if(s)
+		H.internal_organs_by_name["stack"] = s
+
 	for(var/limb_type in has_limbs)
 		var/list/organ_data = has_limbs[limb_type]
 		var/limb_path = organ_data["path"]
@@ -286,11 +289,6 @@
 
 	for(var/obj/item/organ/O in (H.organs|H.internal_organs))
 		O.owner = H
-
-	if(s)
-		H.internal_organs_by_name["stack"] = s
-		H.internal_organs += s
-		s.owner = H
 
 	H.sync_organ_dna()
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -31,6 +31,7 @@
 	var/body_part = null               // Part flag
 	var/icon_position = 0              // Used in mob overlay layering calculations.
 	var/model                          // Used when caching robolimb icons.
+	var/use_robotic_sprites = 1        // If 0, does not use the robotic sprite replacement
 	var/force_icon                     // Used to force override of species-specific limb icons (for prosthetics).
 	var/icon/mob_icon                  // Cached icon for use in mob overlays.
 	var/gendered_icon = 0              // Whether or not the icon state appends a gender.

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -75,7 +75,7 @@ var/list/limb_icon_cache = list()
 		icon = force_icon
 	else if (!dna)
 		icon = 'icons/mob/human_races/r_human.dmi'
-	else if (robotic >= ORGAN_ROBOT)
+	else if (use_robotic_sprites && robotic >= ORGAN_ROBOT)
 		icon = 'icons/mob/human_races/robotic.dmi'
 	else if (status & ORGAN_MUTATED)
 		icon = species.deform

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -305,7 +305,8 @@
 		return
 
 	if(is_charged_weapon==1)
-		playsound(src.loc, charge_sound, 100, 1)
+		if(charge_sound)
+			playsound(src.loc, charge_sound, 100, 1)
 		user.visible_message("<span class = 'notice'>[user] starts charging the [src]!</span>")
 
 		is_charging = 1

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -31,13 +31,11 @@
 	return 1
 
 /obj/item/weapon/reagent_containers/hypospray/proc/has_been_refilled()
-	if(starts_with.len == 0)
-		return 0
-	for(var/datum/chem in reagents)
+	for(var/datum/reagent/chem in reagents.reagent_list)
 		if(!(chem.type in starts_with))
 			return 1
 		else
-			if(chem.volume > startswith[chem,type])
+			if(chem.volume > chem.overdose)
 				return 1
 	return 0
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -36,6 +36,9 @@
 	for(var/datum/chem in reagents)
 		if(!(chem.type in starts_with))
 			return 1
+		else
+			if(chem.volume > startswith[chem,type])
+				return 1
 	return 0
 
 /obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -39,7 +39,7 @@
 		gm.allow_scan = 1
 
 		GLOB.global_announcer.autosay("Our Orbital Defence Platform has fallen! Regroup at the ONI base, and get ready to strike out at covenant scanning devices.", "HIGHCOMM SIGINT", RADIO_FLEET, LANGUAGE_GALCOM)
-		GLOB.global_announcer.autosay("The human defences are down! Plant the holy scanners, and locate the relic! Do not be distracted by the human's defenses!", "Covenant Overwatch", RADIO_COV, LANGUAGE_SANGHEILI)
+		GLOB.global_announcer.autosay("The human defences are down! Plant the holy scanners, and locate the relic! Do not be distracted by the human's groundside fortifications!", "Covenant Overwatch", RADIO_COV, LANGUAGE_SANGHEILI)
 
 	. = ..()
 

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -33,6 +33,15 @@
 	if(gm.scan_percent < 100)
 		return 1
 
+/obj/effect/overmap/ship/unsc_odp_cassius/Destroy()
+	var/datum/game_mode/outer_colonies/gm = ticker.mode
+	if(istype(gm))
+		gm.allow_scan = 1
+
+		GLOB.global_announcer.autosay("Our Orbital Defence Platform has fallen! Regroup at the ONI base, and get ready to strike out at covenant scanning devices.", "HIGHCOMM SIGINT", RADIO_FLEET, LANGUAGE_GALCOM)
+		GLOB.global_announcer.autosay("The human defences are down! Plant the holy scanners, and locate the relic! Do not be distracted by the human's defenses!", "Covenant Overwatch", RADIO_COV, LANGUAGE_SANGHEILI)
+
+	. = ..()
 
 /datum/game_mode/outer_colonies
 	name = "Outer Colonies"

--- a/maps/unsc_achlys/achlys_objects.dm
+++ b/maps/unsc_achlys/achlys_objects.dm
@@ -360,3 +360,9 @@
 	anchored = 1
 	density = 0
 	opacity = 0
+
+/obj/vehicles/air/overmap/pelican/achlys/enter_as_position(var/mob/living/carbon/human/user,var/position = "passenger")
+	if(!istype(user))
+		to_chat(user,"<span class = 'notice'>You can't enter [src]!</span>")
+		return
+	. = ..()


### PR DESCRIPTION
:cl: XO-11
tweak: the prophet throne, when facing south, no longer obscures the entire mob.
tweak: the co's sword has arrived in space-mail, alongside his magnum. Curiously, a duplicate sword has arrived and has been assigned to the XO
/:cl: