### PR TITLE
Fixes ODST Officer Ranks being enlisted

### DIFF
--- a/code/modules/halo/unsc/jobs/ODST.dm
+++ b/code/modules/halo/unsc/jobs/ODST.dm
@@ -24,12 +24,12 @@
 	spawn_positions = 1
 	is_whitelisted = 1
 	economic_modifier = 1.5
-	outfit_type = /decl/hierarchy/outfit/job/unsc/odst/e5
+	outfit_type = /decl/hierarchy/outfit/job/unsc/odst/o1
 	alt_titles = list(\
 		"ODST Sergeant",\
-		"ODST Staff Sergeant" = /decl/hierarchy/outfit/job/unsc/odst/e6,\
-		"ODST Gunnery Sergeant" = /decl/hierarchy/outfit/job/unsc/odst/e7,\
-		"ODST Master Sergeant" = /decl/hierarchy/outfit/job/unsc/odst/e8)
+		"ODST Lieutenant" = /decl/hierarchy/outfit/job/unsc/odst/o1,\
+		"ODST Captain" = /decl/hierarchy/outfit/job/unsc/odst/o2,\
+		"ODST Major" = /decl/hierarchy/outfit/job/unsc/odst/o3)
 	access = list(\
 		access_unsc,\
 		access_unsc_armoury,\

--- a/code/modules/halo/unsc/jobs/ODST_outfits.dm
+++ b/code/modules/halo/unsc/jobs/ODST_outfits.dm
@@ -15,20 +15,20 @@
 		/obj/item/clothing/accessory/rank/marine/enlisted/e5,\
 		/obj/item/clothing/accessory/badge/tags)
 
-/decl/hierarchy/outfit/job/unsc/odst/e6
-	name = "ODST Staff Sergeant"
+/decl/hierarchy/outfit/job/unsc/odst/o1
+	name = "ODST Lieutenant"
 	starting_accessories = list(\
-		/obj/item/clothing/accessory/rank/marine/enlisted/e6,\
+		/obj/item/clothing/accessory/rank/marine/officer/o2,\
 		/obj/item/clothing/accessory/badge/tags)
 
-/decl/hierarchy/outfit/job/unsc/odst/e7
-	name = "ODST Gunnery Sergeant"
+/decl/hierarchy/outfit/job/unsc/odst/o2
+	name = "ODST Captain"
 	starting_accessories = list(\
-		/obj/item/clothing/accessory/rank/marine/enlisted/e7,\
+		/obj/item/clothing/accessory/rank/marine/officer/o3,\
 		/obj/item/clothing/accessory/badge/tags)
 
-/decl/hierarchy/outfit/job/unsc/odst/e8
-	name = "ODST Master Sergeant"
+/decl/hierarchy/outfit/job/unsc/odst/o3
+	name = "ODST Major"
 	starting_accessories = list(\
-		/obj/item/clothing/accessory/rank/marine/enlisted/e8,\
+		/obj/item/clothing/accessory/rank/marine/officer/o4,\
 		/obj/item/clothing/accessory/badge/tags)


### PR DESCRIPTION
Makes the ODST Officer Ranks the actual Officer ranks and not enlisted

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Joe4444
bugfix: Fixes the ranks assigned to ODST Officer alt titles
rscdel: Fixes the rank pins given to ODST Officer alt titles
/:cl:
