### PR TITLE
Say/me inputs are now escapable

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -6,7 +6,7 @@
 	set category = "IC"
 	return
 
-/mob/verb/say_verb(message as text)
+/mob/verb/say_verb(message as text|null)
 	set name = "Say"
 	set category = "IC"
 
@@ -14,7 +14,7 @@
 		qdel(typing_indicator)
 	usr.say(message)
 
-/mob/verb/me_verb(message as text)
+/mob/verb/me_verb(message as text|null)
 	set name = "Me"
 	set category = "IC"
 

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -50,7 +50,7 @@ I IS TYPIN'!'
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","say (text)") as text
+	var/message = input("","say (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		say_verb(message)
@@ -60,7 +60,7 @@ I IS TYPIN'!'
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","me (text)") as text
+	var/message = input("","me (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		me_verb(message)


### PR DESCRIPTION
QoL change, you can now press the Escape key to close a say/me input similar to the OOC input.

:cl: Shadowtail117
tweak: You can now press the Escape key to close out a say/me input box.
/:cl: