### PR TITLE
It is now permanently 2540

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -48,7 +48,7 @@ var/next_station_date_change = 1 DAY
 	if(!station_date || update_time)
 		var/extra_days = round(station_time_in_ticks / (1 DAY)) DAYS
 		var/timeofday = world.timeofday + extra_days
-		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+544)) + "-" + time2text(timeofday, "MM-DD")
+		station_date = "2540" + "-" + time2text(timeofday, "MM-DD")
 	return station_date
 
 /proc/time_stamp()


### PR DESCRIPTION
To keep the date in time with the server's lore, it is now permanently today's date, 2540. (Alternatively, I can change it so that 2021 will be 2541 if we don't want a static year.)

:cl: Shadowtail117
tweak: The year is now permanently 2540.
/:cl: