### PR TITLE
Add autopunctuation

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -227,6 +227,13 @@
 /proc/capitalize(var/t as text)
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
+//Adds a period to a message that doesn't already have valid punctuation.
+/proc/autopunctuation(var/t as text)
+	. = t
+	var/end = copytext(t, length(t))
+	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
+		. += "."
+
 //This proc strips html properly, remove < > and all text between
 //for complete text sanitizing should be used sanitize()
 /proc/strip_html_properly(var/input)

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -89,13 +89,13 @@
 	return scrambled_text
 
 /datum/language/proc/format_message(message, verb)
-	return "[verb], <span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
+	return "[verb], <span class='message'><span class='[colour]'>\"[autopunctuation(capitalize(message))]\"</span></span>"
 
 /datum/language/proc/format_message_plain(message, verb)
-	return "[verb], \"[capitalize(message)]\""
+	return "[verb], \"[autopunctuation(capitalize(message))]\""
 
 /datum/language/proc/format_message_radio(message, verb)
-	return "[verb], <span class='[colour]'>\"[capitalize(message)]\"</span>"
+	return "[verb], <span class='[colour]'>\"[autopunctuation(capitalize(message))]\"</span>"
 
 /datum/language/proc/get_talkinto_msg_range(message)
 	// if you yell, you'll be heard from two tiles over instead of one


### PR DESCRIPTION
Adds a period to any `say` message that doesn't already have some form of punctuation. Still trying to get the `me` verb to follow suit but having some trouble; figured I would put the PR up anyway.

Personally, I think this helps maintain an RP atmosphere as complete sentences with punctuation are a lot more immersive than ones without, even if the player isn't intending to use them.

:cl: Shadowtail117
tweak: Spoken messages will automatically have a period appended to them if you don't use punctuation.
/:cl: