### PR TITLE
Makes projectiles always hit destructibles when directly targeted

### DIFF
--- a/code/modules/halo/mobs/elevation_handling.dm
+++ b/code/modules/halo/mobs/elevation_handling.dm
@@ -1,4 +1,4 @@
-#define FLIGHT_DODGE_DIVISOR 8
+#define FLIGHT_DODGE_DIVISOR 6
 #define FLIGHT_DODGE_MESSAGE_CHANCE 33
 
 /mob/living/CanPass(atom/movable/mover, turf/start, height=0, air_group=0)

--- a/code/modules/halo/structures/_destructible.dm
+++ b/code/modules/halo/structures/_destructible.dm
@@ -233,7 +233,7 @@
 		return 1
 
 /obj/structure/destructible/proc/projectile_block_check(var/obj/item/projectile/P)
-	if(P.original && P.original == src) //If they're specifically shooting at us, we'll block them all the time.
+	if(P.original && P.original == loc) //If they're specifically shooting at us, we'll block them all the time.
 		return 1
 	var/modified_cover_rating = cover_rating
 	if(P.starting)


### PR DESCRIPTION
:cl: XO-11
tweak: Destructible defenses like tank traps and sandbags can now be directly targeted if you want to focus on eliminating them.
/:cl: