### PR TITLE
m7 fix

### DIFF
--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -26,7 +26,7 @@
 					/obj/item/ammo_magazine/ma5b/m118 = 0,
 					/obj/item/ammo_magazine/m392/m120 = 0,
 					/obj/item/ammo_magazine/br55/m634 = 0,
-					/obj/item/ammo_magazine/m7 = 0,
+					/obj/item/ammo_magazine/m7/m443 = 0,
 					/obj/item/ammo_magazine/m7/rubber = 0,
 					/obj/item/ammo_box/shotgun = 0,
 					/obj/item/ammo_box/shotgun/slug = 0,


### PR DESCRIPTION
#2791 

M7 fired just fine locally, but the magazine had the wrong path in the gunvendors.dm file