### PR TITLE
Add special reloads for projectile weapons

### DIFF
--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -21,6 +21,7 @@
 	accuracy = 1
 	wielded_item_state = "carbine-wielded"
 	advanced_covenant = 1
+	speed_reload_time = -1 //already auto-ejects
 	matter = list("nanolaminate" = 1)
 	hud_bullet_row_num = 9
 	hud_bullet_reffile = 'code/modules/halo/icons/hud_display/hud_bullet_7x8.dmi'


### PR DESCRIPTION
Players can now perform special reloads for weapons with magazines (e.g., the assault rifle or the magnum, or technically needle weaponry). Tactical reloads take 1.5 seconds to perform and will exchange the magazine in your hand for the one in the gun (it will put the old mag directly into your hand), allowing you to save a half-full clip. Speed reloads are only 1 second and drop the old magazine on the floor, useful for quickly getting rid of a spent magazine.

Obviously, not every gun should be able to be tactically reloaded, so all projectile-based weapons have two new variables: `special_reload_time` and `tactical_reload_time`. These control the amount of time, in seconds, that reload for the gun will take and defaults to the above values. Set them to -1 to disable special reloads for that weapon. I've disallowed the plasma carbine from speed reloads since that has its own magazine system separate from the default code, but other unconventional weapons like needlers and rocket launchers have it. I'm not well-versed in every weapon and how feasible this would be (especially UNSC weapons) so, this is something that can easily be changed.

Overall this allows for much more fluid magazine handling instead of having to empty the gun, drop the old magazine, click on the new magazine, then click on the gun (which can be difficult to do in a stressful situation). The Weapons Expertise skill was not factored into this since skills appear largely vestigial.

:cl: Shadowtail117
rscadd: You can now tactically reload a projectile weapon by clicking on it with an appropriate magazine while on grab intent.
rscadd: You can now speed reload a projectile weapon by clicking on it with an appropriate magazine while on harm intent.
/:cl: