### PR TITLE
Unlocks two spartan slots in phase 2

### DIFF
--- a/code/modules/halo/factions/fleet_handling.dm
+++ b/code/modules/halo/factions/fleet_handling.dm
@@ -28,6 +28,12 @@
 	GLOB.UNSC.AnnounceCommand("Reinforcements from the [fleetname] Fleet have arrived in the system. Hold out for just a little longer, marines.")
 	GLOB.COVENANT.AnnounceCommand("An overwhelming human fleet has jumped insystem. You have failed to achieve your objectives in time.")
 
+	//unlock a spartan after a short delay
+	spawn(100)
+		var/datum/job/special_job = job_master.occupations_by_title[/datum/job/unsc/spartan_two]
+		if(special_job)
+			special_job.total_positions += 1
+			GLOB.UNSC.AnnounceCommand("Spartan IIs have been deployed to the battlefront.")
 	. = ..()
 
 /datum/faction/proc/set_endless_fleets()

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -519,7 +519,7 @@ datum/unit_test/ladder_check/start_test()
 //=======================================================================================
 
 /datum/unit_test/open_space_above_stairs
-	name = "MAP: Open space above stairs/ladders"
+	name = "MAP: Open space above stairs"
 
 /datum/unit_test/open_space_above_stairs/start_test()
 

--- a/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
+++ b/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
@@ -29,4 +29,11 @@
 	var/datum/game_mode/outer_colonies/gm = ticker.mode
 	if(istype(gm))
 		gm.allow_scan = 1
+
+		//unlock a spartan slot after a short delay
+		spawn(100)
+			var/datum/job/special_job = job_master.occupations_by_title[/datum/job/unsc/spartan_two]
+			if(special_job)
+				special_job.total_positions += 1
+				GLOB.UNSC.AnnounceCommand("Spartan IIs have been deployed to the battlefront.")
 	. = ..()

--- a/maps/faction_bases/faction_base_unsc.dm
+++ b/maps/faction_bases/faction_base_unsc.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_EMPTY(unsc_base_spawns)
 /datum/spawnpoint/unsc_base
 	display_name = "UNSC Base Spawns"
 	restrict_job_type = list(\
+	/datum/job/unsc/spartan_two,\
 	/datum/job/unsc/crew,\
 	/datum/job/unsc/medical,\
 	/datum/job/unsc/marine,\
@@ -51,6 +52,7 @@ GLOBAL_LIST_EMPTY(unsc_base_fallback_spawns)
 /datum/spawnpoint/unsc_base_fallback
 	display_name = "UNSC Base Fallback Spawns"
 	restrict_job_type = list(\
+	/datum/job/unsc/spartan_two,\
 	/datum/job/unsc/marine,\
 	/datum/job/unsc/marine/specialist,\
 	/datum/job/unsc/marine/squad_leader,\

--- a/maps/geminus_city/invasion_geminus_jobdefs.dm
+++ b/maps/geminus_city/invasion_geminus_jobdefs.dm
@@ -1,6 +1,7 @@
 
 /datum/map/geminus_city
 	allowed_jobs = list(\
+		/datum/job/unsc/spartan_two,\
 		/datum/job/unsc/crew,\
 		/datum/job/unsc/medical,\
 		/datum/job/unsc/marine,\


### PR DESCRIPTION
One at the destruction of the ODP, one at the arrival of the UNSC fleet. 
:cl: CaelAislinn
rscadd: A spartan slot is now unlocked when the ODP is destroyed, and another when the UNSC fleet arrives. 
/:cl: