### PR TITLE
drop pod fixes/debug changes

### DIFF
--- a/code/modules/halo/vehicles/types/drop_pod.dm
+++ b/code/modules/halo/vehicles/types/drop_pod.dm
@@ -178,7 +178,7 @@
 
 	var/turf/drop_turf = get_drop_turf(drop_point)
 	if(isnull(drop_turf))
-		to_chat(usr,"<span class = 'notice'>No valid drop-turfs available.</span>")
+		to_chat(usr,"<span class = 'notice'>No valid drop-turfs available at selected point.</span>")
 		return
 
 	proc_launch_pod(usr,drop_turf)

--- a/code/modules/halo/vehicles/types/drop_pod.dm
+++ b/code/modules/halo/vehicles/types/drop_pod.dm
@@ -66,7 +66,7 @@
 		visible_message("<span class = 'warning'>[src] blurts a warning: ERROR: NO AVAILABLE DROP-TARGETS.</span>")
 		return
 	var/list/valid_points = list()
-	for(var/turf/l in dview(drop_point,drop_accuracy))
+	for(var/turf/l in range(drop_point,drop_accuracy))
 		if(istype(l,/turf/simulated/floor))
 			valid_points += l
 		if(istype(l,/turf/unsimulated/floor))
@@ -171,7 +171,12 @@
 		return
 	om_targ = potential_om_targ[om_user_choice]
 
-	var/turf/drop_turf = get_drop_turf(get_drop_point(usr,om_targ))
+	var/drop_point = get_drop_point(usr,om_targ)
+	if(isnull(drop_point))
+		to_chat(usr,"<span class = 'notice'>Error acquiring drop-point information from system.</span>")
+		return
+
+	var/turf/drop_turf = get_drop_turf(drop_point)
 	if(isnull(drop_turf))
 		to_chat(usr,"<span class = 'notice'>No valid drop-turfs available.</span>")
 		return


### PR DESCRIPTION
:cl: XO-11
tweak: Changes drop-pod code to giver better feedback as to which point in the landing zone acquisition it failed, for debugging purposes. Also makes a small change to the code itself as a potential fix.
/:cl: