### PR TITLE
Add VSC launch.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ __pycache__
 # ignore config, but not subdirs
 config/*
 !config/*/
+
+#VS Code files
 .vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 # ignore config, but not subdirs
 config/*
 !config/*/
+.vscode/launch.json


### PR DESCRIPTION
Some people prefer using Visual Studio Code over Dream Maker (or whatever software) and part of its design is attaching a debugger ingame; this adds it to the gitignore so there are no conflicts.

Changelog not required.