### PR TITLE
Secondary heart fix

### DIFF
--- a/code/modules/halo/covenant/species/sangheili/organs.dm
+++ b/code/modules/halo/covenant/species/sangheili/organs.dm
@@ -2,11 +2,12 @@
 //Organ Defines + misc//
 
 /obj/item/organ/internal/heart_secondary
-	name = "Secondary Heart"
+	name = "secondary heart"
 	parent_organ = "chest"
 	organ_tag = "second heart"
 	icon_state = "heart-on"
 	min_broken_damage = 30
+	max_damage = 45
 	var/useheart = 0
 
 /obj/item/organ/internal/heart_secondary/process()
@@ -20,6 +21,9 @@
 			damage = heart.damage
 			heart.damage = 0
 			useheart = 0
+			heart.status &= ~ORGAN_DEAD
+			owner.resuscitate()
+			to_chat(owner, "<span class='notice'>You feel a tightness in your chest as your secondary heart resumes circulation!</span>")
 		return
 	for(var/obj/item/organ/external/e in owner.bad_external_organs)
 		if(!e.clamped() && prob(SANGHEILI_BLEEDBLOCK_CHANCE))


### PR DESCRIPTION
Fixes the secondary heart to actually resuscitate you and gives the player a message indicating what has happened. Also changed the name to be in line with naming standards and the maximum health to be the same as the primary heart.

:cl: Shadowtail117
bugfix: Sangheili's secondary hearts will now work as advertised and revive you should your primary heart stop.
/:cl: