### PR TITLE
Making most of weapons caseless

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -13,7 +13,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 1000)
 
 	var/caliber = "357"		//determines which casings will fit
-	var/handle_casings = EJECT_CASINGS	//determines how spent casings should be handled
+	var/handle_casings = CASELESS	//determines how spent casings should be handled
 	var/ejection_angle = 90 //If we handle casings by ejecting them, which direction should we throw them? Angle between 1 to 360
 	var/load_method = SINGLE_CASING|SPEEDLOADER //1 = Single shells, 2 = box or quick loader, 3 = magazine
 	var/obj/item/ammo_casing/chambered = null

--- a/html/changelogs/example - копия.yml
+++ b/html/changelogs/example - копия.yml
@@ -1,0 +1,5 @@
+author: Terror4000rus
+delete-after: True
+changes: 
+  - tweak: "All weapons are caseless now."
+  - maptweak: "Replaced silver walls in ODP medbay with reinforced one (and painted)."

--- a/html/changelogs/terror4000rus-case.yml
+++ b/html/changelogs/terror4000rus-case.yml
@@ -1,5 +1,5 @@
 author: Terror4000rus
 delete-after: True
 changes: 
-  - tweak: "All weapons are caseless now."
+  - tweak: "Most of guns are caseless now."
   - maptweak: "Replaced silver walls in ODP medbay with reinforced one (and painted)."


### PR DESCRIPTION
Just a banch of examples:
<details>

![dreamseeker_2020-08-01_07-14-47](https://user-images.githubusercontent.com/19491666/89656463-d1670c00-d8f5-11ea-9967-c25fea36e773.png)
![dreamseeker_2020-08-01_07-13-59](https://user-images.githubusercontent.com/19491666/89656480-d6c45680-d8f5-11ea-8cfd-b594a4b8c7ff.png)
![dreamseeker_2020-08-01_07-16-51](https://user-images.githubusercontent.com/19491666/89656498-ddeb6480-d8f5-11ea-8532-f55d2481e6f0.png)
</details>

Each case - is an object. 
It moves from the gun after each fire to its turf.
It launches itself away from the shooter.
It hits objects around while in fly - it also adding more logs in chat. Useless logs.
It stays at the floor for the whole game.
It moves around with atmosphere. With every light airflow, every +60 cases from one MA5 magazine at tiles will move around, because they aren't bigger than a paper.
It can be picked up by accident in middle of fight, which is annoying.
As the server's main orientation is around combat, there shitton of cases every round.

It adds more immersion to combat. 
...Yes. But there is too much cases around - it makes area just unpleasant to stay (at least, for me).

They should be removed.