### PR TITLE
Fix initial population of mobs_in_sectors list

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -486,7 +486,7 @@ default behaviour is:
 	if(om_obj_old)
 		GLOB.mobs_in_sectors[om_obj_old] -= src
 	if(om_obj_new)
-		GLOB.mobs_in_sectors[om_obj_new] |= list(src) // |= is used instead of += to avoid duplication
+		GLOB.mobs_in_sectors[om_obj_new] |= src // |= is used instead of += to avoid duplication
 
 /mob/living/Move(a, b, flag)
 	if (buckled)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -46,11 +46,12 @@
 	GLOB.mob_list += src
 	..()
 
-/mob/LateInitialize()
+/mob/Initialize()
+	. = ..()
 	last_z = z
 	var/obj/om_obj = map_sectors["[z]"]
 	if(om_obj)
-		GLOB.mobs_in_sectors[om_obj] |= list(src) // |= is used instead of += to avoid duplication
+		GLOB.mobs_in_sectors[om_obj] |= src // |= is used instead of += to avoid duplication
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 	if(!client)	return


### PR DESCRIPTION
Mobs don't seem to `LateInitialize()` so they weren't being added to the sector's list of mobs. Closes #2965 

:cl: bloxgate
bugfix: Messages that rely on knowing which Z-level you spawn on now work correctly
/:cl:
