### PR TITLE
Adds force-destroy nuke effects to unsc odp cassius

### DIFF
--- a/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
+++ b/maps/faction_bases/ODP_Cassius/ODP_Cassius.dm
@@ -45,3 +45,8 @@
 		ai_job.total_positions = 0
 
 	. = ..()
+
+/obj/effect/overmap/ship/unsc_odp_cassius/nuked_effects(var/nuke_at_loc)
+	. = ..()
+	superstructure_failing = 0
+	pre_superstructure_failing()


### PR DESCRIPTION
:cl: XO-11
tweak: Makes the UNSC odp force-destroy itself when a nuke goes off on it.
/:cl:

Fixes #2964 