### PR TITLE
Increase heart health

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -15,7 +15,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 	var/beat_sound = 'sound/effects/singlebeat.ogg'
 	var/tmp/next_blood_squirt = 0
 	relative_size = 15
-	max_damage = 45
+	max_damage = 90
 	var/open
 
 /obj/item/organ/internal/heart/die()


### PR DESCRIPTION
Min broken damage is now 45, min bruised is 22. This doubles the current amount of damage needed for heart damage to have in game effects.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: bloxgate
tweak: Doubled the amount of damage hearts must take to become necrotic.
/:cl:
