### PR TITLE
fixes the animated sprite for jetpacks not updating on mob

### DIFF
--- a/code/modules/halo/clothing/jetpacks.dm
+++ b/code/modules/halo/clothing/jetpacks.dm
@@ -61,7 +61,7 @@
 	user.take_flight(flight_ticks_curr,"<span class = 'warning'>[user.name][takeoff_msg]</span>","<span class = 'warning'>[user.name][land_msg]</span>")
 	GLOB.processing_objects -= src
 	update_icon()
-	user.update_icon()
+	user.update_inv_back(1)
 	if(!flight_bar)
 		flight_bar = new(user,flight_ticks_max,src)
 
@@ -76,7 +76,7 @@
 		user.take_flight(0,(output_msg ? "<span class = 'warning'>[user.name][takeoff_msg]</span>" : null),(output_msg ? "<span class = 'warning'>[user.name][land_msg]</span>" : null))
 	GLOB.processing_objects += src
 	update_icon()
-	user.update_icon()
+	user.update_inv_back(1)
 
 /obj/item/flight_item/ui_action_click()
 	if(usr != loc)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Changes the user.update_icon() for user.update_inv_back(1) on the code so it actually updates the item_state and the overlay on mob for the jetpacks.
<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Patata
rscadd: jetpacks now have an animation for the active state
/:cl:
