### PR TITLE
ERT Loadouts [WIP]

### DIFF
--- a/code/modules/halo/insurrection/innie_outfits.dm
+++ b/code/modules/halo/insurrection/innie_outfits.dm
@@ -75,3 +75,181 @@
 		W.rank = "Colonist"
 		W.assignment = "Colonist"
 		W.update_name()
+
+/decl/hierarchy/outfit/job/geminus_innie/ert
+	name = "Insurrectionist ERT"
+
+	head = /obj/item/clothing/head/helmet/innie/medium/brown
+	l_hand = /obj/item/weapon/gun/projectile/ma3_ar
+	r_hand = /obj/item/weapon/storage/box/ma3_m118
+	glasses = /obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/balaclava/tactical
+	suit = /obj/item/clothing/suit/storage/innie/medium/brown
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/innie/jumpsuit
+	shoes = /obj/item/clothing/shoes/innie_boots/medium/brown
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/x52/x52gloves
+	pda_slot = null
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/geminus_innie/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()
+
+/decl/hierarchy/outfit/job/geminus_innie/medic/ert
+	name = "Insurrectionist Medic ERT"
+
+	head = /obj/item/clothing/head/helmet/innie/medium/white
+	l_hand = /obj/item/weapon/gun/projectile/ma37_ar
+	r_hand = /obj/item/weapon/storage/box/ma37_m118
+	glasses = /obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/balaclava/tactical
+	suit = /obj/item/clothing/suit/storage/innie/medium/white
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/innie/jumpsuit
+	shoes = /obj/item/clothing/shoes/innie_boots/medium/white
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/x52/x52gloves
+	pda_slot = null
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/geminus_innie/medic/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()
+
+/decl/hierarchy/outfit/job/geminus_innie_leader/ert
+	name = "Insurrectionist Captain ERT"
+
+	head = /obj/item/clothing/head/helmet/innie/heavy/vblue
+	l_hand = /obj/item/weapon/gun/projectile/br55
+	r_hand = /obj/item/weapon/storage/box/br55_m634
+	glasses =/obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/balaclava/tactical
+	suit = /obj/item/clothing/suit/storage/innie/heavy/blue
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/innie/jumpsuit
+	shoes = /obj/item/clothing/shoes/innie_boots/medium/blue
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/x52/x52gloves
+	pda_slot = null
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/geminus_innie_leader/ert(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()
+
+/decl/hierarchy/outfit/job/colonist/geminus_innie_orion_defector/ert
+	name = "Insurrectionist Orion Defector ERT"
+
+	head = /obj/item/clothing/head/helmet/innie/urfdefector
+	l_hand = /obj/item/weapon/gun/projectile/m7_smg/silenced
+	r_hand = /obj/item/weapon/storage/box/m7_m443/rnd48
+	glasses = /obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/gas/soebalaclava
+	suit = /obj/item/clothing/suit/storage/innie/urfdefector
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/psysuit/theta
+	shoes = /obj/item/clothing/shoes/marine/orion
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/marine/orion
+	pda_slot = null
+	back = /obj/item/weapon/storage/backpack/odst/regular
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/colonist/geminus_innie_orion_defector/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()
+
+
+/decl/hierarchy/outfit/job/innie_colossus/ert
+	name = "Insurrectionist Heavy ERT"
+
+	head = /obj/item/clothing/head/bomb_hood/security/colossus
+	l_hand = /obj/item/weapon/gun/projectile/br55
+	r_hand = /obj/item/weapon/storage/box/br55_m634
+	glasses = /obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/gas/soebalaclava
+	suit = /obj/item/clothing/suit/bomb_suit/security/colossus
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/psysuit/theta
+	shoes = /obj/item/clothing/shoes/innie_boots/medium/black
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/marine/orion
+	pda_slot = null
+	back = /obj/item/weapon/storage/backpack/odst/regular
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/innie_colossus/ert(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()
+
+/decl/hierarchy/outfit/job/zeal_team/ert
+	name = "Zeal Team 6 ERT"
+
+	head = /obj/item/clothing/head/helmet/zeal
+	l_hand = /obj/item/weapon/gun/projectile/br55
+	r_hand = /obj/item/weapon/storage/box/br55_m634
+	glasses = /obj/item/clothing/glasses/hud/tactical
+	mask = /obj/item/clothing/mask/gas/soebalaclava
+	suit = /obj/item/clothing/suit/justice/zeal
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	uniform = /obj/item/clothing/under/psysuit/theta
+	shoes = /obj/item/clothing/shoes/innie_boots/light/brown
+	l_ear = /obj/item/device/radio/headset/insurrection
+	gloves = /obj/item/clothing/gloves/marine/orion
+	pda_slot = null
+	back = /obj/item/weapon/storage/backpack/odst/regular
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/zeal_team_rifleman/ert(mob/living/carbon/human/H, rank, assignment)
+	. = ..()
+
+	var/obj/item/weapon/card/id/W = .
+	if(W)
+		W.rank = "Colonist"
+		W.assignment = "Colonist"
+		W.update_name()

--- a/code/modules/halo/insurrection/innie_outfits.dm
+++ b/code/modules/halo/insurrection/innie_outfits.dm
@@ -154,7 +154,7 @@
 
 	flags = 0
 
-/decl/hierarchy/outfit/job/geminus_innie_leader/ert(mob/living/carbon/human/H, rank, assignment)
+/decl/hierarchy/outfit/job/geminus_innie_leader/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
 	. = ..()
 
 	var/obj/item/weapon/card/id/W = .
@@ -168,7 +168,7 @@
 
 	head = /obj/item/clothing/head/helmet/innie/urfdefector
 	l_hand = /obj/item/weapon/gun/projectile/m7_smg/silenced
-	r_hand = /obj/item/weapon/storage/box/m7_m443/rnd48
+	r_hand = /obj/item/weapon/storage/box/rnd48
 	glasses = /obj/item/clothing/glasses/hud/tactical
 	mask = /obj/item/clothing/mask/gas/soebalaclava
 	suit = /obj/item/clothing/suit/storage/innie/urfdefector
@@ -215,7 +215,7 @@
 
 	flags = 0
 
-/decl/hierarchy/outfit/job/innie_colossus/ert(mob/living/carbon/human/H, rank, assignment)
+/decl/hierarchy/outfit/job/innie_colossus/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
 	. = ..()
 
 	var/obj/item/weapon/card/id/W = .
@@ -245,7 +245,7 @@
 
 	flags = 0
 
-/decl/hierarchy/outfit/job/zeal_team_rifleman/ert(mob/living/carbon/human/H, rank, assignment)
+/decl/hierarchy/outfit/job/zeal_team_rifleman/ert/equip_id(mob/living/carbon/human/H, rank, assignment)
 	. = ..()
 
 	var/obj/item/weapon/card/id/W = .

--- a/code/modules/halo/insurrection/soe_outfits.dm
+++ b/code/modules/halo/insurrection/soe_outfits.dm
@@ -42,3 +42,59 @@
 
 	flags = 0
 
+/decl/hierarchy/outfit/job/soe_commando/ert
+	name = "SOE Commando ERT"
+
+	//Actual Commando gear is spawned on their ship.
+	head = /obj/item/clothing/head/helmet/urfc
+	l_hand = /obj/item/weapon/gun/projectile/ma5b_ar
+	r_hand = /obj/item/weapon/storage/box/ma5b_m118
+	suit = /obj/item/clothing/suit/armor/special/urfc
+	gloves = /obj/item/clothing/gloves/soegloves/urfc
+	l_ear = /obj/item/device/radio/headset/commando
+	uniform = /obj/item/clothing/under/urfc_jumpsuit
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	shoes = /obj/item/clothing/shoes/magboots/urfc
+	starting_accessories = list(/obj/item/clothing/accessory/holster/thigh)
+	back = /obj/item/weapon/storage/backpack/cmdo
+	l_pocket = /obj/item/weapon/storage/firstaid/unsc
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/soe_commando_officer/ert
+	name = "SOE Commando Officer ERT"
+
+	head = /obj/item/clothing/head/helmet/urfc/squadleader
+
+	suit = /obj/item/clothing/suit/armor/special/urfc/squadleader
+	gloves = /obj/item/clothing/gloves/soegloves/urfc
+	l_ear = /obj/item/device/radio/headset/commando
+	uniform = /obj/item/clothing/under/urfc_jumpsuit/jumpsuit
+	shoes = /obj/item/clothing/shoes/magboots/urfc
+	back = /obj/item/weapon/storage/backpack/cmdo
+	mask = /obj/item/clothing/mask/gas/soebalaclava
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	starting_accessories = list(/obj/item/clothing/accessory/holster/thigh)
+	l_pocket = /obj/item/weapon/gun/projectile/heavysniper/handgonne
+	r_pocket = /obj/item/weapon/storage/firstaid/unsc
+
+	flags = 0
+
+/decl/hierarchy/outfit/job/soe_commando_captain/ert
+	name = "SOE Captain ERT"
+
+	head = /obj/item/clothing/head/helmet/urfccommander
+	suit = /obj/item/clothing/suit/armor/special/urfc/squadleader
+	gloves = /obj/item/clothing/gloves/soegloves/urfc
+	l_hand = /obj/item/weapon/gun/projectile/shotgun/soe
+	r_hand = /obj/item/ammo_magazine/kv32
+	l_ear = /obj/item/device/radio/headset/commando
+	uniform = /obj/item/clothing/under/urfc_jumpsuit/commander
+	shoes = /obj/item/clothing/shoes/magboots/urfc
+	belt = /obj/item/weapon/storage/belt/marine_ammo
+	back = /obj/item/weapon/storage/backpack/cmdo
+	l_pocket = /obj/item/ammo_magazine/kv32
+	r_pocket = /obj/item/ammo_magazine/kv32
+
+	flags = 0

--- a/code/modules/halo/weapons/M7.dm
+++ b/code/modules/halo/weapons/M7.dm
@@ -93,6 +93,10 @@
 	name = "box of M7 5mm M443 magazines"
 	startswith = list(/obj/item/ammo_magazine/m7/m443 = 7)
 
+/obj/item/weapon/storage/box/rnd48
+	name = "box of M7 5mm M443 magazines"
+	startswith = list(/obj/item/ammo_magazine/m7/m443/rnd48 = 7)
+
 //M443 Rubber Ammunition
 
 /obj/item/ammo_magazine/m7/rubber


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Adds ERT loadouts that automatically come with weapons and equipment suited for battle, allowing admins to quickly make a team of soldiers of a specific faction. Currently WIP and only has insurrectionist loadouts.


<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Guprei
rscadd: Adds SOE ERT Loadouts.
rscadd: Adds Insurrectionist ERT Loadouts.
/:cl:
