### PR TITLE
Explosive Weapon Tweaks

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -5,7 +5,7 @@ it needs to create more trails.A beaker could have a steam_trail_follow system s
 would spawn and follow the beaker, even if it is carried or thrown.
 */
 
-#define SMOKE_PROJPASS_ACC_MALUS 3
+#define SMOKE_PROJPASS_ACC_MALUS 1
 
 /obj/effect/effect
 	name = "effect"
@@ -191,9 +191,9 @@ steam.start() -- spawns the effect
 		effect_proj(M)
 
 /obj/effect/effect/smoke/proc/effect_proj(var/obj/item/projectile/p)
-	if(istype(p))
+	if(!istype(p))
 		return
-	P.accuracy -= SMOKE_PROJPASS_ACC_MALUS
+	p.accuracy -= SMOKE_PROJPASS_ACC_MALUS
 
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (istype(M))

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -5,6 +5,7 @@ it needs to create more trails.A beaker could have a steam_trail_follow system s
 would spawn and follow the beaker, even if it is carried or thrown.
 */
 
+#define SMOKE_PROJPASS_ACC_MALUS 3
 
 /obj/effect/effect
 	name = "effect"
@@ -186,6 +187,13 @@ steam.start() -- spawns the effect
 	..()
 	if(istype(M))
 		affect(M)
+	else
+		effect_proj(M)
+
+/obj/effect/effect/smoke/proc/effect_proj(var/obj/item/projectile/p)
+	if(istype(p))
+		return
+	P.accuracy -= SMOKE_PROJPASS_ACC_MALUS
 
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (istype(M))
@@ -505,3 +513,5 @@ steam.start() -- spawns the effect
 				round(min(light, BOMBCAP_LIGHT_RADIUS)),
 				round(min(flash, BOMBCAP_FLASH_RADIUS))
 				)
+
+#undef SMOKE_PROJPASS_ACC_MALUS

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -5,7 +5,7 @@ it needs to create more trails.A beaker could have a steam_trail_follow system s
 would spawn and follow the beaker, even if it is carried or thrown.
 */
 
-#define SMOKE_PROJPASS_ACC_MALUS 1
+#define SMOKE_PROJPASS_ACC_MALUS 2
 
 /obj/effect/effect
 	name = "effect"
@@ -188,9 +188,9 @@ steam.start() -- spawns the effect
 	if(istype(M))
 		affect(M)
 	else
-		effect_proj(M)
+		affect_proj(M)
 
-/obj/effect/effect/smoke/proc/effect_proj(var/obj/item/projectile/p)
+/obj/effect/effect/smoke/proc/affect_proj(var/obj/item/projectile/p)
 	if(!istype(p))
 		return
 	p.accuracy -= SMOKE_PROJPASS_ACC_MALUS

--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -99,7 +99,7 @@
 		/obj/item/weapon/gun/energy/beam_rifle = 2,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15,
-		/obj/item/turret_deploy_kit/plasturret = 4
+		/obj/item/turret_deploy_kit/plasturret = 3
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/sangheili/equipment // Equipment for Sangheili
@@ -181,12 +181,15 @@
 		/obj/item/weapon/grenade/smokebomb/covenant = 0,
 		/obj/item/weapon/grenade/plasma = 0,
 		/obj/item/weapon/grenade/frag/spike = 0,
+		"Misc" = -1,
+		/obj/item/turret_deploy_kit/plasturret = 2,
 	)
 	amounts = list(
 		/obj/item/weapon/gun/launcher/grenade/brute_shot = 3,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/frag/spike = 15,
+		/obj/item/turret_deploy_kit/plasturret = 2,
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/jiralhanae/equipment // Equipment for Jiralhanae
@@ -256,12 +259,15 @@
 		"Explosives" = -1,
 		/obj/item/weapon/gun/energy/beam_rifle = 0,
 		/obj/item/weapon/grenade/plasma = 0,
-		/obj/item/weapon/grenade/smokebomb/covenant = 0
+		/obj/item/weapon/grenade/smokebomb/covenant = 0,
+		"Misc" = -1,
+		/obj/item/turret_deploy_kit/plasturret = 0
 	)
 	amounts = list(\
 		/obj/item/weapon/gun/energy/beam_rifle = 2,
 		/obj/item/weapon/grenade/plasma = 15,
-		/obj/item/weapon/grenade/smokebomb/covenant = 15
+		/obj/item/weapon/grenade/smokebomb/covenant = 15,
+		/obj/item/turret_deploy_kit/plasturret = 1
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/kigyar/equipment // Equipment for Kig-Yar
@@ -351,7 +357,7 @@
 		/obj/item/weapon/gun/energy/plasmarepeater = 3,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 12,
-		/obj/item/turret_deploy_kit/plasturret = 4
+		/obj/item/turret_deploy_kit/plasturret = 2
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/unggoy/equipment // Equipment for Unggoy

--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -94,9 +94,9 @@
 		/obj/item/turret_deploy_kit/plasturret = 0
 	)
 	amounts = list(\
-		/obj/item/weapon/gun/projectile/fuel_rod = 3,
+		/obj/item/weapon/gun/projectile/fuel_rod = 1,
 		/obj/item/weapon/gun/energy/plasmarepeater = 3,
-		/obj/item/weapon/gun/energy/beam_rifle = 3,
+		/obj/item/weapon/gun/energy/beam_rifle = 2,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15,
 		/obj/item/turret_deploy_kit/plasturret = 4
@@ -259,7 +259,7 @@
 		/obj/item/weapon/grenade/smokebomb/covenant = 0
 	)
 	amounts = list(\
-		/obj/item/weapon/gun/energy/beam_rifle = 3,
+		/obj/item/weapon/gun/energy/beam_rifle = 2,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15
 	)
@@ -347,7 +347,7 @@
 		/obj/item/turret_deploy_kit/plasturret = 0
 	)
 	amounts = list(\
-		/obj/item/weapon/gun/projectile/fuel_rod = 3,
+		/obj/item/weapon/gun/projectile/fuel_rod = 2,
 		/obj/item/weapon/gun/energy/plasmarepeater = 3,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 12,

--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -79,8 +79,8 @@
 					)
 	amounts = list(\
 		/obj/item/weapon/gun/projectile/m739_lmg = 3,
-		/obj/item/weapon/gun/projectile/srs99_sniper = 3,
-		/obj/item/weapon/gun/projectile/m41 = 3,
+		/obj/item/weapon/gun/projectile/srs99_sniper = 2,
+		/obj/item/weapon/gun/projectile/m41 = 1,
 		/obj/item/turret_deploy_kit/HMG = 2,
 		/obj/item/weapon/plastique = 2,
 		/obj/item/weapon/plastique/breaching = 2,
@@ -109,7 +109,7 @@
 					)
 	amounts = list(\
 		/obj/item/weapon/gun/projectile/m545_lmg  = 1,
-		/obj/item/weapon/gun/projectile/heavysniper = 1,
+		/obj/item/weapon/gun/projectile/heavysniper = 2,
 		/obj/item/weapon/gun/projectile/m41 = 1,
 		/obj/item/turret_deploy_kit/HMG = 2,
 		/obj/item/weapon/plastique = 8,

--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -165,7 +165,6 @@
 					/obj/item/weapon/storage/pocketstore/hardcase/bullets = 0,
 					/obj/item/weapon/storage/pocketstore/hardcase/grenade = 1,
 					/obj/item/weapon/storage/pocketstore/hardcase/armorkits = 0,
-					/obj/item/weapon/storage/pocketstore/hardcase/rockets = 1,
 					/obj/item/weapon/storage/pocketstore/hardcase/medbottles = 0,
 					/obj/item/weapon/storage/pocketstore/hardcase/hypos = 0,
 					/obj/item/weapon/storage/pocketstore/hardcase/materials = 0,

--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -42,7 +42,9 @@
 					"Miscellaneous" = -1,
 					/obj/item/weapon/armor_patch = 0,
 					/obj/item/weapon/armor_patch/mini = 0,
-					/obj/item/drop_pod_beacon = 0
+					/obj/item/drop_pod_beacon = 0,
+					/obj/item/turret_deploy_kit/HMG = 0,
+					/obj/item/turret_deploy_kit/chaingun = 0,
 					)
 	amounts = list(\
 		/obj/item/weapon/grenade/frag/m9_hedp = 15,
@@ -50,6 +52,8 @@
 		/obj/item/weapon/plastique = 2,
 		/obj/item/weapon/plastique/breaching = 2,
 		/obj/item/weapon/plastique/breaching/longrange = 2,
+		/obj/item/turret_deploy_kit/HMG = 2,
+		/obj/item/turret_deploy_kit/chaingun = 2,
 	)
 
 /obj/machinery/pointbased_vending/armory/hybrid/innie
@@ -72,6 +76,7 @@
 					/obj/item/ammo_magazine/m739/m118 = 0,
 					"Turrets" = -1,
 					/obj/item/turret_deploy_kit/HMG = 0,
+					/obj/item/turret_deploy_kit/chaingun = 0,
 					"Explosives" = -1,
 					/obj/item/weapon/plastique = 0,
 					/obj/item/weapon/plastique/breaching = 0,
@@ -81,7 +86,8 @@
 		/obj/item/weapon/gun/projectile/m739_lmg = 3,
 		/obj/item/weapon/gun/projectile/srs99_sniper = 2,
 		/obj/item/weapon/gun/projectile/m41 = 1,
-		/obj/item/turret_deploy_kit/HMG = 2,
+		/obj/item/turret_deploy_kit/HMG = 3,
+		/obj/item/turret_deploy_kit/chaingun = 3,
 		/obj/item/weapon/plastique = 2,
 		/obj/item/weapon/plastique/breaching = 2,
 		/obj/item/weapon/plastique/breaching/longrange = 2,

--- a/code/modules/halo/storage/pocketstorage.dm
+++ b/code/modules/halo/storage/pocketstorage.dm
@@ -108,7 +108,7 @@
 
 /obj/item/weapon/storage/pocketstore/hardcase/tools/cov
 	icon_state = "hardcase_cov_generic"
-
+/*
 /obj/item/weapon/storage/pocketstore/hardcase/rockets
 	name = "102mm HEAT SPNKr Hardcase"
 	desc = "A belt-clippable hardcase capable of holding up to 2 M41 rocket tubes."
@@ -117,7 +117,7 @@
 	storage_slots = 2
 	can_hold = list(/obj/item/ammo_magazine/spnkr)
 	max_w_class = ITEM_SIZE_LARGE
-
+*/ //This is now unused as it unbalances the carry capacities of ammo and the speed detriments.
 /obj/item/weapon/storage/pocketstore/hardcase/armorkits
 	name = "Tactical Hardcase (Armour Kits)"
 	desc = "A reinforced storage box, clipped near your pockets. Created to hold armour repair kits in a convenient location."

--- a/code/modules/halo/vehicles/types/scorpion.dm
+++ b/code/modules/halo/vehicles/types/scorpion.dm
@@ -104,6 +104,7 @@
 	damtype = "bomb"
 	armor_penetration = 50
 	shield_damage = 240
+	steps_between_delays = 3
 
 /obj/item/projectile/bullet/scorp_cannon/on_impact(var/atom/impacted)
 	explosion(get_turf(impacted),0,1,3,5,guaranteed_damage = 50,guaranteed_damage_range = 2)

--- a/code/modules/halo/weapons/M41.dm
+++ b/code/modules/halo/weapons/M41.dm
@@ -40,7 +40,7 @@
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	icon_state = "SPNKr"
 	mag_type = MAGAZINE
-	slot_flags = SLOT_BELT | SLOT_MASK //Shhh it's a joke
+	slot_flags = SLOT_BELT
 	ammo_type = /obj/item/ammo_casing/spnkr
 	caliber = "spnkr"
 	max_ammo = 2
@@ -55,10 +55,10 @@
 	icon_state = "ssr"
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	check_armour = "bomb"
-	step_delay = 1.2
-	kill_count = 15
-	shield_damage = 180
-	damage = 100
+	step_delay = 1.3
+	kill_count = 21
+	shield_damage = 100
+	damage = 70
 	armor_penetration = 50
 
 /obj/item/projectile/bullet/ssr/on_impact(var/atom/target)

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -318,8 +318,8 @@
 	check_armour = "bomb"
 	damage_type = "bomb"
 	damtype = "bomb"
-	step_delay = 1.2
-	kill_count = 15
+	step_delay = 1.3
+	kill_count = 21
 	shield_damage = 100
 	damage = 50
 	armor_penetration = 50

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -1,4 +1,5 @@
 #define ADHERENCE_TIME 1.0
+#define PLASNADE_EMBEDDED_DAM_ADD 10
 
 //plasma grenade visual effect
 /obj/effect/plasma_explosion
@@ -27,12 +28,12 @@
 	icon = 'code/modules/halo/weapons/icons/Covenant Weapons.dmi'
 	icon_state = "plasmagrenade"
 	throw_speed = 0 //sleep each tick
-	det_time = 40
+	det_time = 30
 	can_adjust_timer = 0
 	starttimer_on_hit = 1
 	arm_sound = 'code/modules/halo/sounds/Plasmanadethrow.ogg'
-	alt_explosion_range = 1
-	alt_explosion_damage_max = 60
+	alt_explosion_range = 2
+	alt_explosion_damage_max = 40
 	matter = list("nanolaminate" = 1, "kemocite" = 1)
 	salvage_components = list(/obj/item/plasma_core)
 	item_state_slots = list(slot_l_hand_str = "plasma_nade_off", slot_r_hand_str = "plasma_nade_off")
@@ -83,11 +84,13 @@
 			if(dist <= round(alt_explosion_range + world.view - 2, 1))
 				M.playsound_local(epicenter, 'code/modules/halo/sounds/Plasmanadedetonate.ogg', 100, 1)
 	var/mob/living/carbon/human/mob_containing = loc
-	do_alt_explosion()
-	explosion(get_turf(src),0,0,1,0)
 	if(istype(mob_containing))
 		mob_containing.contents -= src
 		mob_containing.embedded -= src
+		alt_explosion_damage_max += PLASNADE_EMBEDDED_DAM_ADD
+	do_alt_explosion()
+	if(explosion_size)
+		explosion(get_turf(O), -1, 2, 2, 0)
 	loc = null
 	qdel(src)
 
@@ -97,3 +100,7 @@
 	det_time = 5
 	throw_range = 0
 	alt_explosion_range = 2
+	alt_explosion_damage_max = 60
+
+#undef ADHERENCE_TIME
+#undef PLASNADE_EMBEDDED_DAM_ADD

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -85,12 +85,14 @@
 				M.playsound_local(epicenter, 'code/modules/halo/sounds/Plasmanadedetonate.ogg', 100, 1)
 	var/mob/living/carbon/human/mob_containing = loc
 	if(istype(mob_containing))
+		alt_explosion_damage_max += PLASNADE_EMBEDDED_DAM_ADD
+		do_alt_explosion()
+		explosion(get_turf(src), -1, 2, 2, 0)
 		mob_containing.contents -= src
 		mob_containing.embedded -= src
-		alt_explosion_damage_max += PLASNADE_EMBEDDED_DAM_ADD
-	do_alt_explosion()
-	if(explosion_size)
-		explosion(get_turf(O), -1, 2, 2, 0)
+	else
+		do_alt_explosion()
+		explosion(get_turf(src), -1, 2, 2, 0)
 	loc = null
 	qdel(src)
 

--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -4,16 +4,17 @@
 	desc = "This High-Explosive Dual-Purpose fragmentation grenade is designed to be effective against infantry and lightly armored vehicles."
 	icon = 'code/modules/halo/weapons/icons/Weapon Sprites.dmi'
 	icon_state = "M9 HEDP"
-	num_fragments = 100
+	num_fragments = 8
 	can_adjust_timer = 0
 	starttimer_on_hit = 1
 	det_time = 30
+	explosion_size = 2
 	alt_explosion_range = 2
-	alt_explosion_damage_max = 35
+	alt_explosion_damage_max = 40
 
 /obj/item/weapon/grenade/frag/m9_hedp/on_explosion(var/turf/O)
 	if(explosion_size)
-		explosion(get_turf(O), -1, -1,explosion_size, round(explosion_size*2))
+		explosion(get_turf(O), -1, explosion_size,explosion_size, 0)
 	do_alt_explosion()
 
 /obj/item/weapon/storage/box/m9_frag

--- a/code/modules/halo/weapons/turrets/turret.dm
+++ b/code/modules/halo/weapons/turrets/turret.dm
@@ -240,7 +240,7 @@
 	item_state = "chaingun_obj"
 	one_hand_penalty = -1
 
-	slowdown_general = 7
+	slowdown_general = 3.5
 	w_class = ITEM_SIZE_HUGE
 	can_rename = 0
 	item_icons = list( //Null here due to this version being used only when manning the turret, Every turret requires a /detached define with the item_icons set.
@@ -302,6 +302,7 @@
 //Detached Turret Gun Define// Every detachable turret gun needs this.
 /obj/item/weapon/gun/projectile/turret/detached
 	removed_from_turret = 1
+	can_rename = 1
 	item_icons = list(
 		slot_l_hand_str = 'code/modules/halo/weapons/turrets/mob_turret.dmi',
 		slot_r_hand_str = 'code/modules/halo/weapons/turrets/mob_turret.dmi',

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -156,9 +156,9 @@
 	wielded_item_state = "z8carbine-wielded"
 	//would have one_hand_penalty=4,5 but the added weight of a grenade launcher makes one-handing even harder
 	firemodes = list(
-		list(mode_name="semiauto",       burst=1,    fire_delay=0, use_launcher=null, one_hand_penalty=5, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3,    fire_delay=null, use_launcher=null, one_hand_penalty=6, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.6, 1.0)),
-		list(mode_name="fire grenades",  burst=null, fire_delay=null, use_launcher=1,    one_hand_penalty=5, burst_accuracy=null, dispersion=null)
+		list(mode_name="semiauto",       burst=1,    fire_delay=5, use_launcher=null, one_hand_penalty=5, burst_accuracy=null, dispersion=null),
+		list(mode_name="3-round bursts", burst=3,    fire_delay=6, use_launcher=null, one_hand_penalty=6, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.6, 1.0)),
+		list(mode_name="fire grenades",  burst=null, fire_delay=6, use_launcher=1,    one_hand_penalty=5, burst_accuracy=null, dispersion=null)
 		)
 
 	var/use_launcher = 0

--- a/maps/base_assault/base_assault_gm.dm
+++ b/maps/base_assault/base_assault_gm.dm
@@ -21,6 +21,10 @@
 	stalemate_at = world.time + STALEMATE_TIMER
 	do_flank_poplock()
 
+/datum/game_mode/base_assault/proc/delete_bomblocations()
+	for(var/obj/effect/bomblocation/b in world)
+		qdel(b)
+
 /datum/game_mode/base_assault/proc/do_flank_poplock()
 	if(flank_tags.len == 0)
 		return


### PR DESCRIPTION
:cl: XO-11
tweak: Modifies the overall count of AT and sniper weapons (12 - > 4).
tweak: Makes a projectile passing through smoke gain an accuracy penalty.
tweak: Brings both grenade types more in line with eachother, upping and lowering damage where appropriate. Grenades should be more generally useful rather than useful in only one way.
/:cl: