### PR TITLE
Brings the M7S more in-line with H3 ODST gameplay

### DIFF
--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -230,7 +230,7 @@
 					/obj/item/ammo_magazine/m762_ap/MA5B/TTR = 0,
 					/obj/item/ammo_magazine/m762_ap/M392 = 0,
 					/obj/item/ammo_magazine/m95_sap/br55 = 0,
-					/obj/item/ammo_magazine/m5 = 0,
+					/obj/item/ammo_magazine/m5_s = 0,
 					/obj/item/ammo_magazine/m5/rubber = 0,
 					/obj/item/ammo_box/shotgun = 0,
 					/obj/item/ammo_box/shotgun/slug = 0,

--- a/code/modules/halo/weapons/ammo.dm
+++ b/code/modules/halo/weapons/ammo.dm
@@ -298,6 +298,18 @@
 	max_ammo = 60
 	multiple_sprites = 1
 
+/obj/item/ammo_magazine/m5_s
+    name = "magazine (5mm) SOCOM M443 Caseless FMJ"
+    desc = "5x23mm M443 Caseless Full Metal Jacket magazine. Fun sized with no pesky casing!"
+    icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
+    icon_state = "m7mag"
+    mag_type = MAGAZINE
+    ammo_type = /obj/item/ammo_casing/m5
+    matter = list(DEFAULT_WALL_MATERIAL = 600)
+    caliber = "5mm"
+    max_ammo = 48
+    multiple_sprites = 1
+
 /obj/item/ammo_magazine/m5/rubber
 	name = "magazine (5mm) M443 Caseless Rubber"
 	desc = "Rubber bullets for riot suppression."

--- a/code/modules/halo/weapons/smg.dm
+++ b/code/modules/halo/weapons/smg.dm
@@ -46,7 +46,6 @@
 	desc = "The M7S is a special operations variant of the M7 submachine gun with inbuilt suppressor and host of other attachments. Takes 5mm calibre magazines."
 	silenced = 1
 	is_heavy = 1
-	accuracy = -1
 	scoped_accuracy = 1
 	fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
 	//fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'

--- a/code/modules/halo/weapons/smg.dm
+++ b/code/modules/halo/weapons/smg.dm
@@ -42,14 +42,43 @@
 	. = ..()
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced
-	name = "M7S submachine gun"
-	desc = "The M7S is a special operations variant of the M7 submachine gun with inbuilt suppressor and host of other attachments. Takes 5mm calibre magazines."
-	silenced = 1
-	is_heavy = 1
-	icon_state = "m7smgs"
-	item_state = "m7s"
-	fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
-	//fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
+    name = "M7S submachine gun"
+    desc = "The M7S is a special operations variant of the M7 submachine gun with inbuilt suppressor and host of other attachments. Takes 5mm calibre magazines."
+    silenced = 1
+    is_heavy = 1
+    accuracy = -1
+    scoped_accuracy = 1
+    icon_state = "m7smgs"
+    item_state = "m7s"
+    fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
+    //fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
+caliber = "5mm"
+    slot_flags = SLOT_BACK|SLOT_BELT
+    reload_sound = 'code/modules/halo/sounds/SMG_Reload_New.wav'
+    load_method = MAGAZINE
+    magazine_type = /obj/item/ammo_magazine/m5
+    handle_casings = CASELESS
+    burst = 4
+    burst_delay = 1.5
+    dispersion = list(0.1, 0.3, 0.65, 1.0)
+    one_hand_penalty = 2
+    allowed_magazines = list(/obj/item/ammo_magazine/m5_s, /obj/item/ammo_magazine/m5/rubber)
+    w_class = ITEM_SIZE_NORMAL
+    hud_bullet_row_num = 20
+    wielded_item_state = "m7-wielded"
+    item_icons = list(
+        slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi',
+        slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
+        slot_back_str = 'code/modules/halo/weapons/icons/Back_Weapons.dmi',
+        slot_s_store_str = 'code/modules/halo/weapons/icons/Armor_Weapons.dmi',
+        slot_belt_str = 'code/modules/halo/weapons/icons/Belt_Weapons.dmi',
+        )
+/obj/item/weapon/gun/projectile/m7_smg/silenced/verb/scope()
+    set category = "Weapon"
+    set name = "Use Scope"
+    set popup_menu = 1
+
+    toggle_scope(usr, 2.0)
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced/update_icon()
 	if(ammo_magazine)

--- a/code/modules/halo/weapons/smg.dm
+++ b/code/modules/halo/weapons/smg.dm
@@ -47,6 +47,7 @@
 	silenced = 1
 	is_heavy = 1
 	scoped_accuracy = 1
+	magazine_type = /obj/item/ammo_magazine/m5_s
 	fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
 	//fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
 	dispersion = list(0.1, 0.3, 0.65, 1.0)

--- a/code/modules/halo/weapons/smg.dm
+++ b/code/modules/halo/weapons/smg.dm
@@ -55,7 +55,7 @@
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced/verb/scope()
 	set category = "Weapon"
-	set name = "Use Scope"
+	set name = "Use Scope (Sidearm)"
 	set popup_menu = 1
 
 	toggle_scope(usr, 2.0)

--- a/code/modules/halo/weapons/smg.dm
+++ b/code/modules/halo/weapons/smg.dm
@@ -42,43 +42,24 @@
 	. = ..()
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced
-    name = "M7S submachine gun"
-    desc = "The M7S is a special operations variant of the M7 submachine gun with inbuilt suppressor and host of other attachments. Takes 5mm calibre magazines."
-    silenced = 1
-    is_heavy = 1
-    accuracy = -1
-    scoped_accuracy = 1
-    icon_state = "m7smgs"
-    item_state = "m7s"
-    fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
-    //fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
-caliber = "5mm"
-    slot_flags = SLOT_BACK|SLOT_BELT
-    reload_sound = 'code/modules/halo/sounds/SMG_Reload_New.wav'
-    load_method = MAGAZINE
-    magazine_type = /obj/item/ammo_magazine/m5
-    handle_casings = CASELESS
-    burst = 4
-    burst_delay = 1.5
-    dispersion = list(0.1, 0.3, 0.65, 1.0)
-    one_hand_penalty = 2
-    allowed_magazines = list(/obj/item/ammo_magazine/m5_s, /obj/item/ammo_magazine/m5/rubber)
-    w_class = ITEM_SIZE_NORMAL
-    hud_bullet_row_num = 20
-    wielded_item_state = "m7-wielded"
-    item_icons = list(
-        slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi',
-        slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
-        slot_back_str = 'code/modules/halo/weapons/icons/Back_Weapons.dmi',
-        slot_s_store_str = 'code/modules/halo/weapons/icons/Armor_Weapons.dmi',
-        slot_belt_str = 'code/modules/halo/weapons/icons/Belt_Weapons.dmi',
-        )
-/obj/item/weapon/gun/projectile/m7_smg/silenced/verb/scope()
-    set category = "Weapon"
-    set name = "Use Scope"
-    set popup_menu = 1
+	name = "M7S submachine gun"
+	desc = "The M7S is a special operations variant of the M7 submachine gun with inbuilt suppressor and host of other attachments. Takes 5mm calibre magazines."
+	silenced = 1
+	is_heavy = 1
+	accuracy = -1
+	scoped_accuracy = 1
+	fire_sound = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
+	//fire_sound_burst = 'code/modules/halo/sounds/SMG_SOCOM_Fire.wav'
+	dispersion = list(0.1, 0.3, 0.65, 1.0)
+	one_hand_penalty = 2
+	allowed_magazines = list(/obj/item/ammo_magazine/m5_s, /obj/item/ammo_magazine/m5/rubber)
 
-    toggle_scope(usr, 2.0)
+/obj/item/weapon/gun/projectile/m7_smg/silenced/verb/scope()
+	set category = "Weapon"
+	set name = "Use Scope"
+	set popup_menu = 1
+
+	toggle_scope(usr, 2.0)
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced/update_icon()
 	if(ammo_magazine)


### PR DESCRIPTION
Gives the M7S a scope and tweaks it's performance to accomodate this. Also lowers magazine size count and adds new 48 round magazines to the ODST weapons vendor.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: BladeburstNINJA
rscadd: Gives M7S a scope and adds 48 round 5mm SOCOM magazines to the ODST armory.
rscdel: Removes 60 round 5mm magazines from the ODST weapons vendor.
/:cl:
