### PR TITLE
Switch to setup-java@v2 and Temurin JDK

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
             tgui/node_modules
           key: ${{ runner.os }}-tgui-${{ env.BYOND_MAJOR }}.${{ env.BYOND_MINOR }}
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: '11'
-          java-package: jdk
+          distribution: 'temurin'
       - name: Install dependencies
         run: |
           sudo apt update
@@ -78,10 +78,10 @@ jobs:
             ~/BYOND-${{ env.BYOND_MAJOR }}.${{ env.BYOND_MINOR }}
           key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}.${{ env.BYOND_MINOR }}
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: '11'
-          java-package: jdk
+          distribution: 'temurin'
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
Makes some changes to the testing workflow. We're now using the Eclipse Foundation's OpenJDK build, and the newer version of the setup-java workflow.
