### PR TITLE
Fix flamethrowers heating up the atmosphere

### DIFF
--- a/code/modules/halo/weapons/flamethrowers.dm
+++ b/code/modules/halo/weapons/flamethrowers.dm
@@ -64,7 +64,6 @@
 	..()
 	var/impacted_loc = loc
 	if(!ismob(loc))
-		new /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel(loc)
 		new /obj/effect/fire/noheat(impacted_loc)
 
 /obj/item/projectile/bullet/fire/launch_from_gun(var/atom/target)


### PR DESCRIPTION
Turns out the flamethrower fuel that gets spewed on the ground is responsible for the fire (through means of which I do not yet know). Removing it fixed the issue, and now even in an enclosed environment neither you being on fire nor the flamethrower itself will heat up the room.

:cl: Shadowtail117
bugfix: Hellbringer flamethrowers will no longer heat up the atmosphere.
/:cl: