### PR TITLE
Add executions

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1804,6 +1804,7 @@
 #include "code\modules\halo\misc\comms_bypass_key.dm"
 #include "code\modules\halo\misc\conversion_contracts.dm"
 #include "code\modules\halo\misc\custom_explosion.dm"
+#include "code\modules\halo\misc\executions.dm"
 #include "code\modules\halo\misc\explosion_cratering.dm"
 #include "code\modules\halo\misc\faction_banner.dm"
 #include "code\modules\halo\misc\faction_whitelist.dm"

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -8,6 +8,12 @@
 		..()
 	return
 
+/obj/item/weapon/attack(mob/living/M, mob/living/user, target_zone)
+	if(user.a_intent == I_GRAB && can_execute(user, M) && M.lying)
+		do_execute(user, M)
+		return
+	. = ..()
+	
 /obj/item/weapon/handle_shield(var/mob/user, var/damage, var/atom/dam_source = null, var/mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	var/obj/item/damage_source = dam_source
 	if(isnull(damage_source))

--- a/code/modules/halo/covenant/species/sangheili/clothing.dm
+++ b/code/modules/halo/covenant/species/sangheili/clothing.dm
@@ -165,6 +165,11 @@
 	slot_r_hand_str = "en_dag_r_hand" )
 	hitsound = 'code/modules/halo/sounds/Energyswordhit.ogg'
 
+/obj/item/weapon/melee/energy/elite_sword/g_dagger/can_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	active = 1
+	. = ..()
+	active = initial(active)
+
 /obj/item/weapon/melee/energy/elite_sword/g_dagger/New(var/obj/created_by)
 	.=..()
 	creator_dagger = created_by

--- a/code/modules/halo/misc/executions.dm
+++ b/code/modules/halo/misc/executions.dm
@@ -1,0 +1,44 @@
+#define EXECUTION_TIME 2 SECONDS
+
+/obj/item/weapon
+    var/executions_allowed = FALSE
+    var/list/start_execute_messages = list(BP_CHEST = "\The USER prepares to execute \the VICTIM with \the WEAPON!")
+    var/list/finish_execute_messages = list(BP_CHEST = "\The USER executes \the VICTIM with \the WEAPON!")
+
+//Make sure the weapon can execute, the victim isn't dead, there are valid messages for this zone, and the victim has that body part.
+/obj/item/weapon/proc/can_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+    return executions_allowed && victim.stat != DEAD && start_execute_messages[user.zone_sel.selecting] && victim.get_organ(user.zone_sel.selecting)
+
+//Returns true if we successfully executed, false if we were interrupted.
+/obj/item/weapon/proc/do_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+    var/zone = user.zone_sel.selecting
+
+    var/startmessage = start_execute_messages[zone]
+    startmessage = replacetext(startmessage, "USER", user.name)
+    startmessage = replacetext(startmessage, "VICTIM", victim.name)
+    startmessage = replacetext(startmessage, "WEAPON", src.name)
+
+    if(user.loc != victim.loc)
+        user.Move(victim.loc)
+    user.visible_message("<span class='danger'>[startmessage]</span>")
+
+    if(!do_after(user, EXECUTION_TIME, victim))
+        return FALSE
+
+    var/execmessage = finish_execute_messages[zone]
+    execmessage = replacetext(execmessage, "USER", user.name)
+    execmessage = replacetext(execmessage, "VICTIM", victim.name)
+    execmessage = replacetext(execmessage, "WEAPON", src.name)
+
+    user.visible_message("<span class='danger'>[execmessage]</span>")
+    victim.next_scream_at = world.time + 1
+    victim.emote("painscream")
+    playsound(loc, hitsound, 100)
+    victim.apply_damage(150, damtype, zone, 0, src.damage_flags(), src)
+    victim.visible_message("<span class='danger'><i>[victim] briefly struggles before seizing up and falling limp...</i></span>")
+    var/obj/item/organ/internal/brain/B = victim.internal_organs_by_name[BP_BRAIN]
+    if(B)
+        B.die()
+    return TRUE
+
+#undef EXECUTION_TIME

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -30,6 +30,11 @@
 
 	unacidable = 1
 
+	executions_allowed = TRUE
+	start_execute_messages  = list(BP_CHEST = "\The USER prepares to run \the VICTIM through with \the WEAPON!", BP_HEAD = "\The USER steps over \the VICTIM and winds up their arm, holding \the WEAPON!")
+	finish_execute_messages = list(BP_CHEST = "\The USER runs \the VICTIM through with \the WEAPON!", BP_HEAD = "\The USER slices \the VICTIM's head clean off with \the WEAPON!")
+	var/decapitate = TRUE
+
 /obj/item/weapon/melee/energy/elite_sword/New()
 	. = ..()
 	verbs += /obj/item/weapon/melee/energy/elite_sword/proc/enable_failsafe
@@ -59,6 +64,17 @@
 	if(mob.species.type in ESWORD_LEAP_FAR_SPECIES)
 		return 4
 	return lunge_dist
+
+/obj/item/weapon/melee/energy/elite_sword/can_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	if(!active)
+		return FALSE
+	return ..()
+	
+/obj/item/weapon/melee/energy/elite_sword/do_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	if(!..())
+		return
+	if(user.zone_sel.selecting == BP_HEAD && decapitate)
+		victim.get_organ(BP_HEAD)?.droplimb() //Decapitate them
 
 /obj/item/weapon/melee/energy/elite_sword/proc/change_misc_variables(var/deactivate = 0)
 	if(deactivate)
@@ -133,6 +149,9 @@
 	sharp = 0
 
 	lunge_dist = 2
+	start_execute_messages  = list(BP_CHEST = "\The USER prepares to run \the VICTIM through with \the WEAPON!", BP_HEAD = "\The USER steps over \the VICTIM and winds up their arm, holding \the WEAPON!")
+	finish_execute_messages = list(BP_CHEST = "\The USER runs \the VICTIM through with \the WEAPON!", BP_HEAD = "\The USER slices \the VICTIM's throat wide open with \the WEAPON!")
+	decapitate = FALSE
 
 /obj/item/weapon/melee/energy/elite_sword/dagger/activate(mob/living/user)
 	..()
@@ -216,6 +235,10 @@ Luckily, this isn't a downside due to the explosive properties of such a large a
 	var/regen_at = -1
 	var/explode_damage = 60
 
+	executions_allowed = TRUE
+	start_execute_messages = list(BP_CHEST = "\The USER lines up \the WEAPON against \the VICTIM's back!", BP_HEAD = "\The USER lines up \the WEAPON against \the VICTIM's neck!")
+	finish_execute_messages = list(BP_CHEST ="\The USER impales \the VICTIM with \the WEAPON and detonates it!", BP_HEAD = "\The USER stabs clean through \the VICTIM's neck with \the WEAPON, detonating it!")
+
 /obj/item/weapon/melee/blamite/update_icon()
 	if(regen_at != -1)
 		icon_state = "[initial(icon_state)]_handle"
@@ -255,16 +278,18 @@ Luckily, this isn't a downside due to the explosive properties of such a large a
 	else
 		visible_message("<span class = 'warning'>[name] overloads, singing the air around it!</span>")
 
-/obj/item/weapon/melee/blamite/proc/do_explode_in_player(var/mob/living/player)
+/obj/item/weapon/melee/blamite/proc/do_explode_in_player(var/mob/living/player, var/silent = FALSE)
 	//Kabloeey in a player//
 	if(player)
 		player.adjustFireLoss(explode_damage)
-		player.visible_message("<span class = 'notice'>The embedded Blamite Blade overloads, burning [player.name]!</span>")
+		if(!silent)
+			player.visible_message("<span class = 'notice'>The embedded Blamite Blade overloads, burning [player.name]!</span>")
 
-/obj/item/weapon/melee/blamite/proc/pre_explode_in_player(var/mob/living/user,var/mob/living/carbon/human/target)
+/obj/item/weapon/melee/blamite/proc/pre_explode_in_player(var/mob/living/user,var/mob/living/carbon/human/target, var/silent = FALSE)
 	if(!istype(target))
 		return
-	user.visible_message("<span class = 'warning'>[user.name] lodges the blade of their [name] into [target.name], snapping it off at the hilt.</span>")
+	if(!silent)
+		user.visible_message("<span class = 'warning'>[user.name] lodges the blade of their [name] into [target.name], snapping it off at the hilt.</span>")
 	regen_at = world.time + regen_delay
 	explode_at = -1
 	update_icon()
@@ -276,7 +301,7 @@ Luckily, this isn't a downside due to the explosive properties of such a large a
 	embed_organ.embed(shard)
 	spawn(explode_delay)
 		if(target && locate(/obj/item/weapon/material/shard/shrapnel/blamite) in target.embedded)
-			do_explode_in_player(target)
+			do_explode_in_player(target, silent)
 
 /obj/item/weapon/melee/blamite/attack_self(var/mob/user)
 	if(regen_at != -1)
@@ -289,6 +314,18 @@ Luckily, this isn't a downside due to the explosive properties of such a large a
 	explode_at = world.time + explode_delay
 	GLOB.processing_objects |= src
 	update_icon()
+
+/obj/item/weapon/melee/blamite/can_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	if(regen_at != -1)
+		return FALSE
+	return ..()
+
+//Instant explosion
+/obj/item/weapon/melee/blamite/do_execute(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	if(..())
+		explode_delay = 1
+		pre_explode_in_player(user, victim, TRUE)
+		explode_delay = initial(explode_delay)
 
 /obj/item/weapon/melee/blamite/process()
 	if(explode_at != -1 && world.time > explode_at)

--- a/code/modules/halo/weapons/melee.dm
+++ b/code/modules/halo/weapons/melee.dm
@@ -1,6 +1,6 @@
 
 /obj/item/weapon/material/knife/combat_knife
-	name = "combat knife"
+	name = "\improper combat knife"
 	desc = "Multipurpose knife for utility use and close quarters combat"
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	icon_state = "Knife"
@@ -13,8 +13,12 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	armor_penetration = 70
 
+	executions_allowed = TRUE
+	start_execute_messages = list(BP_CHEST = "\The USER steps on \the VICTIM and brandishes \the WEAPON!", BP_HEAD = "\The USER grips \the VICTIM's shoulder and brandishes \the WEAPON!")
+	finish_execute_messages = list(BP_CHEST = "\The USER guts VICTIM with \the WEAPON!", BP_HEAD = "\The USER slices clean through \the VICTIM's neck with \the WEAPON!")
+
 /obj/item/weapon/material/machete
-	name = "machete"
+	name = "\improper machete"
 	desc = "A standard issue machete used for hacking things apart. It is very sharp "
 	icon= 'code/modules/halo/weapons/icons/machete.dmi'
 	icon_state = "machete_obj"
@@ -37,6 +41,10 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	unacidable = 1
 	lunge_dist = 2
+
+	executions_allowed = TRUE
+	start_execute_messages = list(BP_CHEST = "\The USER steps on \the VICTIM and brandishes \the WEAPON!", BP_HEAD = "\The USER grips \the VICTIM's shoulder and brandishes \the WEAPON!")
+	finish_execute_messages = list(BP_CHEST = "\The USER guts VICTIM with \the WEAPON!", BP_HEAD = "\The USER slices clean through \the VICTIM's neck with \the WEAPON!")
 
 /obj/item/weapon/material/machete/officersword
 	name = "CO's Sword"


### PR DESCRIPTION
Adds executions to the game following most of the roadmap from https://github.com/HaloSpaceStation/HaloSpaceStation13/discussions/2872. Species barriers were not implemented and anyone can do them with the right weapon.

You can now execute someone who is on the ground with a combat knife, machete, energy sword, energy dagger, and blamite weapon. You do this by targeting an appropriate body part (for most it is either the chest or head) and on grab intent while within arms' reach (or you can leap at them). They have to still be alive (no repeatedly executing a dead guy) and it takes two seconds; if they or you move during that time, it will be canceled. Executing deals fatal damage to the appropriate body part and instantly kills the brain.

Every `obj/item/weapon` now has three new variables: `executions_allowed`, `start_execute_messages`, and `stop_execute_messages`. `executions_allowed` is self-explanatory; the latter two are associative lists for targeting zones. The key is the body part, the value is the message to be shown. Include "USER", "VICTIM", and "WEAPON" in these messages and they will automatically be converted to the appropriate names. These messages themselves are entirely flavor (except for the blamite weapons, which _do_ explode) and the damage type and flags are derived from the weapon that was used.

:cl: Shadowtail117
rscadd: Added executions. Target a downed but still alive player with an appropriate weapon on grab intent and the correct zone to deliver a killing blow.
rscadd: Made the following weapons appropriate for executions: Combat knife (head, chest), machete (head, chest), energy sword/dagger (head, chest), blamite weapon (head, chest).
/:cl: