### PR TITLE
Plasma weapon overheating

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2614,6 +2614,7 @@
 #include "code\modules\projectiles\attachment_system.dm"
 #include "code\modules\projectiles\effects.dm"
 #include "code\modules\projectiles\gun.dm"
+#include "code\modules\projectiles\gun_overheat.dm"
 #include "code\modules\projectiles\projectile.dm"
 #include "code\modules\projectiles\ammunition\boxes.dm"
 #include "code\modules\projectiles\ammunition\bullets.dm"

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -33,7 +33,7 @@
 
 /obj/item/weapon/gun/energy/plasmapistol/New()
 	. = ..()
-	overcharge_cost = initial(charge_cost)*4
+	overcharge_cost = max_shots / 4
 
 /obj/item/weapon/gun/energy/plasmapistol/attack_self(var/mob/user)
 	if(power_supply.charge >= overcharge_cost)

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -46,10 +46,10 @@
 			update_icon()
 			return 1
 
-/obj/item/weapon/gun/energy/plasmapistol/proc/set_overcharge(var/new_overcharge = 1, var/mob/user = null)
+/obj/item/weapon/gun/energy/plasmapistol/proc/set_overcharge(var/new_overcharge = 1, var/mob/user = null, var/silent = 0)
 	if(new_overcharge != overcharge)
 		if(new_overcharge)
-			if(user)
+			if(user && !silent)
 				visible_message("<span class='notice'>[user.name]'s [src]'s lights brighten</span>","<span class='notice'>You activate your [src]'s overcharge</span>")
 			projectile_type = overcharge_type
 			charge_cost = overcharge_cost
@@ -58,8 +58,9 @@
 			set_light(3, 1, "66FF00")
 			burst = 1
 			fire_delay = initial(fire_delay) * 3 //triples the fire delay.
+			heat_per_shot = overheat_capacity
 		else
-			if(user)
+			if(user && !silent)
 				visible_message("<span class='notice'>[user.name]'s [src]'s lights darken</span>","<span class='notice'>You deactivate your [src]'s overcharge</span>")
 			projectile_type = initial(projectile_type)
 			overcharge = 0
@@ -68,6 +69,13 @@
 			set_light(0, 0, "66FF00")
 			burst = initial(burst)
 			fire_delay = initial(fire_delay)
+			heat_per_shot = initial(heat_per_shot)
+
+/obj/item/weapon/gun/energy/plasmapistol/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0)
+	. = ..()
+
+	//disable overcharge
+	set_overcharge(0,null,0)
 
 /obj/item/weapon/gun/energy/plasmapistol/disabled
 	desc = "A dual funtionality pistol: It fires bolts of plasma, and when overcharged is capable of emitting a small emp burst at the point of impact. This one appears to be disabled"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -98,18 +98,11 @@
 						stat("Shield Level:","[(shield_datum.shieldstrength/shield_datum.totalshields)*100]%")
 		var/obj/item/weapon/gun/gun_l = l_hand
 		var/obj/item/weapon/gun/gun_r = r_hand
-		if(istype(gun_l) && gun_l.overheat_capacity != -1)
-			gun_l.check_reset_overheat()
-			var/overheat_percent = 100
-			if(gun_l.overheat_capacity > 0)
-				overheat_percent = 100 *(1 - (gun_l.overheat_capacity/initial(gun_l.overheat_capacity)))
-			stat("[gun_l] Overheat: [overheat_percent]%")
-		if(istype(gun_r) && gun_r.overheat_capacity != -1)
-			gun_r.check_reset_overheat()
-			var/overheat_percent = 100
-			if(gun_r.overheat_capacity > 0)
-				overheat_percent = 100 *(1 - (gun_r.overheat_capacity/initial(gun_r.overheat_capacity)))
-			stat("[gun_r] Overheat: [overheat_percent]%")
+		if(istype(gun_l) && gun_l.overheat_capacity > 0)
+			stat("[gun_l] Heat: [round(100 * gun_l.heat_current / gun_l.overheat_capacity)]%")
+
+		if(istype(gun_r) && gun_r.overheat_capacity > 0)
+			stat("[gun_r] Heat: [round(100 * gun_r.heat_current / gun_r.overheat_capacity)]%")
 
 /mob/living/carbon/human/ex_act(severity)
 	if(!blinded)

--- a/code/modules/projectiles/gun_overheat.dm
+++ b/code/modules/projectiles/gun_overheat.dm
@@ -1,0 +1,84 @@
+
+/obj/item/weapon/gun
+	//Fire delay is modified by this, then used to determine the time after last firing to count as the weapon
+	//recovering from all the overheat it has accumulated
+	//Example: fire_delay 10 with a fullclear_mod of 2 means the player must wait for 20 before firing for the heat to
+	//be cleared.
+	var/overheat_fullclear_delay = 3 SECONDS
+	var/overheat_fullclear_at = 0
+	var/overheat_sfx = null
+	var/overheat_capacity = -1 //If set above -1, a weapon will decrement this counter per-shot until it hits 0.
+	var/heat_current = 0
+	var/datum/progressbar/heat_bar
+	var/heat_per_shot = 1
+
+/obj/item/weapon/gun/process()
+	world << "[src.type]/process()"
+
+	if(process_heat())
+		return
+
+	return PROCESS_KILL
+
+/obj/item/weapon/gun/proc/process_heat()
+	world << "/obj/item/weapon/gun/proc/process_heat()"
+	if(heat_current > 0)
+		//cool down slightly
+		add_heat(-1)
+
+		//are we overheated?
+		if(overheat_fullclear_at)
+			if(heat_current <= 0)
+				clear_overheat()
+				color = initial(color)
+			else
+				//flash red and white
+				if(color == "#ff0000")
+					color = "#ffff00"
+				else
+					color = "#ff0000"
+
+		//continue processing
+		return 1
+
+	//stop processing
+	return 0
+
+/obj/item/weapon/gun/proc/add_heat(var/new_val)
+	world << "/obj/item/weapon/gun/proc/add_heat([new_val])"
+	heat_current = heat_current + new_val
+
+	if(heat_current > 0)
+		if(!heat_bar)
+			heat_bar = new (src.loc, overheat_capacity, src)
+			GLOB.processing_objects.Add(src)
+		heat_bar.update(heat_current)
+
+		if(heat_current >= overheat_capacity)
+			do_overheat()
+	else
+		qdel(heat_bar)
+		heat_bar = null
+		GLOB.processing_objects.Remove(src)
+
+/obj/item/weapon/gun/proc/do_overheat()
+	overheat_fullclear_at = world.time + overheat_fullclear_delay + overheat_capacity * 0.5 SECONDS
+	var/mob/M = src.loc
+	visible_message("\icon[src] <span class = 'warning'>[M]'s [src] overheats!</span>",\
+		"\icon[src] <span class = 'warning'>Your [src] overheats!</span>",)
+	if(overheat_sfx)
+		playsound(M,overheat_sfx,100,1)
+
+/obj/item/weapon/gun/proc/clear_overheat()
+	overheat_fullclear_at = 0
+	heat_current = 0
+	if(heat_bar)
+		qdel(heat_bar)
+		heat_bar = null
+
+/obj/item/weapon/gun/proc/check_overheat()
+	if(overheat_fullclear_at)
+		to_chat(src.loc,"\icon[src] <span class='warning'>[src] clunks as you pull the trigger, \
+			it has overheated and needs to ventilate heat...</span>")
+		return 1
+	return 0

--- a/code/modules/projectiles/gun_overheat.dm
+++ b/code/modules/projectiles/gun_overheat.dm
@@ -1,19 +1,14 @@
 
 /obj/item/weapon/gun
-	//Fire delay is modified by this, then used to determine the time after last firing to count as the weapon
-	//recovering from all the overheat it has accumulated
-	//Example: fire_delay 10 with a fullclear_mod of 2 means the player must wait for 20 before firing for the heat to
-	//be cleared.
 	var/overheat_fullclear_delay = 3 SECONDS
 	var/overheat_fullclear_at = 0
 	var/overheat_sfx = null
-	var/overheat_capacity = -1 //If set above -1, a weapon will decrement this counter per-shot until it hits 0.
+	var/overheat_capacity = -1
 	var/heat_current = 0
 	var/datum/progressbar/heat_bar
 	var/heat_per_shot = 1
 
 /obj/item/weapon/gun/process()
-	world << "[src.type]/process()"
 
 	if(process_heat())
 		return
@@ -21,7 +16,6 @@
 	return PROCESS_KILL
 
 /obj/item/weapon/gun/proc/process_heat()
-	world << "/obj/item/weapon/gun/proc/process_heat()"
 	if(heat_current > 0)
 		//cool down slightly
 		add_heat(-1)
@@ -32,9 +26,9 @@
 				clear_overheat()
 				color = initial(color)
 			else
-				//flash red and white
+				//flash red and yellow
 				if(color == "#ff0000")
-					color = "#ffff00"
+					color = "#ffa500"
 				else
 					color = "#ff0000"
 
@@ -45,7 +39,6 @@
 	return 0
 
 /obj/item/weapon/gun/proc/add_heat(var/new_val)
-	world << "/obj/item/weapon/gun/proc/add_heat([new_val])"
 	heat_current = heat_current + new_val
 
 	if(heat_current > 0)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -43,6 +43,13 @@
 	return ..()
 
 /obj/item/weapon/gun/energy/process()
+	. = PROCESS_KILL
+	. = ..()
+	if(process_self_recharge())
+		return 0
+	return .
+
+/obj/item/weapon/gun/energy/proc/process_self_recharge()
 	if(self_recharge) //Every [recharge_time] ticks, recharge a shot for the cyborg
 		charge_tick++
 		if(charge_tick < recharge_time) return 0
@@ -58,12 +65,14 @@
 
 		power_supply.give(charge_cost) //... to recharge the shot
 		update_icon()
-	return 1
+		return 1
 
 /obj/item/weapon/gun/energy/consume_next_projectile()
 	if(!power_supply) return null
 	if(!ispath(projectile_type)) return null
 	if(!power_supply.checked_use(charge_cost)) return null
+	if(self_recharge)
+		GLOB.processing_objects.Add(src)
 	return new projectile_type(src)
 
 /obj/item/weapon/gun/energy/proc/get_external_power_supply()


### PR DESCRIPTION
:cl: CaelAislinn
imageadd: Adds a visual effect for plasma weapon heat now so you can tell if you're about to overheat. 
bugfix: Plasma pistol will now instantly overheat after firing an overcharge shot. It will also consume a lot more energy to use. 
experiment: Removes chatlog spam about firing a gun. 
/:cl: