### PR TITLE
Lava elevation fix, stranded optimisation and SM shard removal

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -178,7 +178,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper shield generator construction kit crate"
 	access = access_ce
-
+/*
 /decl/hierarchy/supply_pack/engineering/smbig
 	name = "Supermatter Core"
 	contains = list(/obj/machinery/power/supermatter)
@@ -186,7 +186,7 @@
 	containertype = /obj/structure/closet/crate/secure/large/phoron
 	containername = "\improper Supermatter crate (CAUTION)"
 	access = access_ce
-
+*/
 /decl/hierarchy/supply_pack/engineering/fueltank
 	name = "Fuel tank crate"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)

--- a/code/game/turfs/unsimulated/lava.dm
+++ b/code/game/turfs/unsimulated/lava.dm
@@ -46,7 +46,6 @@
 
 	if(loseme)
 		if(Obj.elevation == BASE_ELEVATION)
-
 			for(var/obj/effect/decal/cleanable/ash/A in src)
 				qdel(A)
 			spawn(rand(25,75))

--- a/code/game/turfs/unsimulated/lava.dm
+++ b/code/game/turfs/unsimulated/lava.dm
@@ -45,12 +45,14 @@
 		loseme = 1
 
 	if(loseme)
-		for(var/obj/effect/decal/cleanable/ash/A in src)
-			qdel(A)
-		spawn(rand(25,75))
-			if(Obj && Obj.loc == src)
-				src.visible_message("\icon[Obj]<span class='danger'>[Obj] sinks under the surface of [src]!</span>")
-				qdel(Obj)
+		if(Obj.elevation == BASE_ELEVATION)
+
+			for(var/obj/effect/decal/cleanable/ash/A in src)
+				qdel(A)
+			spawn(rand(25,75))
+				if(Obj && Obj.loc == src)
+					src.visible_message("\icon[Obj]<span class='danger'>[Obj] sinks under the surface of [src]!</span>")
+					qdel(Obj)
 
 	light_range = 5
 	light_power = 2

--- a/code/modules/halo/flood/types/carrier.dm
+++ b/code/modules/halo/flood/types/carrier.dm
@@ -1,4 +1,7 @@
 
+#define CARRIER_SPORES_MIN 6
+#define CARRIER_SPORES_MAX 12
+
 /mob/living/simple_animal/hostile/flood/carrier
 	name = "Flood carrier"
 	icon = 'code/modules/halo/flood/flood_carrier.dmi'
@@ -33,7 +36,7 @@
 
 	var/turf/spawn_turf = src.loc
 	spawn(0)
-		var/sporesleft = rand(3,9)
+		var/sporesleft = rand(CARRIER_SPORES_MIN,CARRIER_SPORES_MAX)
 		while(sporesleft > 0)
 			var/mob/living/simple_animal/hostile/flood/infestor/S = new(spawn_turf)
 			sporesleft -= 1
@@ -47,3 +50,6 @@
 	spawn(3)
 		qdel(src)
 	return ..(0,deathmessage)
+
+#undef CARRIER_SPORES_MIN
+#undef CARRIER_SPORES_MAX

--- a/code/modules/halo/flood/types/pure.dm
+++ b/code/modules/halo/flood/types/pure.dm
@@ -12,7 +12,7 @@
 	melee_damage_upper = 55
 	attacktext = "Whips"
 	mob_size = MOB_LARGE
-	resistance = 30 //MA5 Rounds literally can't damage this >:)
+	resistance = 20
 	bound_width = 96
 	bound_height = 96
 

--- a/code/modules/xenoarcheaology/artifacts/artifact_find.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact_find.dm
@@ -7,10 +7,8 @@
 	artifact_id = "[pick("kappa","sigma","antaeres","beta","omicron","iota","epsilon","omega","gamma","delta","tau","alpha")]-[random_id(/datum/artifact_find, 100, 999)]"
 
 	artifact_find_type = pick(
-	5;/obj/machinery/power/supermatter,
 	5;/obj/structure/constructshell,
 	5;/obj/machinery/syndicate_beacon,
-	25;/obj/machinery/power/supermatter/shard,
 	50;/obj/structure/cult/pylon,
 	100;/obj/machinery/auto_cloner,
 	100;/obj/machinery/giga_drill,

--- a/maps/_gamemodes/firefight/_mode.dm
+++ b/maps/_gamemodes/firefight/_mode.dm
@@ -23,7 +23,7 @@
 	var/pilot_name = "GA-TL1 Longsword Pilot"
 
 	var/current_wave = 0
-	var/max_waves = 5
+	var/max_waves = 8
 
 	var/is_spawning = 0	//0 = rest, 1 = spawning
 	var/spawn_subwave_interval = 10 SECONDS

--- a/maps/_gamemodes/firefight/_mode.dm
+++ b/maps/_gamemodes/firefight/_mode.dm
@@ -26,22 +26,22 @@
 	var/max_waves = 5
 
 	var/is_spawning = 0	//0 = rest, 1 = spawning
-	var/spawn_subwave_interval = 30 SECONDS
+	var/spawn_subwave_interval = 10 SECONDS
 	var/next_subwave_at = 0
 	var/max_spawns_tick_perf = 20		//keep this the same for performance reasons. acts as a max-cap
-	var/max_spawns_tick_base = 5
-	var/max_spawns_tick = 5 //But this one changes based on players-active
-	var/enemy_numbers_base = 5	//the total number of enemies
-	var/enemy_numbers_left = 5
+	var/max_spawns_tick_base = 1 //Keep this low so players don't get overwhelmed. Increases by player_bonus_enemies
+	var/max_spawns_tick = 1 //But this one changes based on players-active.
+	var/enemy_numbers_base = 10 //the total number of enemies
+	var/enemy_numbers_left = 10
 	var/wave_bonus_enemies = list(3, 4, 5, 6, 8)
-	var/player_bonus_enemies = list(1, 2, 3, 4)
+	var/player_bonus_enemies = list(0, 1, 1.5, 2.5)
 	var/list/wave_spawn_landmarks = list()
 
 	var/time_rest_end = 0
 	var/interval_resupply = 4 MINUTES
 	var/time_next_resupply = 0
 
-	var/rest_time = 2 MINUTES
+	var/rest_time = 4 MINUTES
 	var/safe_time = 999999
 
 	var/time_evac_leave = 0

--- a/maps/_gamemodes/firefight/_mode.dm
+++ b/maps/_gamemodes/firefight/_mode.dm
@@ -36,6 +36,7 @@
 	var/wave_bonus_enemies = list(3, 4, 5, 6, 8)
 	var/player_bonus_enemies = list(0, 1, 1.5, 2.5)
 	var/list/wave_spawn_landmarks = list()
+	var/list/last_spawns_list
 
 	var/time_rest_end = 0
 	var/interval_resupply = 4 MINUTES

--- a/maps/_gamemodes/firefight/process.dm
+++ b/maps/_gamemodes/firefight/process.dm
@@ -35,7 +35,7 @@
 			var/players_alive = max(player_faction.players_alive() - 1, 0)
 			var/playercount_bonus = player_bonus_enemies[GLOB.difficulty_level]
 			var/player_bonus = playercount_bonus * players_alive
-			max_spawns_tick = min(max_spawns_tick_perf,max_spawns_tick_base + playercount_bonus)
+			max_spawns_tick = min(max_spawns_tick_perf,round(max_spawns_tick_base + player_bonus))
 
 			//calculate the enemy strength for this wave
 			enemy_numbers_left = enemy_numbers_base + wave_bonus + player_bonus

--- a/maps/_gamemodes/firefight/spawn.dm
+++ b/maps/_gamemodes/firefight/spawn.dm
@@ -97,9 +97,14 @@
 		if(spawn_list_index > wave_spawns.len)
 			spawn_list_index = wave_spawns.len
 		weighted_spawn_list = wave_spawns[spawn_list_index]
+		last_spawns_list = weighted_spawn_list
 	else
-		//no custom emeny list, just pull from the faction defender list
-		weighted_spawn_list = enemy_faction.defender_mob_types
+		if(last_spawns_list)
+			weighted_spawn_list = last_spawn_list
+		else
+			//no custom emeny list and no previous wave list, just pull from the faction defender list
+			weighted_spawn_list = enemy_faction.defender_mob_types
+			last_spawns_list = weighted_spawn_list
 
 	while(amount >= 1)
 		var/spawn_type = pickweight(weighted_spawn_list)

--- a/maps/_gamemodes/firefight/spawn.dm
+++ b/maps/_gamemodes/firefight/spawn.dm
@@ -90,18 +90,18 @@
 	enemy_numbers_left -= amount
 
 	//pick a hostile mob to spawn
-	while(amount >= 1)
-		var/list/weighted_spawn_list
-		if(wave_spawns.len)
-			//this gamemode has a custom list of spawns in increasing difficulty per wave
-			var/spawn_list_index = current_wave
-			if(spawn_list_index > wave_spawns.len)
-				spawn_list_index = wave_spawns.len
-			weighted_spawn_list = wave_spawns[spawn_list_index]
-		else
-			//no custom emeny list, just pull from the faction defender list
-			weighted_spawn_list = enemy_faction.defender_mob_types
+	var/list/weighted_spawn_list
+	if(wave_spawns.len)
+		//this gamemode has a custom list of spawns in increasing difficulty per wave
+		var/spawn_list_index = current_wave
+		if(spawn_list_index > wave_spawns.len)
+			spawn_list_index = wave_spawns.len
+		weighted_spawn_list = wave_spawns[spawn_list_index]
+	else
+		//no custom emeny list, just pull from the faction defender list
+		weighted_spawn_list = enemy_faction.defender_mob_types
 
+	while(amount >= 1)
 		var/spawn_type = pickweight(weighted_spawn_list)
 		spawn_attackers(spawn_type, 1)
 		amount -= 1

--- a/maps/_gamemodes/firefight/spawn.dm
+++ b/maps/_gamemodes/firefight/spawn.dm
@@ -100,7 +100,7 @@
 		last_spawns_list = weighted_spawn_list
 	else
 		if(last_spawns_list)
-			weighted_spawn_list = last_spawn_list
+			weighted_spawn_list = last_spawns_list
 		else
 			//no custom emeny list and no previous wave list, just pull from the faction defender list
 			weighted_spawn_list = enemy_faction.defender_mob_types

--- a/maps/_gamemodes/firefight/subtypes/stranded.dm
+++ b/maps/_gamemodes/firefight/subtypes/stranded.dm
@@ -16,11 +16,8 @@
 		/datum/game_mode/firefight/proc/spawn_resupply,\
 		/datum/game_mode/firefight/proc/spawn_ship_debris)
 
-	max_spawns_tick_perf = 30
-	max_spawns_tick_base = 15
-	max_spawns_tick = 15
-	enemy_numbers_base = 25
-	enemy_numbers_left = 25
+	enemy_numbers_base = 15
+	enemy_numbers_left = 15
 
 	wave_spawns = list()
 

--- a/maps/_gamemodes/firefight/subtypes/stranded.dm
+++ b/maps/_gamemodes/firefight/subtypes/stranded.dm
@@ -19,7 +19,59 @@
 	enemy_numbers_base = 15
 	enemy_numbers_left = 15
 
-	wave_spawns = list()
+	wave_spawns = list(\
+		list(\
+			/mob/living/simple_animal/hostile/flood/carrier = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/human = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/guard = 1,
+		),
+		list(\
+			/mob/living/simple_animal/hostile/flood/carrier = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/human = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ODST = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/guard = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/oni = 1,
+
+		),
+		list(\
+			/mob/living/simple_animal/hostile/flood/carrier = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/human = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ODST = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/guard = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/oni = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor2 = 1,
+
+		),
+		list(\
+			/mob/living/simple_animal/hostile/flood/carrier = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/human = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ODST = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/guard = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/oni = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor2 = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/major = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/zealot = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ultra = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ranger = 1,
+		),
+		list(\
+			/mob/living/simple_animal/hostile/flood/carrier = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/human = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ODST = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/guard = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/oni = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/minor2 = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/major = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/zealot = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ultra = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/specops = 1,
+			/mob/living/simple_animal/hostile/flood/combat_form/ranger = 1,
+
+		)
+	)
 
 /datum/game_mode/firefight/stranded/pre_setup()
 	. = ..()


### PR DESCRIPTION
:cl: XO-11
tweak: Removes the SM shard from carge.
tweak: Makes lava respect elevation when choosing to destroy passing objects.
tweak: Stranded now caches the last viable spawn list it was given to allow for games to run past their defined waves.
tweak: Slightly increases the base max waves for firefight and derivative modes.
/:cl: