### PR TITLE
Fix Embedded Grenades Causing Immortality

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -126,6 +126,8 @@
 			if(m.loc != loc)
 				mult = multiplier_non_direct
 			m.adjustFireLoss(alt_explosion_damage_max*mult)
+			m.updatehealth()
+			m.UpdateAppearance()
 		if(apply_ex_act)
 			a.ex_act(3)
 	return 1

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -48,6 +48,7 @@
 	do_alt_explosion(1)
 	if(istype(mob_containing))
 		mob_containing.contents -= src
+		mob_containing.embedded -= src
 	loc = null
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -44,9 +44,10 @@
 	var/obj/item/organ/external/head = get_organ(BP_HEAD)
 	var/mob/living/simple_animal/borer/B
 
-	for(var/I in head.implants)
-		if(istype(I,/mob/living/simple_animal/borer))
-			B = I
+	if(istype(head))
+		for(var/I in head.implants)
+			if(istype(I,/mob/living/simple_animal/borer))
+				B = I
 	if(B)
 		if(!B.ckey && ckey && B.controlling)
 			B.ckey = ckey

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -151,30 +151,31 @@
 	var/protection = blocked_mult(getarmor(null, "bomb"))
 
 	// focus most of the blast on one organ
-	var/obj/item/organ/external/take_blast = pick(organs)
-	degrade_affected_armor(b_loss,BRUTE,take_blast)
-	degrade_affected_armor(f_loss,BURN,take_blast)
-	b_loss *= protection
-	f_loss *= protection
+	if(src && src.organs)
+		var/obj/item/organ/external/take_blast = pick(organs)
+		degrade_affected_armor(b_loss,BRUTE,take_blast)
+		degrade_affected_armor(f_loss,BURN,take_blast)
+		b_loss *= protection
+		f_loss *= protection
 
-	take_blast.take_damage(b_loss * 0.7, f_loss * 0.7, used_weapon = "Explosive blast")
+		take_blast.take_damage(b_loss * 0.7, f_loss * 0.7, used_weapon = "Explosive blast")
 
-	// distribute the remaining 30% on all limbs equally (including the one already dealt damage)
-	b_loss *= 0.3
-	f_loss *= 0.3
+		// distribute the remaining 30% on all limbs equally (including the one already dealt damage)
+		b_loss *= 0.3
+		f_loss *= 0.3
 
-	var/weapon_message = "Explosive Blast"
-	for(var/obj/item/organ/external/temp in organs)
-		var/loss_val
-		if(temp.organ_tag  == BP_HEAD)
-			loss_val = 0.2
-		else if(temp.organ_tag == BP_CHEST)
-			loss_val = 0.4
-		else
-			loss_val = 0.05
-		temp.take_damage(b_loss * loss_val, f_loss * loss_val, used_weapon = weapon_message)
-		degrade_affected_armor(b_loss*loss_val,BRUTE,temp)
-		degrade_affected_armor(f_loss*loss_val,BURN,temp)
+		var/weapon_message = "Explosive Blast"
+		for(var/obj/item/organ/external/temp in organs)
+			var/loss_val
+			if(temp.organ_tag  == BP_HEAD)
+				loss_val = 0.2
+			else if(temp.organ_tag == BP_CHEST)
+				loss_val = 0.4
+			else
+				loss_val = 0.05
+			temp.take_damage(b_loss * loss_val, f_loss * loss_val, used_weapon = weapon_message)
+			degrade_affected_armor(b_loss*loss_val,BRUTE,temp)
+			degrade_affected_armor(f_loss*loss_val,BURN,temp)
 
 	if(throw_mob)
 		var/throw_in = NORTH //Just a default, in case anything breaks


### PR DESCRIPTION
In rare situations embedded plasma grenades could delete the organs list before the mob death proc(s) would run, resulting in a runtime before the mob was killed. I've added a check that the affected mob and its organs list is intact before it tries to use them.

Closes #2641 

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: bloxgate
bugfix: Embedded plasma grenades no longer result in immortality
bugfix: Plasma grenade explosions properly update mob icons
/:cl:
