### PR TITLE
Input bar changes colors depending on status

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -295,7 +295,7 @@ macro "borghotkeymode"
 macro "macro"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
 		is-disabled = false
 	elem 
 		name = "CENTER+REP"
@@ -521,7 +521,7 @@ macro "macro"
 macro "hotkeymode"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true\""
+		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5\""
 		is-disabled = false
 	elem 
 		name = "CENTER+REP"


### PR DESCRIPTION
The input bar will now be white when Hotkey mode is enabled and the normal pink color when it is disabled. Makes it much more clear what mode you're in. The colors are taken from what most others servers do (as well as the cyborg code in the repository) - #F0F0F0 and #D3B5B5.

:cl: Shadowtail117
tweak: The input bar will now change colors depending on whether or not Hotkey mode is enabled. White is on, pink is off.
/:cl: