### PR TITLE
Fixes mining drill runtime error

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -92,7 +92,11 @@
 			harvesting.has_resources = 0
 			harvesting.resources = null
 			resource_field -= harvesting
-			harvesting = pick(resource_field)
+			
+			if(!resource_field.len)
+				harvesting = null
+			else
+				harvesting = pick(resource_field)
 
 		if(!harvesting) return
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

```[14:02:15] Runtime in drill.dm,95: pick() from empty list
  proc name: process (/obj/machinery/mining/drill/process)
  src: the mining drill head (/obj/machinery/mining/drill)
  src.loc: the dirt (75,145,7) (/turf/simulated/floor/planet/dirt)
  call stack:
  the mining drill head (/obj/machinery/mining/drill): process()
  machinery (/datum/controller/process/machinery): internal process machinery()
  machinery (/datum/controller/process/machinery): doWork()
  machinery (/datum/controller/process/machinery): process()
  /datum/controller/processSched... (/datum/controller/processScheduler): runProcess(machinery (/datum/controller/process/machinery))```

