### PR TITLE
makes the ONI base viable

### DIFF
--- a/maps/faction_bases/complex046/complex046.dmm
+++ b/maps/faction_bases/complex046/complex046.dmm
@@ -302,7 +302,6 @@
 "mS" = (/obj/effect/landmark/dropship_land_point/unsc/no_artifact{name = "ONI Complex 046 (Geminus) Vehicle Bay"},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "nV" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Plasteel Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/machinery/light/small{dir = 8},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "nX" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
-"od" = (/obj/machinery/door/airlock/halo{name = "Nuclear Payload"; req_access = list(142)},/turf/unsimulated/mineral,/area/faction_base/oni/research)
 "os" = (/obj/structure/noticeboard,/turf/simulated/wall/iron/blue,/area/faction_base/oni/barracks)
 "oS" = (/obj/machinery/light,/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "pe" = (/obj/structure/ore_box,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
@@ -328,6 +327,7 @@
 "wy" = (/obj/machinery/vending/armory/attachment,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "wW" = (/obj/structure/urinal,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "xa" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"xf" = (/obj/machinery/door/airlock/halo{name = "Nuclear Payload"; req_access = list(142)},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "xx" = (/obj/structure/repair_bench,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "xB" = (/obj/structure/window/reinforced/treated,/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "xD" = (/obj/machinery/door/airlock/halo{name = "Storage"; req_access = list(142)},/turf/space,/area/faction_base/oni/hangar)
@@ -437,7 +437,7 @@ aabhbhbhbhbhbhbhbhbhbhaaeEeEeEaabxbxbxbxbxbxbxbxbxbxyVbxbxbxbxbFeHbJbJebebbJlmbF
 aabhbCbCbCbCbCbCbCbCbhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaWdbFtmbJbJebebbJYmbFeOePePhkePePeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFSNbJbJbJVobJYabFeOePePMPMNwWeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFbFSxSxSxbFbJkPbFeOhkMNMNeOeOeOeOeOeOaa
-aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdUluUbJbJbJbFodbFbFeOeOeOeOeOeOeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdUluUbJbJbJbFxfbFbFeOeOeOeOeOeOeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdNebJbJbJbJbFaxfvbFeOeOeOeOeOeOeOeOeOeOaa
 aabhcMbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdejehebkFglbFfegJbFeOeOeOeOeOeOeOeOeOeOaa
 aafAbhbhbhbhbhbhbhbhbhaadbbQbQbQbQbQbQbQaaesbRbRbRbRbRbRbRaaWdbFbFbFbFbFbFbFbFbFeOeOeOeOeOeOeOeOeOeOaa

--- a/maps/faction_bases/complex046/complex046.dmm
+++ b/maps/faction_bases/complex046/complex046.dmm
@@ -34,10 +34,8 @@
 "aH" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tech/orange{tag = "icon-techfloor_orangefulltwogrid (WEST)"; icon_state = "techfloor_orangefulltwogrid"; dir = 8},/area/faction_base/oni/cryodorms)
 "aI" = (/obj/structure/closet/crate{name = "Defensive AI Crate"},/obj/item/dumb_ai_chip,/obj/item/dumb_ai_chip,/obj/item/dumb_ai_chip,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aJ" = (/obj/effect/landmark/start{name = "ONI Research Director"},/obj/effect/landmark/start{name = "ONI Researcher"},/turf/simulated/floor/tech/white,/area/faction_base/oni/cryodorms)
-"aK" = (/turf/simulated/floor/plating,/area/faction_base/oni/hangar)
 "aL" = (/obj/structure/table/rack,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aM" = (/obj/machinery/autolathe/ammo_fabricator/oni_fab,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"aN" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Glass Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aO" = (/obj/machinery/door/airlock/halo/lifepod{name = "Cargo"; req_access = list(317)},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aP" = (/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aQ" = (/obj/structure/table/standard,/obj/item/weapon/pinpointer/scanpoint_locator/unsc,/obj/item/weapon/pinpointer/scanpoint_locator/unsc,/obj/item/weapon/pinpointer/scanpoint_locator/unsc,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
@@ -52,8 +50,6 @@
 "aZ" = (/turf/simulated/floor/tech/orange,/area/faction_base/oni/cryodorms)
 "ba" = (/obj/item/device/radio/intercom{dir = 1; icon_state = "intercom"; name = "intercom"; pixel_x = 0; pixel_y = -32; tag = "icon-intercom (NORTH)"},/turf/simulated/floor/tech/orange,/area/faction_base/oni/cryodorms)
 "bb" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor/tech/orange,/area/faction_base/oni/cryodorms)
-"bc" = (/obj/machinery/light,/turf/simulated/floor/tech/orange{tag = "icon-techfloor_orangefulltwogrid (SOUTHEAST)"; icon_state = "techfloor_orangefulltwogrid"; dir = 6},/area/faction_base/oni/hangar)
-"bd" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "be" = (/turf/simulated/wall/iron/blue,/area/faction_base/oni)
 "bf" = (/turf/simulated/wall/iron/blue,/area/faction_base/oni/barracks)
 "bg" = (/obj/structure/faction_banner/unsc{name = "ONI Complex 046"; pixel_x = -32; pixel_y = 32},/turf/simulated/floor/tech/steel,/area/faction_base/oni/garage)
@@ -64,11 +60,8 @@
 "bl" = (/obj/item/device/radio/intercom{dir = 4; icon_state = "intercom"; name = "intercom"; pixel_x = -32; pixel_y = 0; tag = "icon-intercom (EAST)"},/obj/machinery/vending/sovietsoda,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "bm" = (/obj/item/weapon/stool{anchored = 1},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "bn" = (/obj/structure/table/standard,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"bo" = (/turf/simulated/wall/iron/blue,/area/faction_base/oni/blacksite)
 "bp" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/machinery/food_replicator,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "bq" = (/turf/simulated/floor/tech/steel,/area/faction_base/oni/garage)
-"br" = (/turf/simulated/floor/tiled/dark,/area/faction_base/oni/blacksite)
-"bs" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Metal Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "bt" = (/obj/machinery/vending/snack,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "bu" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "bv" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
@@ -107,7 +100,6 @@
 "cc" = (/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cd" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "ce" = (/obj/structure/closet/medical_wall/filled{pixel_y = 32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
-"cf" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/plating,/area/faction_base/oni/hangar)
 "cg" = (/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
 "ch" = (/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
 "ci" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/faction_banner/unsc{name = "ONI Complex 046"; pixel_y = 32},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
@@ -126,13 +118,8 @@
 "cv" = (/obj/structure/bed/chair/comfy/captain{name = "Comfy Chair"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cw" = (/obj/item/device/radio/intercom{dir = 8; icon_state = "intercom"; name = "intercom"; pixel_x = 25; pixel_y = 0; tag = "icon-intercom (WEST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cx" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/closet/crate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"cy" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/blacksite)
 "cz" = (/obj/machinery/light/colored/orange{tag = "icon-orange1 (WEST)"; icon_state = "orange1"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
 "cA" = (/obj/machinery/cryopod/oni,/obj/machinery/light/colored/orange{tag = "icon-orange1 (EAST)"; icon_state = "orange1"; dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
-"cB" = (/obj/machinery/light{dir = 1},/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"cC" = (/obj/machinery/light{dir = 1},/obj/machinery/pointbased_vending/armory/heavy,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"cD" = (/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/machinery/pointbased_vending/armory/odstvend,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"cE" = (/obj/machinery/light{dir = 1},/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cF" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/beakers,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "cG" = (/obj/structure/table/glass,/obj/item/weapon/reagent_containers/dropper,/obj/item/device/reagent_scanner/adv,/obj/item/weapon/storage/box/pillbottles,/obj/item/weapon/hand_labeler,/obj/item/weapon/storage/box/pillbottles,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "cH" = (/obj/structure/table/glass,/obj/machinery/reagentgrinder,/obj/item/stack/material/phoron{amount = 10000},/obj/item/stack/material/phoron{amount = 10000},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
@@ -146,7 +133,6 @@
 "cP" = (/obj/structure/table/woodentable,/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cQ" = (/obj/structure/bed/chair/comfy/captain{dir = 8; icon_state = "capchair_preview"; name = "Comfy chair"; tag = "icon-capchair_preview (WEST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cR" = (/obj/machinery/computer/cryopod{pixel_y = -32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
-"cS" = (/obj/machinery/light{dir = 4},/obj/machinery/pointbased_vending/armory/odstvend/armour,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cT" = (/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cU" = (/obj/machinery/pointbased_vending/armory/heavy,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cV" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/brown,/obj/effect/landmark/start/unsc_base_fallback,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
@@ -154,12 +140,10 @@
 "cX" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "cY" = (/obj/structure/closet/crate/medical{name = "Medical Kits Crate"},/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "cZ" = (/obj/structure/bed/chair/comfy/captain{dir = 1; icon_state = "capchair_preview"; name = "Comfy chair"; tag = "icon-capchair_preview (NORTH)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
-"da" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/sofa/right,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "db" = (/obj/effect/shuttle_landmark/unsc_offsite_supply,/turf/simulated/floor/plating,/area/shuttle/unsc_offsite_supply)
 "dc" = (/obj/structure/rearm_repair_station/human{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "dd" = (/turf/simulated/floor/tiled/dark,/area/faction_base/oni/cryodorms)
 "de" = (/obj/structure/closet{icon_closed = "toolcloset"; icon_opened = "toolclosetopen"; icon_state = "toolcloset"},/obj/item/weapon/wrench,/obj/item/weapon/crowbar,/obj/item/weapon/screwdriver,/obj/item/weapon/weldingtool/hugetank,/obj/item/weapon/wirecutters,/obj/item/device/multitool,/obj/item/device/analyzer,/obj/item/stack/cable_coil,/obj/item/clothing/gloves/insulated,/obj/item/clothing/glasses/welding,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"df" = (/obj/item/device/radio/intercom{dir = 4; icon_state = "intercom"; name = "intercom"; pixel_x = -32; pixel_y = 0; tag = "icon-intercom (EAST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "dg" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dh" = (/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "di" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/wrench,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/storage/box/bloodpacks,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
@@ -172,7 +156,6 @@
 "dp" = (/obj/machinery/door/airlock/multi_tile/halo/blast{name = "ONI Research"; req_access = list(315)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "dq" = (/obj/machinery/door/window/odst_armory{icon_state = "left"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "dr" = (/obj/machinery/vending/armory/attachment,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"ds" = (/obj/machinery/light,/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "dt" = (/obj/machinery/vending/armory/medical,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "du" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dv" = (/obj/machinery/atmospherics/unary/cryo_cell{dir = 1},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
@@ -180,7 +163,6 @@
 "dx" = (/obj/machinery/chemical_dispenser/full,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "dy" = (/obj/structure/bed/chair{dir = 8; icon_state = "chair_preview"},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "dz" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"dA" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/obj/structure/table/rack,/obj/item/stack/material/plastic/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "dB" = (/obj/machinery/thermopod{icon_state = "syndipod_0-r"},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dC" = (/obj/machinery/iv_drip,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dD" = (/obj/vehicles/warthog,/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
@@ -191,7 +173,6 @@
 "dI" = (/turf/simulated/floor/light/tech_neon/side,/area/faction_base/oni/hangar)
 "dJ" = (/obj/machinery/door/airlock/glass/cargo_shuttle{name = "Shuttle Access"; req_access = list(317)},/turf/simulated/floor/shuttle/yellow,/area/shuttle/oni_shuttle_supply)
 "dK" = (/obj/machinery/door/airlock/halo{name = "Storage"; req_access = list(142)},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"dL" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Plasteel Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "dM" = (/turf/simulated/floor/light/tech_neon/side{dir = 4},/area/faction_base/oni/hangar)
 "dN" = (/turf/simulated/floor/light/tech_neon/tech_white,/area/faction_base/oni/hangar)
 "dO" = (/turf/simulated/floor/light/tech_neon/side{icon_state = "techfloor_lightedcorner"; dir = 8},/area/faction_base/oni/hangar)
@@ -203,12 +184,10 @@
 "dU" = (/obj/vehicles/air/overmap/pelican/unsc{icon_state = "base"; dir = 4},/turf/simulated/floor/light/tech_neon/tech_white,/area/faction_base/oni/hangar)
 "dV" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/table/rack,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "dW" = (/turf/simulated/floor/light/tech_neon/side{dir = 1},/area/faction_base/oni/hangar)
-"dX" = (/obj/structure/bed/chair{tag = "icon-chair_preview (EAST)"; icon_state = "chair_preview"; dir = 4},/turf/simulated/floor/plating,/area/faction_base/oni/hangar)
 "dY" = (/obj/structure/closet/crate{name = "Resuscitation Supplies"},/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."; name = "Surgery Cleaner"},/obj/item/weapon/storage/box/gloves,/obj/item/weapon/storage/box/masks,/obj/item/weapon/reagent_containers/syringe/ld50_syringe/triadrenaline,/obj/item/weapon/reagent_containers/syringe/ld50_syringe/triadrenaline,/obj/item/weapon/reagent_containers/syringe/ld50_syringe/triadrenaline,/obj/item/weapon/reagent_containers/syringe/ld50_syringe/triadrenaline,/obj/item/weapon/reagent_containers/syringe/ld50_syringe/triadrenaline,/obj/item/weapon/defibrillator/loaded,/obj/item/weapon/defibrillator/compact/combat/loaded,/obj/item/weapon/defibrillator/compact/combat/loaded,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "dZ" = (/obj/machinery/conveyor_switch{id = "oni_cargo_conveyor"},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/tech/white,/area/faction_base/oni/hangar)
 "ea" = (/obj/machinery/light,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "eb" = (/obj/structure/table/standard,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"ec" = (/obj/machinery/research/protolathe,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ed" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4; name = "ONI Research"; req_access = list(315)},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ee" = (/obj/machinery/bodyscanner{tag = "icon-body_scanner_0 (WEST)"; icon_state = "body_scanner_0"; dir = 8},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "ef" = (/obj/machinery/body_scanconsole{tag = "icon-body_scannerconsole (WEST)"; icon_state = "body_scannerconsole"; dir = 8},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
@@ -219,16 +198,12 @@
 "ek" = (/obj/machinery/atmospherics/unary/cryo_cell,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "el" = (/obj/machinery/door/airlock/halo/lifepod{name = "Medical Storage"; req_access = list(142)},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "em" = (/turf/simulated/floor/shuttle/yellow,/area/shuttle/oni_shuttle_supply)
-"en" = (/obj/structure/table/rack,/obj/item/stack/material/glass/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"eo" = (/obj/structure/table/rack,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ep" = (/turf/simulated/wall/r_wall,/area/faction_base/oni/digsite)
 "eq" = (/obj/structure/shuttle_engine{dir = 4},/turf/simulated/shuttle/wall{icon_state = "swall_straight"},/area/shuttle/oni_shuttle_supply)
 "er" = (/obj/machinery/organ_printer/robot/mapped,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "es" = (/obj/effect/shuttle_landmark/oni_offsite_supply,/turf/simulated/floor/plating,/area/shuttle/oni_offsite_supply)
 "et" = (/obj/structure/grille,/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/machinery/door/firedoor,/obj/structure/window/reinforced/projresist,/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 4},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"eu" = (/obj/structure/table/rack,/obj/item/stack/material/steel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ev" = (/obj/structure/curtain/medical,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
-"ew" = (/obj/machinery/autolathe,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ex" = (/obj/machinery/research/component_dissembler,/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ey" = (/obj/machinery/conveyor{dir = 1; id = "oni_cargo_conveyor"},/obj/structure/plasticflaps/mining,/turf/simulated/floor/shuttle/yellow,/area/shuttle/oni_shuttle_supply)
 "ez" = (/obj/effect/landmark/start{name = "ONI Researcher"},/obj/effect/landmark/start{name = "ONI Research Director"},/turf/simulated/floor/tech/white,/area/faction_base/oni/cryodorms)
@@ -237,33 +212,25 @@
 "eC" = (/obj/machinery/light,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "eD" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/vehicles/mongoose,/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "eE" = (/turf/unsimulated/mineral,/area/faction_base/oni)
-"eF" = (/turf/simulated/mineral,/area/faction_base/oni)
 "eG" = (/obj/vehicles/scorpion_tank,/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "eH" = (/obj/machinery/research/protolathe/circuits,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "eI" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 1; name = "Barracks"; req_access = list(142)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "eJ" = (/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
 "eK" = (/obj/machinery/autolathe,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"eL" = (/obj/structure/table/glass/white,/obj/item/weapon/storage/firstaid/surgery,/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."; name = "Surgery Cleaner"},/obj/item/stack/nanopaste,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "eM" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 1; name = "Forerunner Digsite"},/turf/simulated/floor/tech/ridged,/area/faction_base/oni/digsite)
-"eN" = (/turf/simulated/floor/tech/ridged,/area/faction_base/oni/research)
 "eO" = (/turf/unsimulated/mineral,/area/faction_base/oni/digsite)
 "eP" = (/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "eQ" = (/obj/structure/closet/secure_closet/miner,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "eR" = (/obj/machinery/floodlight/active/hi_cap,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
-"eS" = (/turf/simulated/wall/forerunner,/area/faction_base/oni/digsite)
+"eS" = (/obj/machinery/vending/boozeomat,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "eT" = (/obj/machinery/organ_printer/flesh/mapped{matter = 1e+007; max_stored_matter = 1e+007},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "eU" = (/obj/structure/table/steel_reinforced,/obj/item/bodybag,/obj/item/bodybag,/obj/item/bodybag,/obj/item/bodybag,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "eV" = (/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "eW" = (/obj/structure/morgue,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "eX" = (/obj/item/device/radio/intercom{dir = 8; icon_state = "intercom"; name = "intercom"; pixel_x = 25; pixel_y = 0; tag = "icon-intercom (WEST)"},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
-"eY" = (/obj/machinery/light/colored/blue,/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"eZ" = (/obj/machinery/light,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
-"fa" = (/obj/structure/morgue,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "fb" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/tech/white,/area/faction_base/oni/hangar)
 "fc" = (/obj/structure/crematorium{_wifi_id = "crem1"; dir = 1; id = "crem1"},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
-"fd" = (/turf/simulated/floor/forerunner_alloy,/area/faction_base/oni/digsite)
 "fe" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
-"ff" = (/turf/unsimulated/floor/chasm,/area/faction_base/oni/digsite)
 "fg" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "fh" = (/obj/structure/bumpstairs/road/oni_gem{faction_restrict = "UNSC"},/turf/simulated/floor/pavement/empty,/area/faction_base/oni)
 "fi" = (/obj/machinery/light/street,/turf/simulated/floor/pavement{tag = "icon-pavement (EAST)"; icon_state = "pavement"; dir = 4},/area/faction_base/oni)
@@ -277,29 +244,18 @@
 "fq" = (/obj/effect/landmark/dropship_land_point/unsc/no_artifact{name = "ONI Complex 046 (Geminus)"},/turf/simulated/floor/light/tech_neon/tech_white,/area/faction_base/oni/hangar)
 "fr" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4; name = "Barracks"; req_access = list(142)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "fs" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
-"ft" = (/obj/structure/sofa/corner,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"fu" = (/obj/machinery/door/airlock/halo{name = "Nuclear Payload"; req_access = list(142)},/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
 "fv" = (/obj/machinery/light/colored/green{tag = "icon-green1 (WEST)"; icon_state = "green1"; dir = 8},/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
 "fw" = (/obj/machinery/photocopier/faxmachine/unsc{dir = 8},/turf/simulated/wall/r_wall,/area/faction_base/oni/research)
-"fx" = (/obj/machinery/button/crematorium{_wifi_id = "crem1"; id = "crem1"; pixel_y = -24},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "fy" = (/obj/machinery/smartfridge/chemistry,/turf/simulated/wall/silver{tag = "icon-solidfwall_opening"; icon_state = "solidfwall_opening"},/area/faction_base/oni/medbay)
-"fz" = (/turf/unsimulated/mineral,/area/faction_base/oni/research)
 "fA" = (/obj/effect/overmap/complex046,/turf/simulated/wall/covenant/reinforced,/area/faction_base/oni)
-"fB" = (/obj/machinery/light,/obj/machinery/vending/armory/attachment,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"fC" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/machinery/pointbased_vending/armory/odstvend,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"fD" = (/obj/structure/sofa{icon_state = "sofamiddle"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"fE" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/sofa/right{icon_state = "sofaend_right"; dir = 1},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "fF" = (/obj/machinery/overmap_weapon_console/ship_scanning_console{name = "Holotable - Scanning"; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "holotable"; dir = 2},/turf/simulated/floor/tech,/area/faction_base/oni/research)
 "fG" = (/obj/machinery/overmap_weapon_console/ship_scanning_console{name = "Holotable - Scanning"; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "holotable"; dir = 1},/turf/simulated/floor/tech,/area/faction_base/oni/research)
 "fH" = (/obj/machinery/door/airlock/multi_tile/halo{dir = 4; name = "Fabrication"; req_access = list(142)},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "fI" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/structure/faction_banner/unsc{name = "ONI Complex 046"; pixel_y = 32},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "fJ" = (/obj/machinery/door/airlock/halo{name = "Armory"; req_access = list(142)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"fK" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/blacksite)
 "fL" = (/turf/simulated/floor/plating,/obj/effect/shuttle_landmark/oni_onsite_supply,/turf/simulated/shuttle/wall/corner/smoothwhite/sw,/area/shuttle/oni_shuttle_supply)
 "fM" = (/obj/machinery/overmap_weapon_console/ship_scanning_console{name = "Holotable - Scanning"; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "holotable"; dir = 4},/obj/machinery/light,/turf/simulated/floor/tech,/area/faction_base/oni/research)
 "fN" = (/obj/machinery/overmap_weapon_console/ship_scanning_console{dir = 8; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "holotable"; name = "Holotable - Scanning"},/turf/simulated/floor/tech,/area/faction_base/oni/research)
-"fQ" = (/obj/structure/table/glass/white,/obj/item/weapon/storage/box/masks,/obj/item/weapon/storage/box/gloves,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
-"fR" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "fS" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "fT" = (/obj/structure/closet,/obj/item/clothing/mask/marine,/obj/item/clothing/accessory/holster/thigh,/obj/item/clothing/gloves/thick/oni_guard,/obj/item/clothing/head/helmet/oni_guard,/obj/item/clothing/head/helmet/oni_guard/visor,/obj/item/clothing/shoes/oni_guard,/obj/item/clothing/suit/storage/oni_guard,/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/item/weapon/gun/projectile/m6d_magnum,/obj/item/weapon/gun/projectile/m6d_magnum,/obj/item/weapon/gun/projectile/m7_smg/silenced,/obj/item/weapon/gun/projectile/m7_smg/silenced,/obj/item/weapon/storage/box/m6d_m224,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "fU" = (/obj/structure/closet,/obj/item/clothing/mask/marine,/obj/item/clothing/accessory/holster/thigh,/obj/item/clothing/gloves/thick/oni_guard,/obj/item/clothing/head/helmet/oni_guard,/obj/item/clothing/head/helmet/oni_guard/visor,/obj/item/clothing/shoes/oni_guard,/obj/item/clothing/suit/storage/oni_guard,/obj/item/weapon/gun/projectile/m6d_magnum,/obj/item/weapon/gun/projectile/m6d_magnum,/obj/item/weapon/gun/projectile/m7_smg/silenced,/obj/item/weapon/gun/projectile/m7_smg/silenced,/obj/item/weapon/storage/box/m6d_m225,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
@@ -308,17 +264,14 @@
 "fX" = (/obj/effect/floor_decal/industrial/warning{tag = "icon-warning (SOUTHEAST)"; icon_state = "warning"; dir = 6},/turf/simulated/floor/tech/white,/area/faction_base/oni/hangar)
 "fY" = (/obj/structure/grille,/obj/structure/window/reinforced/treated,/obj/structure/window/reinforced/treated{dir = 1},/obj/structure/window/reinforced/treated{tag = "icon-rwindow (WEST)"; icon_state = "rwindow"; dir = 8},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "fZ" = (/obj/machinery/recharger/wallcharger{pixel_x = 32},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"ga" = (/turf/simulated/floor/tech/steel,/area/faction_base/oni/research)
 "gb" = (/obj/structure/grille,/obj/structure/window/reinforced/treated,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gc" = (/obj/structure/curtain/medical,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "gd" = (/obj/machinery/light,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "ge" = (/obj/machinery/door/airlock/halo{name = "Marine Bunks"; req_access = list(142)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "gf" = (/obj/structure/table/steel_reinforced,/obj/machinery/atmospherics/pipe/simple/visible/blue,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "gg" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/canister/oxygen{dir = 1},/obj/machinery/light{dir = 8},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
-"gh" = (/obj/structure/sofa/corner{icon_state = "sofacorner"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "gi" = (/obj/structure/sign/halo_floorsign/armory,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "gj" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4; name = "ONI Research"; req_access = list(315)},/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
-"gk" = (/obj/structure/table/standard,/obj/machinery/recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "gl" = (/obj/structure/table/standard,/obj/machinery/cell_charger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "gm" = (/obj/structure/shuttle/window{tag = "icon-9"; icon_state = "9"; color = "grey"},/turf/simulated/floor/shuttle/yellow,/area/shuttle/oni_shuttle_supply)
 "gn" = (/turf/simulated/shuttle/wall{dir = 8; icon_state = "swall"},/area/shuttle/oni_shuttle_supply)
@@ -334,69 +287,149 @@
 "gx" = (/obj/effect/floor_decal/industrial/warning{tag = "icon-warning (EAST)"; icon_state = "warning"; dir = 4},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gy" = (/obj/machinery/conveyor{dir = 1; id = "oni_cargo_conveyor"},/turf/simulated/floor/shuttle/yellow,/area/shuttle/oni_shuttle_supply)
 "gz" = (/obj/machinery/door/airlock/multi_tile/halo{dir = 1; name = "Fabrication"; req_access = list(317)},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"gA" = (/obj/item/modular_computer/console/unsc/oni_supply,/turf/simulated/floor/plating,/area/faction_base/oni/hangar)
 "gB" = (/obj/effect/floor_decal/industrial/warning{tag = "icon-warning (EAST)"; icon_state = "warning"; dir = 4},/obj/structure/closet/crate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gC" = (/obj/structure/grille,/obj/structure/window/reinforced/treated,/obj/structure/window/reinforced/treated{dir = 1},/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
-"gD" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/obj/machinery/light/colored/orange{tag = "icon-orange1 (WEST)"; icon_state = "orange1"; dir = 8},/turf/simulated/floor/plating,/area/faction_base/oni/blacksite)
-"gE" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/plating,/area/faction_base/oni/blacksite)
 "gF" = (/obj/machinery/autosurgeon,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
-"gG" = (/obj/machinery/optable,/obj/machinery/oxygen_pump/anesthetic{name = "surgery anesthetic"; pixel_y = -32},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
-"gH" = (/obj/structure/table/standard,/turf/simulated/floor/plating,/area/faction_base/oni/hangar)
 "gI" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gJ" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/payload/self_destruct,/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
 "gM" = (/obj/structure/table/standard,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gR" = (/obj/structure/closet/crate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"gS" = (/obj/machinery/light/colored/orange{tag = "icon-orange1 (EAST)"; icon_state = "orange1"; dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/blacksite)
+"hk" = (/obj/structure/toilet,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"hx" = (/obj/structure/sofa/right,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"iP" = (/turf/simulated/floor/tech/ridged,/area/faction_base/oni/digsite)
+"iX" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 1},/obj/machinery/mech_recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"js" = (/obj/structure/table/rack,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"jQ" = (/obj/item/modular_computer/console/unsc/oni_supply,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"kC" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/surgery,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."; name = "Surgery Cleaner"},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
+"kF" = (/obj/machinery/light/colored/blue,/obj/structure/table/standard,/obj/machinery/recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"kP" = (/obj/structure/table/rack,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"kY" = (/obj/structure/table/standard,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"lm" = (/obj/structure/table/rack,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"lB" = (/obj/machinery/pointbased_vending/armory/odstvend/armour,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"lC" = (/obj/structure/table/standard,/obj/structure/bedsheetbin,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"nV" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Plasteel Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/machinery/light/small{dir = 8},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"nX" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"od" = (/obj/machinery/door/airlock/halo{name = "Nuclear Payload"; req_access = list(142)},/turf/unsimulated/mineral,/area/faction_base/oni/research)
+"os" = (/obj/structure/noticeboard,/turf/simulated/wall/iron/blue,/area/faction_base/oni/barracks)
+"oF" = (/obj/structure/fitness/weightlifter,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"oS" = (/obj/machinery/light,/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"pe" = (/obj/structure/ore_box,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"qh" = (/obj/structure/inflatable/wall,/obj/structure/inflatable/wall,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"qK" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/closet/crate/bin,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"rF" = (/obj/machinery/light{dir = 4},/obj/machinery/pointbased_vending/armory/heavy,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"rT" = (/obj/machinery/light{dir = 1},/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/obj/structure/bed/padded,/obj/item/weapon/bedsheet/brown,/obj/effect/landmark/start/unsc_base_fallback,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"sd" = (/obj/structure/table/rack,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"sD" = (/obj/structure/showcase,/obj/structure/window/reinforced/treated{tag = "icon-rwindow (WEST)"; icon_state = "rwindow"; dir = 8},/obj/structure/window/reinforced/treated,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"sU" = (/obj/machinery/light{dir = 1},/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"sX" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
+"ti" = (/obj/structure/fitness/punchingbag,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"tm" = (/obj/machinery/light{dir = 8},/obj/machinery/autolathe,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"tI" = (/obj/structure/plushie/drone,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"tO" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4; name = "ONI Mech Storage"; req_access = list(315)},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"uU" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 1},/obj/machinery/vending/engivend,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"vd" = (/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"wl" = (/obj/structure/sofa/left,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"wW" = (/obj/structure/urinal,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"xa" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"xx" = (/obj/structure/repair_bench,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"xK" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"yV" = (/obj/machinery/button/crematorium{_wifi_id = "crem1"; id = "crem1"; pixel_y = -24},/turf/simulated/wall/silver{tag = "icon-solidfwall_opening"; icon_state = "solidfwall_opening"},/area/faction_base/oni/medbay)
+"At" = (/obj/machinery/light,/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"AW" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/sofa/right,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"BL" = (/obj/structure/inflatable/wall,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"Dj" = (/obj/structure/table/standard,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Ew" = (/obj/structure/table/rack,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"EI" = (/obj/machinery/pointbased_vending/armory/odstvend,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"EJ" = (/obj/machinery/mech_recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"ET" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/obj/structure/table/rack,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Ga" = (/obj/structure/table/rack,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Gr" = (/obj/item/device/radio/intercom{dir = 4; icon_state = "intercom"; name = "intercom"; pixel_x = -32; pixel_y = 0; tag = "icon-intercom (EAST)"},/obj/machinery/vending/armory/medical,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"Hm" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Glass Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"HD" = (/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"IZ" = (/obj/structure/inflatable/door{name = "inflatable door-DANGER-"},/turf/simulated/floor/tech/steel,/area/faction_base/oni/research)
+"Jl" = (/obj/machinery/mecha_part_fabricator,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"JK" = (/obj/structure/bed/chair{tag = "icon-chair_preview (EAST)"; icon_state = "chair_preview"; dir = 4},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"JP" = (/obj/structure/janitorialcart,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"Kk" = (/obj/structure/bookcase/manuals/research_and_development,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"Li" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/obj/machinery/light/colored/orange{tag = "icon-orange1 (WEST)"; icon_state = "orange1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
+"LE" = (/obj/machinery/light/colored/orange{tag = "icon-orange1 (EAST)"; icon_state = "orange1"; dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
+"LZ" = (/obj/structure/repair_bench,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"MN" = (/turf/unsimulated/floor/lava,/area/faction_base/oni/digsite)
+"MO" = (/obj/machinery/mech_recharger,/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"MP" = (/obj/structure/plushie/ian,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"Ne" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Nf" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"PG" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Metal Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"PK" = (/obj/structure/reagent_dispensers/fueltank,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Qj" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/largecrate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"Ql" = (/obj/machinery/oxygen_pump/anesthetic{name = "surgery anesthetic"; pixel_y = -32},/obj/machinery/optable,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
+"QS" = (/obj/structure/plushie/beepsky,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"QZ" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/gloves,/obj/item/weapon/storage/box/masks,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
+"Sn" = (/obj/machinery/light,/turf/simulated/floor/tech/orange{tag = "icon-techfloor_orangefulltwogrid (SOUTHEAST)"; icon_state = "techfloor_orangefulltwogrid"; dir = 6},/area/faction_base/oni/cryodorms)
+"Sx" = (/turf/simulated/floor/stairs/north,/area/faction_base/oni/research)
+"SN" = (/obj/machinery/research/protolathe,/obj/machinery/light/colored/blue,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"TM" = (/obj/structure/largecrate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"Ul" = (/obj/machinery/vending/tool,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Vo" = (/obj/machinery/light/colored/blue,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Vt" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"Wd" = (/turf/simulated/wall/r_wall,/area/faction_base/oni)
+"Ww" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Xe" = (/obj/structure/plushie/carp,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"Xx" = (/turf/simulated/floor/stairs/west,/area/faction_base/oni/barracks)
+"Ya" = (/obj/structure/table/rack,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Ym" = (/obj/machinery/light/colored/green{tag = "icon-green1 (WEST)"; icon_state = "green1"; dir = 8},/obj/structure/table/rack,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"Zr" = (/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"ZM" = (/obj/structure/girder/reinforced,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabacacadafafagafafaaababababababaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aafhacacadafafagafafaafpalaqacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacadafafafafafafafafahacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacfiafafafafafafafaffjacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacadafafafafafarararahacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacadafafagafafafafafahacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacadafafanafafafafafahacacacaiajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaa
-aaabacacfiafafafafafarararfjacacacaiawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
-aaabacacadafafafafafafafafahacacacaiawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafagafafaaababababababaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aafhacacadafafagafafaafpalaqacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafafafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacfiafafafafafafafaffjacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafafafafarararahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafagafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafanafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacfiafafafafafarararfjacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
+aaabacacadafafafafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
 aaabacacadafafafafafafafafahacacacaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aafoacacayafafafaffVafafafahfnabfWaiaabebebebebebebebebebebebebeaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaa
-aaasatbqasaUaWaWaWasasasasasasaDaDaDaDaeaeaeaeaeaeaeaeaeaeaeaeaeaDaEaQaIaLaLaDgRaPaPaPaPbdgIgHgHgHaDaa
-aaasbgbqbPaWaWaWaWcicjcjcjcjfIaDaDaDaDaeaeamaoazavazazavazazazaAaDaPaPaPaPaPaOaPaPaPaPaPaPaPaKdXgAaDaa
-aaasckbqaWaWaWaWaWcjapcjcjdDcjaDaDaDaDaeaBaCaFaCaFaCaFaCaFaCaFaGaDaNaPaPaPaSaDbLaPaKaKaKaPaPaKaKcfaDaa
-aaasbqbqaWaWaWaWaWaWaWaWaWaWaWaDaDaDaDaeaHaJfmezfmezfmezfmezfmaGaDdLaPaPaPaLaDaPaPaKaKaKdQdTdZfbfbaDaa
-aaasbqcmcjcjcjaVaWaWaWaWaWaWaWaDaDaDaDaeaRaZaZaZaYaZaZaZbabbaZbcaDbsaPaPgvdeaDdlaPaDaDaDfXgqguguguaDaa
-aaasbqbqcjcjcjaWaWaWaWcjcjeAeDaDaDaDaDaeaeaeaeaeaeaecIddaeaeaeaDaDaDaDdKaDaDaDaPgxdFgtgndJeygogmgnaDaa
-aaasbqbqeGcjcjaWaWaWaWeAcjcjcjbqeBeBdRdHdIdIdIdIdIdSeBeBbBaTaPcxaMeKgMaPaPaLdVaPgxgpemememgyememeqaDaa
+aafoacacayafafafaffVafafafahfnabfWbebebebebebebebebebebebebebebeaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaa
+aaasatbqasaUaWaWaWasasasasasasaDaDaDaDaeaeaeaeaeaeaeaeaeaeaeaeaeaDaEaQaIaLaLaDgRTMTMTMTMQjTMgMgMgMaDaa
+aaasbgbqbPaWaWaWaWcicjcjcjcjfIaDaDaDaDaeaeamaoazavazazavazazazaAaDaPaPaPaPaPaOaPaPaPaPaPaPaPaPJKjQaDaa
+aaasckbqaWaWaWaWaWcjapcjcjdDcjaDaDaDaDaeaBaCaFaCaFaCaFaCaFaCaFaGaDHmaPaPaPaSaDbLaPgIaPaPaPaPaPaPNfaDaa
+aaasbqbqaWaWaWaWaWaWaWaWaWaWaWaDaDaDaDaeaHaJfmezfmezfmezfmezfmaGaDnVaPaPaPJPaDaPaPaPaPaPdQdTdZfbfbaDaa
+aaasbqcmcjcjcjaVaWaWaWaWaWaWaWaDaDaDaDaeaRaZaZaZaYaZaZaZbabbaZSnaDPGaPaPgvdeaDdlaPaDaDaDfXgqguguguaDaa
+aaasbqbqcjcjcjaWaWaWaWeAeAeAeDaDaDaDaDaeaeaeaeaeaeaecIddaeaeaeaeaDaDaDdKaDaDaDaPgxdFgtgndJeygogmgnaDaa
+aaasbqbqeGcjcjaWaWaWaWcjcjcjcjbqeBeBdRdHdIdIdIdIdIdSeBeBbBaTaMcxaMeKgMaPaPaLdVaPgxgpemememgyememeqaDaa
 aaasckbqbqbqbqbqbqbqbqbqbqbqbqbqeBeBdMdNdNdNdNdNdNdOeBeBetaPaPaPaPaPaPaPaPaPaPaPgxgremememgyememeqaDaa
 aaasbqbqbqakcnbqbqbqakbqbqcnbqaueBeBdMdNdPdPdPdPdNdOfseBaPaPaPaPaPaPaPaPaPaPaPaPgxgsemememgyememeqaDaa
 aabfbfeIbVbfbfbfbfbfbfeIbVbfbfbfeBeBdMdNdPdPdPdPdNdOeBeBfHaPaPaPaPaPaPaPaPaPaPaPgxgpemememgyememeqaDaa
 aabfbibVbVbVbjbVbkbVbVbVbVfTfUbfeBeBdMfqdUdNdNdNdNdOeBeBaDaXcaflgRgRaPaPaPaPeagRgBfLgtgtgmgmgtgtgnaDaa
-aabfblbVbVbmbnbmbVbmbnbmbVbVbVbVeBeBdRdWdWdWdWdWdWdReBfgaDaDaDaDfYgbgwgzaPfYgbgbgwaDgDgEgEgEgEgEboboaa
-aabfbpbVbVbmbnbmbVbmbnbmbVbVbVfreBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBbrbrbrbrbrgSboaa
-aabfbtbVbVbmbnbmbVbmbnbmbVbVbubfeBeCeBeBeBeBeBdceBeBeCeBeBeBeBeCeBeBeBeBeBeBeBeBeBeBeBbrbrbrbrbrbrboaa
-aabfbVbVbVbVbVbVbvbVbVbVbVbVbwbfbxbxbybzbAbIeVbxbxbxbxbDbEbKbxbFbGbHgCbMccbGbHbHgCbFbObrbNbNcsbNbNbNaa
-aabfbVbVgigdgibSbTbUgdbVbVbVbVbfbxbWeVeVfyeVeVeVeVbXbxbYbZegbxbFcbcdcccccccccccdfkbFbJbrbNcecgchclbNaa
-aabfbfbffJbffJbfbfbfbfbfgebfbfbfbxcocpeVcqeVeVcreVeVeleVeVbXbxcNcQcccccucccvcccccwbFbJcybNczcgcgcAbNaa
-aabfbfcBbVbVbVcCcDcSbfcEbVbVcEbfbxcFcGcHbxeVeVbxevevbxeVeVcJbxcNcQcccKcLcOcPcQccccbFbJbrbNcRcgcgclbNaa
-aabfbfcTbVbVbVcUdaftbfcVbVbVcVbfbxdgcWcWeVeVeVevdhfSbxeVeVcYbxbFctcccccZcccZccfFfGbFbJfKbNbNbNbNbNbNaa
-aabfbfdfbVbVbVbVdqfDbfcVbVbVcVbfbxdmeVeVeVeVeVevgFdhbxeVeVdibxfwcQdjccccccccccfMfNbFbJbJbFeEeEeEeEeEeE
-aabfbfcTbVbVbVdrfEghbfcVbVbVcVbfbxdneVeVdtducXbxevevbxeVeVdobxbFbFbFbFdpccbFbFbFbFbFdkbJbFeEeFeFeFeFeE
-aabfbfdsbVbVbVfBfCcSbfcVgdbVcVbfbxdveVeVdBdCeVevdhfSbxeVeVdwbxbFdxdydzbJbJbJbJbJbJdzbJbJbFeEeFeFeFeFeE
-aabfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbxdEeVeVeeefeVevgFdhbxdGeVdYbxbFeibJbJebeHbJbJedbJbJbJbJbFeEeFeFeFeFeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabxekeVeVereTeVbxevevbxbxelbxbxbFexbJbJewebbJfZbFgagabFbFbFeEeFeFeFeFeE
-aaeEeEeEeEeEeEeEeEeEeEeEeEeEeEaabxgfeVeVeVeVeVeVeVeVeVeVeVeVeVeJbJbJbJebecbJdAepeMeNbFfzfzeOeEeFeFeFeE
-aaeEeEeEeEeEeEeEeEeEeEeEeEeEeEaabxggeVeVeVeVeVdGeVeVeVeVdGeVeVgjbJbJbJbJbJbJenepePePePePePeQeOeOeOeFeE
-aaeEeEeEeEeEeEeEeEeEeEeEeEeEeEaabxbxgcbxbxbxgcbxbxbxgcbxbxbxbxbFbJbJbJbJbJbJeoepePePePePePePePeReOeOeE
-aaeEeEeEeEeEeEeEeEeEeEeEeEeEeEaabxeLeVfQbxeLeVfQbxeUeVeVbxbxbxbFejehgkgleYbJeuepePePePePePePePePePeOeE
-aaaaaaaaaaaaaaaaaaaaaaaaeEeEeEaabxfReVeVbxfReVeVbxeWeVeXbxbxbxbFbFbFbFbFbFfubFepeRePePePePePePePePeOeE
-aabhbhbhbhbhbhbhbhbhbhaaeEeEeEaabxdhgGeZbxdhgGeZbxfafxfcbxbxbxeEeEeEeEbFaxaxbFeEeOePePePePePePePePeOeE
-aabhbCbCbCbCbCbCbCbCbhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabxeEeEeEeEbFfefvbFeEeOeSfdfdfdfdfdfdfdeSaa
-aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaaaeEeEeEeEbFgJaxbFeEeOeSfdfdfdfdfdfdfdeSaa
-aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaeEeEeEeEeEbFbFbFbFeEeOeSffffffffffffffeSaa
-aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaeEeEeEeEeEeEeEeEeEeEeOeSffffffffffffffeSaa
-aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaeEeEeEeEeEeEeEeEeEeEeOeSffffffffffffffeSaa
-aabhcMbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaeEeEeEeEeEeEeEeEeEeEeOeSffffffffffffffeSaa
-aafAbhbhbhbhbhbhbhbhbhaadbbQbQbQbQbQbQbQaaesbRbRbRbRbRbRbRaaeEeEeEeEeEeEeEeEeEeEeOeSeSeSeSeSeSeSeSeSaa
+aabfblbVbVbmbnbmbVbmbnbmbVbVbVbVeBeBdRdWdWdWdWdWdWdReBfgaDaDaDaDfYgbgwgzaPfYgbgbgwaDLisXsXsXsXsXaDaDaa
+aabfbpbVbVbmbnbmbVbmbnbmbVbVbVfreBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBLEaDaa
+aabfbtbVbVbmbnbmbVbmbnbmbVbVbubfeBeCeBeBeBeBeBdceBeBeCeBeBeBeBeCeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBaDaa
+aabfKkbVbVbVbVbVbvbVbVbVbVbVbwbfbxbxbybzbAbIeVbxbxbxbxbDbEbKbxbFbGbHgCbMccbGbHbHgCbFbObJbNbNcsbNbNbNaa
+aabfKkbVgigdgibSbTbUgdbVbVlCbnbfbxbWeVeVfyeVeVeVeVbXbxbYbZegbxbFcbcdcccccccccccdfkbFbJbJbNcecgchclbNaa
+aabfbfbffJosfJbfbfbfbfbfgebfbfbfbxcocpeVcqeVeVcreVeVeleVeVbXbxcNcQcccccucccvcccccwbFbJWwbNczcgcgcAbNaa
+aaeEbfsUbVbVbVbjvdrFbfrTbVbVrTbfbxcFcGcHbxeVeVbxevevbxeVeVcJbxcNcQcccKcLcOcPcQccccbFbJbJbNcRcgcgclbNaa
+aaeEbfcTbVbVbVbVbVcUbfcVbVbVcVbfbxdgcWcWeVeVeVevdhfSbxeVeVcYbxbFctcccccZcccZccfFfGbFbJxabNbNbNbNbNbNaa
+aaeEbfGrbVbVbVbVbVdrbfcVbVbVcVbfbxdmeVeVeVeVeVevgFdhbxeVeVdibxfwcQdjccccccccccfMfNbFbJbJbFiXEJiXbFbFaa
+aaeEbfcTbVbVbVbVbVcUbfcVbVbVcVbfbxdneVeVdtducXbxevevbxHDeVdobxbFbFbFbFdpccbFbFbFbFbFdkbJbFbJbJbJMObFaa
+aaeEbfZrbVbVbVbVbVrFbfcVgdbVcVbfbxdveVeVdBdCeVevdhfSbxHDeVdwbxbFdxdydzbJbJbJbJbJbJdzbJbJbJbJbJbJEJbFaa
+aaeEbfZrbVbVbVxxbfbfbfbfbfbfbfbfbxdEeVeVeeefeVevgFdhbxoSeVdYbxbFeibJbJbJbJbJbJedbJbJbJbJtObJbJbJMObFaa
+aaeEbfcTbVbVbVbVAWwlsDhxwlbjlBbfbxekeVeVereTeVbxevevbxbxelbxbxbFexbJbJebebbJfZbFIZIZbFbFbFbFbFbFbFbFaa
+aaeEbfGrbVbVbVXxdqbVbVbVbVbVlBbfbxgfeVeVeVeVeVeVeVeVeVeVeVeVeVeJbJbJbJebebbJETbFeMiPepeReQeOeOeOeOeOaa
+aaeEbfcTbVbVbVXxdqbVbVbVbVbVEIbfbxggeVeVeVeVeVdGeVeVeVeVdGeVeVgjbJbJbJebebbJGabFVtZMBLhkePpeeOeOeOeOaa
+aaeEbfAtbVbVbVgdqKeSLZtioFgdEIbfbxbxgcbxbxbxgcbxbxbxgcbxbxbxbxbFPKbJbJbJbJbJjsbFZMqhBLePePePeOeOeOeOaa
+aaeEbfbfbfbfbfbfbfbfbfbfbfbfbfbfbxxKeVnXbxxKeVnXbxeUeVeVeVeXbxbFJlbJxaebebbJEwbFBLBLePePXeePeOeOeOeOaa
+aaaaaaaaaaaaaaaaaaaaaaaaeEeEeEaabxkCQlQZbxkCQlQZbxeWeVeWdGfcbxbFJlbJbJebebbJsdbFeRePtIePePePeOeOeOeOaa
+aabhbhbhbhbhbhbhbhbhbhaaeEeEeEaabxbxbxbxbxbxbxbxbxbxyVbxbxbxbxbFeHbJbJebebbJlmbFeOePQSePePePeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaWdbFtmbJbJkYDjbJYmbFeOePePhkePePeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFSNbJbJbJVobJYabFeOePePMPMNwWeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFbFSxSxSxbFbJkPbFeOhkMNMNeOeOeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdUluUbJbJbJbFodbFbFeOeOeOeOeOeOeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdNebJbJbJbJbFaxfvbFeOeOeOeOeOeOeOeOeOeOaa
+aabhcMbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdejehebkFglbFfegJbFeOeOeOeOeOeOeOeOeOeOaa
+aafAbhbhbhbhbhbhbhbhbhaadbbQbQbQbQbQbQbQaaesbRbRbRbRbRbRbRaaWdbFbFbFbFbFbFbFbFbFeOeOeOeOeOeOeOeOeOeOaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}

--- a/maps/faction_bases/complex046/complex046.dmm
+++ b/maps/faction_bases/complex046/complex046.dmm
@@ -43,7 +43,6 @@
 "aS" = (/obj/structure/reagent_dispensers/fueltank,/obj/machinery/light/small{dir = 4; pixel_y = 8},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aT" = (/obj/machinery/overmap_comms/receiver,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aU" = (/obj/machinery/door/blast/regular/quadruple{id = "oni_geminus_garage_outer"; name = "Complex 046 Garage Blast Doors"},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
-"aV" = (/obj/effect/landmark/dropship_land_point/unsc/no_artifact{name = "ONI Complex 046 (Geminus) Vehicle Bay"},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "aW" = (/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "aX" = (/obj/machinery/vending/engivend,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "aY" = (/obj/machinery/light,/turf/simulated/floor/tech/orange,/area/faction_base/oni/cryodorms)
@@ -117,7 +116,6 @@
 "cu" = (/obj/structure/bed/chair/comfy/captain{name = "Comfy chair"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cv" = (/obj/structure/bed/chair/comfy/captain{name = "Comfy Chair"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cw" = (/obj/item/device/radio/intercom{dir = 8; icon_state = "intercom"; name = "intercom"; pixel_x = 25; pixel_y = 0; tag = "icon-intercom (WEST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
-"cx" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/closet/crate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "cz" = (/obj/machinery/light/colored/orange{tag = "icon-orange1 (WEST)"; icon_state = "orange1"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
 "cA" = (/obj/machinery/cryopod/oni,/obj/machinery/light/colored/orange{tag = "icon-orange1 (EAST)"; icon_state = "orange1"; dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
 "cF" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/beakers,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
@@ -133,8 +131,6 @@
 "cP" = (/obj/structure/table/woodentable,/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cQ" = (/obj/structure/bed/chair/comfy/captain{dir = 8; icon_state = "capchair_preview"; name = "Comfy chair"; tag = "icon-capchair_preview (WEST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "cR" = (/obj/machinery/computer/cryopod{pixel_y = -32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/blacksite)
-"cT" = (/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"cU" = (/obj/machinery/pointbased_vending/armory/heavy,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cV" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/brown,/obj/effect/landmark/start/unsc_base_fallback,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "cW" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "cX" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
@@ -144,7 +140,6 @@
 "dc" = (/obj/structure/rearm_repair_station/human{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "dd" = (/turf/simulated/floor/tiled/dark,/area/faction_base/oni/cryodorms)
 "de" = (/obj/structure/closet{icon_closed = "toolcloset"; icon_opened = "toolclosetopen"; icon_state = "toolcloset"},/obj/item/weapon/wrench,/obj/item/weapon/crowbar,/obj/item/weapon/screwdriver,/obj/item/weapon/weldingtool/hugetank,/obj/item/weapon/wirecutters,/obj/item/device/multitool,/obj/item/device/analyzer,/obj/item/stack/cable_coil,/obj/item/clothing/gloves/insulated,/obj/item/clothing/glasses/welding,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
-"dg" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dh" = (/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "di" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/wrench,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,/obj/item/weapon/storage/box/bloodpacks,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "dj" = (/obj/machinery/light,/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
@@ -155,9 +150,7 @@
 "do" = (/obj/structure/table/steel_reinforced,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/roller,/obj/item/roller,/obj/item/roller,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/roller,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "dp" = (/obj/machinery/door/airlock/multi_tile/halo/blast{name = "ONI Research"; req_access = list(315)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "dq" = (/obj/machinery/door/window/odst_armory{icon_state = "left"; dir = 8},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
-"dr" = (/obj/machinery/vending/armory/attachment,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "dt" = (/obj/machinery/vending/armory/medical,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
-"du" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dv" = (/obj/machinery/atmospherics/unary/cryo_cell{dir = 1},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "dw" = (/obj/structure/closet/crate/medical,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/combat,/obj/item/weapon/storage/firstaid/adv,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/unsc,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "dx" = (/obj/machinery/chemical_dispenser/full,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
@@ -212,7 +205,6 @@
 "eC" = (/obj/machinery/light,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "eD" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/vehicles/mongoose,/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "eE" = (/turf/unsimulated/mineral,/area/faction_base/oni)
-"eG" = (/obj/vehicles/scorpion_tank,/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "eH" = (/obj/machinery/research/protolathe/circuits,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "eI" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 1; name = "Barracks"; req_access = list(142)},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "eJ" = (/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
@@ -300,59 +292,70 @@
 "iX" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 1},/obj/machinery/mech_recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "js" = (/obj/structure/table/rack,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "jQ" = (/obj/item/modular_computer/console/unsc/oni_supply,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"kk" = (/obj/item/device/radio/intercom{dir = 4; icon_state = "intercom"; name = "intercom"; pixel_x = -32; pixel_y = 0; tag = "icon-intercom (EAST)"},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "kC" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/surgery,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."; name = "Surgery Cleaner"},/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "kF" = (/obj/machinery/light/colored/blue,/obj/structure/table/standard,/obj/machinery/recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "kP" = (/obj/structure/table/rack,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/obj/item/stack/material/iron,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"kY" = (/obj/structure/table/standard,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/obj/item/crystal/orange,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "lm" = (/obj/structure/table/rack,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/obj/item/stack/material/silver/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "lB" = (/obj/machinery/pointbased_vending/armory/odstvend/armour,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "lC" = (/obj/structure/table/standard,/obj/structure/bedsheetbin,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"mS" = (/obj/effect/landmark/dropship_land_point/unsc/no_artifact{name = "ONI Complex 046 (Geminus) Vehicle Bay"},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "nV" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Plasteel Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/machinery/light/small{dir = 8},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "nX" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "od" = (/obj/machinery/door/airlock/halo{name = "Nuclear Payload"; req_access = list(142)},/turf/unsimulated/mineral,/area/faction_base/oni/research)
 "os" = (/obj/structure/noticeboard,/turf/simulated/wall/iron/blue,/area/faction_base/oni/barracks)
-"oF" = (/obj/structure/fitness/weightlifter,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "oS" = (/obj/machinery/light,/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "pe" = (/obj/structure/ore_box,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "qh" = (/obj/structure/inflatable/wall,/obj/structure/inflatable/wall,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "qK" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/closet/crate/bin,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
-"rF" = (/obj/machinery/light{dir = 4},/obj/machinery/pointbased_vending/armory/heavy,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "rT" = (/obj/machinery/light{dir = 1},/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/obj/structure/bed/padded,/obj/item/weapon/bedsheet/brown,/obj/effect/landmark/start/unsc_base_fallback,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "sd" = (/obj/structure/table/rack,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/obj/item/stack/material/gold/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "sD" = (/obj/structure/showcase,/obj/structure/window/reinforced/treated{tag = "icon-rwindow (WEST)"; icon_state = "rwindow"; dir = 8},/obj/structure/window/reinforced/treated,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
-"sU" = (/obj/machinery/light{dir = 1},/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"sN" = (/obj/structure/closet/secure_closet/miner,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
+"sO" = (/obj/machinery/pointbased_vending/armory/heavy,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
+"sS" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/machinery/autolathe/ammo_fabricator/oni_fab,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "sX" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "ti" = (/obj/structure/fitness/punchingbag,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "tm" = (/obj/machinery/light{dir = 8},/obj/machinery/autolathe,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "tI" = (/obj/structure/plushie/drone,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "tO" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4; name = "ONI Mech Storage"; req_access = list(315)},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"uD" = (/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
+"uP" = (/obj/structure/fitness/weightlifter,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "uU" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 1},/obj/machinery/vending/engivend,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"vd" = (/obj/item/device/radio/intercom{name = "intercom"; pixel_y = 32},/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"uW" = (/obj/structure/sofa/left,/obj/structure/window/reinforced/treated{dir = 4},/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"vT" = (/obj/structure/window/reinforced/treated{tag = "icon-rwindow (WEST)"; icon_state = "rwindow"; dir = 8},/obj/machinery/sleeper,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "wl" = (/obj/structure/sofa/left,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
+"wy" = (/obj/machinery/vending/armory/attachment,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "wW" = (/obj/structure/urinal,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "xa" = (/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "xx" = (/obj/structure/repair_bench,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"xB" = (/obj/structure/window/reinforced/treated,/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
+"xD" = (/obj/machinery/door/airlock/halo{name = "Storage"; req_access = list(142)},/turf/space,/area/faction_base/oni/hangar)
 "xK" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"yn" = (/obj/machinery/light{dir = 1},/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
+"yG" = (/obj/machinery/light,/obj/machinery/vending/armory/attachment,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "yV" = (/obj/machinery/button/crematorium{_wifi_id = "crem1"; id = "crem1"; pixel_y = -24},/turf/simulated/wall/silver{tag = "icon-solidfwall_opening"; icon_state = "solidfwall_opening"},/area/faction_base/oni/medbay)
-"At" = (/obj/machinery/light,/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "AW" = (/obj/structure/window/reinforced/projresist{icon_state = "rwindow"; dir = 8},/obj/structure/sofa/right,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "BL" = (/obj/structure/inflatable/wall,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
-"Dj" = (/obj/structure/table/standard,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/obj/item/crystal/pink,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"BM" = (/obj/machinery/pointbased_vending/armory/heavy,/obj/structure/window/reinforced/treated,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
+"Em" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "Ew" = (/obj/structure/table/rack,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/obj/item/stack/material/steel/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "EI" = (/obj/machinery/pointbased_vending/armory/odstvend,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "EJ" = (/obj/machinery/mech_recharger,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "ET" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/obj/structure/table/rack,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/item/stack/material/plastic/fifty,/obj/structure/window/reinforced/treated{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "Ga" = (/obj/structure/table/rack,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"Gr" = (/obj/item/device/radio/intercom{dir = 4; icon_state = "intercom"; name = "intercom"; pixel_x = -32; pixel_y = 0; tag = "icon-intercom (EAST)"},/obj/machinery/vending/armory/medical,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "Hm" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Glass Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/reinforced/fifty,/obj/item/stack/material/glass/fifty,/obj/item/stack/material/glass/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "HD" = (/obj/structure/closet/crate/freezer,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
+"IV" = (/obj/machinery/pointbased_vending/armory/hybrid,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "IZ" = (/obj/structure/inflatable/door{name = "inflatable door-DANGER-"},/turf/simulated/floor/tech/steel,/area/faction_base/oni/research)
 "Jl" = (/obj/machinery/mecha_part_fabricator,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "JK" = (/obj/structure/bed/chair{tag = "icon-chair_preview (EAST)"; icon_state = "chair_preview"; dir = 4},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "JP" = (/obj/structure/janitorialcart,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"Kf" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/structure/rearm_repair_station/human,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "Kk" = (/obj/structure/bookcase/manuals/research_and_development,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
 "Li" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/structure/window/reinforced/treated{dir = 1},/obj/machinery/light/colored/orange{tag = "icon-orange1 (WEST)"; icon_state = "orange1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "LE" = (/obj/machinery/light/colored/orange{tag = "icon-orange1 (EAST)"; icon_state = "orange1"; dir = 4},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
+"LY" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
 "LZ" = (/obj/structure/repair_bench,/turf/simulated/floor/carpet/blue,/area/faction_base/oni/barracks)
 "MN" = (/turf/unsimulated/floor/lava,/area/faction_base/oni/digsite)
 "MO" = (/obj/machinery/mech_recharger,/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
@@ -365,21 +368,28 @@
 "Ql" = (/obj/machinery/oxygen_pump/anesthetic{name = "surgery anesthetic"; pixel_y = -32},/obj/machinery/optable,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "QS" = (/obj/structure/plushie/beepsky,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "QZ" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/gloves,/obj/item/weapon/storage/box/masks,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
+"Rn" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/stairs/west,/area/faction_base/oni/barracks)
+"Rw" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/vehicles/scorpion_tank,/turf/simulated/floor/road{tag = "icon-road_empty (NORTH)"; icon_state = "road_empty"; dir = 1},/area/faction_base/oni/garage)
 "Sn" = (/obj/machinery/light,/turf/simulated/floor/tech/orange{tag = "icon-techfloor_orangefulltwogrid (SOUTHEAST)"; icon_state = "techfloor_orangefulltwogrid"; dir = 6},/area/faction_base/oni/cryodorms)
 "Sx" = (/turf/simulated/floor/stairs/north,/area/faction_base/oni/research)
 "SN" = (/obj/machinery/research/protolathe,/obj/machinery/light/colored/blue,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "TM" = (/obj/structure/largecrate,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"TS" = (/obj/machinery/light,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "Ul" = (/obj/machinery/vending/tool,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
+"UV" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "Vo" = (/obj/machinery/light/colored/blue,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "Vt" = (/obj/structure/girder/displaced,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"VS" = (/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 "Wd" = (/turf/simulated/wall/r_wall,/area/faction_base/oni)
 "Ww" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "Xe" = (/obj/structure/plushie/carp,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
 "Xx" = (/turf/simulated/floor/stairs/west,/area/faction_base/oni/barracks)
+"XY" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/ai_routing_node/unsc,/turf/simulated/floor/tech/white,/area/faction_base/oni/medbay)
 "Ya" = (/obj/structure/table/rack,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/obj/item/stack/material/diamond/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
 "Ym" = (/obj/machinery/light/colored/green{tag = "icon-green1 (WEST)"; icon_state = "green1"; dir = 8},/obj/structure/table/rack,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/obj/item/stack/material/uranium/ten,/turf/simulated/floor/tiled/dark,/area/faction_base/oni/research)
-"Zr" = (/obj/machinery/pointbased_vending/armory/armor,/turf/simulated/floor/tech/gray,/area/faction_base/oni/barracks)
+"YO" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/machinery/sleeper,/turf/simulated/floor/tiled/white,/area/faction_base/oni/medbay)
 "ZM" = (/obj/structure/girder/reinforced,/turf/unsimulated/floor/dirt{icon = 'code/modules/halo/misc/TWS- Assests/floors/floors.dmi'},/area/faction_base/oni/digsite)
+"ZN" = (/turf/simulated/floor/reinforced,/area/faction_base/oni/barracks)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -392,39 +402,39 @@ aaabacacadafafagafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawaw
 aaabacacadafafanafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
 aaabacacfiafafafafafarararfjacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
 aaabacacadafafafafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
-aaabacacadafafafafafafafafahacacacaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaabacacadafafafafafafafafahacacacaiajajajawawawawawawawawawawawawawawawawawawawawawawawawawawawawawaa
 aafoacacayafafafaffVafafafahfnabfWbebebebebebebebebebebebebebebeaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaDaa
 aaasatbqasaUaWaWaWasasasasasasaDaDaDaDaeaeaeaeaeaeaeaeaeaeaeaeaeaDaEaQaIaLaLaDgRTMTMTMTMQjTMgMgMgMaDaa
-aaasbgbqbPaWaWaWaWcicjcjcjcjfIaDaDaDaDaeaeamaoazavazazavazazazaAaDaPaPaPaPaPaOaPaPaPaPaPaPaPaPJKjQaDaa
-aaasckbqaWaWaWaWaWcjapcjcjdDcjaDaDaDaDaeaBaCaFaCaFaCaFaCaFaCaFaGaDHmaPaPaPaSaDbLaPgIaPaPaPaPaPaPNfaDaa
-aaasbqbqaWaWaWaWaWaWaWaWaWaWaWaDaDaDaDaeaHaJfmezfmezfmezfmezfmaGaDnVaPaPaPJPaDaPaPaPaPaPdQdTdZfbfbaDaa
-aaasbqcmcjcjcjaVaWaWaWaWaWaWaWaDaDaDaDaeaRaZaZaZaYaZaZaZbabbaZSnaDPGaPaPgvdeaDdlaPaDaDaDfXgqguguguaDaa
-aaasbqbqcjcjcjaWaWaWaWeAeAeAeDaDaDaDaDaeaeaeaeaeaeaecIddaeaeaeaeaDaDaDdKaDaDaDaPgxdFgtgndJeygogmgnaDaa
-aaasbqbqeGcjcjaWaWaWaWcjcjcjcjbqeBeBdRdHdIdIdIdIdIdSeBeBbBaTaMcxaMeKgMaPaPaLdVaPgxgpemememgyememeqaDaa
+aaasbgbqbPaWaWaWaWcicjcjKfcjfIaDsNLYsNaeaeamaoazavazazavazazazaAaDaPaPaPaPaPaOaPaPaPaPaPaPaPaPJKjQaDaa
+aaasckbqaWaWaWaWaWcjapcjcjdDcjaDsNeBsNaeaBaCaFaCaFaCaFaCaFaCaFaGaDHmaPaPaPaSaDbLaPgIaPaPaPaPaPaPNfaDaa
+aaasbqbqaWaWaWaWaWaWaWaWaWaWaWaDsNeBsNaeaHaJfmezfmezfmezfmezfmaGaDnVaPaPaPJPaDaPaPaPaPaPdQdTdZfbfbaDaa
+aaasbqcmcjcjcjmSaWaWaWaWaWaWaWaDsNeBsNaeaRaZaZaZaYaZaZaZbabbaZSnaDPGaPaPgvdeaDdlaPaDaDaDfXgqguguguaDaa
+aaasbqbqcjRwcjcjaWaWaWeAeAeAeDaDaDxDaDaeaeaeaeaeaeaecIddaeaeaeaeaDaDaDdKaDaDaDaPgxdFgtgndJeygogmgnaDaa
+aaasbqbqcjcjcjcjaWaWaWcjcjcjcjbqeBeBdRdHdIdIdIdIdIdSeBeBbBaTaPsSaMeKgMaPaPaLdVaPgxgpemememgyememeqaDaa
 aaasckbqbqbqbqbqbqbqbqbqbqbqbqbqeBeBdMdNdNdNdNdNdNdOeBeBetaPaPaPaPaPaPaPaPaPaPaPgxgremememgyememeqaDaa
-aaasbqbqbqakcnbqbqbqakbqbqcnbqaueBeBdMdNdPdPdPdPdNdOfseBaPaPaPaPaPaPaPaPaPaPaPaPgxgsemememgyememeqaDaa
+aaasbqbqbqbqcnbqakbqbqbqbqcnbqaueBeBdMdNdPdPdPdPdNdOfseBaPaPaPaPaPaPaPaPaPaPaPaPgxgsemememgyememeqaDaa
 aabfbfeIbVbfbfbfbfbfbfeIbVbfbfbfeBeBdMdNdPdPdPdPdNdOeBeBfHaPaPaPaPaPaPaPaPaPaPaPgxgpemememgyememeqaDaa
 aabfbibVbVbVbjbVbkbVbVbVbVfTfUbfeBeBdMfqdUdNdNdNdNdOeBeBaDaXcaflgRgRaPaPaPaPeagRgBfLgtgtgmgmgtgtgnaDaa
 aabfblbVbVbmbnbmbVbmbnbmbVbVbVbVeBeBdRdWdWdWdWdWdWdReBfgaDaDaDaDfYgbgwgzaPfYgbgbgwaDLisXsXsXsXsXaDaDaa
 aabfbpbVbVbmbnbmbVbmbnbmbVbVbVfreBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBLEaDaa
 aabfbtbVbVbmbnbmbVbmbnbmbVbVbubfeBeCeBeBeBeBeBdceBeBeCeBeBeBeBeCeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBeBaDaa
 aabfKkbVbVbVbVbVbvbVbVbVbVbVbwbfbxbxbybzbAbIeVbxbxbxbxbDbEbKbxbFbGbHgCbMccbGbHbHgCbFbObJbNbNcsbNbNbNaa
-aabfKkbVgigdgibSbTbUgdbVbVlCbnbfbxbWeVeVfyeVeVeVeVbXbxbYbZegbxbFcbcdcccccccccccdfkbFbJbJbNcecgchclbNaa
+aabfKkbVgigdgibSbTbUgdbVbVlCbnbfbxbWeVeVfyeVeVvTeVYObxbYbZegbxbFcbcdcccccccccccdfkbFbJbJbNcecgchclbNaa
 aabfbfbffJosfJbfbfbfbfbfgebfbfbfbxcocpeVcqeVeVcreVeVeleVeVbXbxcNcQcccccucccvcccccwbFbJWwbNczcgcgcAbNaa
-aaeEbfsUbVbVbVbjvdrFbfrTbVbVrTbfbxcFcGcHbxeVeVbxevevbxeVeVcJbxcNcQcccKcLcOcPcQccccbFbJbJbNcRcgcgclbNaa
-aaeEbfcTbVbVbVbVbVcUbfcVbVbVcVbfbxdgcWcWeVeVeVevdhfSbxeVeVcYbxbFctcccccZcccZccfFfGbFbJxabNbNbNbNbNbNaa
-aaeEbfGrbVbVbVbVbVdrbfcVbVbVcVbfbxdmeVeVeVeVeVevgFdhbxeVeVdibxfwcQdjccccccccccfMfNbFbJbJbFiXEJiXbFbFaa
-aaeEbfcTbVbVbVbVbVcUbfcVbVbVcVbfbxdneVeVdtducXbxevevbxHDeVdobxbFbFbFbFdpccbFbFbFbFbFdkbJbFbJbJbJMObFaa
-aaeEbfZrbVbVbVbVbVrFbfcVgdbVcVbfbxdveVeVdBdCeVevdhfSbxHDeVdwbxbFdxdydzbJbJbJbJbJbJdzbJbJbJbJbJbJEJbFaa
-aaeEbfZrbVbVbVxxbfbfbfbfbfbfbfbfbxdEeVeVeeefeVevgFdhbxoSeVdYbxbFeibJbJbJbJbJbJedbJbJbJbJtObJbJbJMObFaa
-aaeEbfcTbVbVbVbVAWwlsDhxwlbjlBbfbxekeVeVereTeVbxevevbxbxelbxbxbFexbJbJebebbJfZbFIZIZbFbFbFbFbFbFbFbFaa
-aaeEbfGrbVbVbVXxdqbVbVbVbVbVlBbfbxgfeVeVeVeVeVeVeVeVeVeVeVeVeVeJbJbJbJebebbJETbFeMiPepeReQeOeOeOeOeOaa
-aaeEbfcTbVbVbVXxdqbVbVbVbVbVEIbfbxggeVeVeVeVeVdGeVeVeVeVdGeVeVgjbJbJbJebebbJGabFVtZMBLhkePpeeOeOeOeOaa
-aaeEbfAtbVbVbVgdqKeSLZtioFgdEIbfbxbxgcbxbxbxgcbxbxbxgcbxbxbxbxbFPKbJbJbJbJbJjsbFZMqhBLePePePeOeOeOeOaa
+aaeEbfynZNbVbVRnuDEmbfrTbVbVrTbfbxcFcGcHbxeVeVbxevevbxeVeVcJbxcNcQcccKcLcOcPcQccccbFbJbJbNcRcgcgclbNaa
+aaeEbfIVZNbVbVXxZNVSbfcVbVbVcVbfbxXYcWcWeVeVeVevdhfSbxeVeVcYbxbFctcccccZcccZccfFfGbFbJxabNbNbNbNbNbNaa
+aaeEbfIVZNbVbVXxZNZNbfcVbVbVcVbfbxdmeVeVeVeVeVevgFdhbxeVeVdibxfwcQdjccccccccccfMfNbFbJbJbFiXEJiXbFbFaa
+aaeEbfxBZNbVbVXxZNVSbfcVbVbVcVbfbxdneVeVdtdtcXbxevevbxHDeVdobxbFbFbFbFdpccbFbFbFbFbFdkbJbFbJbJbJMObFaa
+aaeEbfkkbVbVbVXxZNEmbfcVgdbVcVbfbxdveVeVdBdCeVevdhfSbxHDeVdwbxbFdxdydzbJbJbJbJbJbJdzbJbJbJbJbJbJEJbFaa
+aaeEbfsOZNbVbVxxbfbfbfbfbfbfbfbfbxdEeVeVeeefeVevgFdhbxoSeVdYbxbFeibJbJbJbJbJbJedbJbJbJbJtObJbJbJMObFaa
+aaeEbfBMZNbVbVbVAWwlsDhxuWUVlBbfbxekeVeVereTeVbxevevbxbxelbxbxbFexbJbJebebbJfZbFIZIZbFbFbFbFbFbFbFbFaa
+aaeEbfkkbVbVbVXxdqbVbVbVbVZNlBbfbxgfeVeVeVeVeVeVeVeVeVeVeVeVeVeJbJbJbJebebbJETbFeMiPepeReQeOeOeOeOeOaa
+aaeEbfwyZNbVbVXxdqbVbVbVbVZNEIbfbxggeVeVeVeVeVdGeVeVeVeVdGeVeVgjbJbJbJebebbJGabFVtZMBLhkePpeeOeOeOeOaa
+aaeEbfyGZNbVbVgdqKeSLZtiuPTSEIbfbxbxgcbxbxbxgcbxbxbxgcbxbxbxbxbFPKbJbJbJbJbJjsbFZMqhBLePePePeOeOeOeOaa
 aaeEbfbfbfbfbfbfbfbfbfbfbfbfbfbfbxxKeVnXbxxKeVnXbxeUeVeVeVeXbxbFJlbJxaebebbJEwbFBLBLePePXeePeOeOeOeOaa
 aaaaaaaaaaaaaaaaaaaaaaaaeEeEeEaabxkCQlQZbxkCQlQZbxeWeVeWdGfcbxbFJlbJbJebebbJsdbFeRePtIePePePeOeOeOeOaa
 aabhbhbhbhbhbhbhbhbhbhaaeEeEeEaabxbxbxbxbxbxbxbxbxbxyVbxbxbxbxbFeHbJbJebebbJlmbFeOePQSePePePeOeOeOeOaa
-aabhbCbCbCbCbCbCbCbCbhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaWdbFtmbJbJkYDjbJYmbFeOePePhkePePeOeOeOeOaa
+aabhbCbCbCbCbCbCbCbCbhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaWdbFtmbJbJebebbJYmbFeOePePhkePePeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFSNbJbJbJVobJYabFeOePePMPMNwWeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdbFbFSxSxSxbFbJkPbFeOhkMNMNeOeOeOeOeOeOaa
 aabhbCbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdUluUbJbJbJbFodbFbFeOeOeOeOeOeOeOeOeOeOaa
@@ -433,3 +443,4 @@ aabhcMbCbCbCbCbCbCbCbhaabQbQbQbQbQbQbQbQaabRbRbRbRbRbRbRbRaaWdejehebkFglbFfegJbF
 aafAbhbhbhbhbhbhbhbhbhaadbbQbQbQbQbQbQbQaaesbRbRbRbRbRbRbRaaWdbFbFbFbFbFbFbFbFbFeOeOeOeOeOeOeOeOeOeOaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+


### PR DESCRIPTION
Makes ONI base with the following: 
1. More mats;
2. Expanded and revamped armory;
3. Added medical vendors to the armory;
3. Removal of the unused lift;
4. Addition of more machines for the researchers;
5. Multiple small fixes;
6. Added a mech storage room;
6. Fixing multiple weird areas placement. 

Before: 
![image](https://user-images.githubusercontent.com/56667232/146877379-439515bd-4bde-48b4-b7a5-44601df05c7f.png)
After: 
![image](https://user-images.githubusercontent.com/56667232/146877399-0452e999-8c5c-4825-b0f1-e82dfb13162a.png)


:cl: enkidienne
maptweak: General ONI base update and map rebalance!
maptweak: Removed unused lift in ONI.
/:cl:

