### PR TITLE
Stop inconclusive map votes from crashing server

### DIFF
--- a/code/controllers/voting/_vote.dm
+++ b/code/controllers/voting/_vote.dm
@@ -10,6 +10,7 @@ GLOBAL_VAR_INIT(last_player_vote, 0)
 	var/additional_text_title
 	var/initiator = null
 	var/question = null
+	var/status_quo //If set, we will return this answer if noone votes.
 	var/started_time = null
 	var/time_remaining = 0
 	var/total_votes = 0

--- a/code/controllers/voting/announce_result.dm
+++ b/code/controllers/voting/announce_result.dm
@@ -43,6 +43,8 @@
 
 	else
 		text += "<b>Vote Result: Inconclusive - No Votes!</b>"
+		if (status_quo)
+			firstChoice = status_quo
 	log_vote(text)
 	to_world("<font color='purple'>[text]</font>")
 

--- a/code/controllers/voting/vote_types.dm
+++ b/code/controllers/voting/vote_types.dm
@@ -323,7 +323,7 @@
 
 /datum/vote/mapswitch
 	name = "mapswitch"
-	var/status_quo = "Do not switch"
+	status_quo = "Do not switch"
 	var/list/map_options = list()
 
 /datum/vote/mapswitch/Initialize()


### PR DESCRIPTION
Closes #3006 

:cl: Bloxgate
bugfix: Inconclusive map votes no longer crash the server
/:cl:
