### PR TITLE
toggle flight verb

### DIFF
--- a/code/modules/halo/clothing/jetpacks.dm
+++ b/code/modules/halo/clothing/jetpacks.dm
@@ -20,12 +20,8 @@
 /obj/item/flight_item/verb/toggle_flight()
 	set name = "Toggle Flight"
 	set category = "Object"
-	set src in usr
 
-	if(active)
-		deactivate(usr)
-	else
-		activate(usr)
+	ui_action_click()
 
 /obj/item/flight_item/New()
 	. = ..()

--- a/code/modules/halo/clothing/jetpacks.dm
+++ b/code/modules/halo/clothing/jetpacks.dm
@@ -17,6 +17,16 @@
 	slowdown_general = 0.1
 	action_button_name = "Activate Jump-Jet"
 
+/obj/item/flight_item/verb/toggle_flight()
+	set name = "Toggle Flight"
+	set category = "Object"
+	set src in usr
+
+	if(active)
+		deactivate(usr)
+	else
+		activate(usr)
+
 /obj/item/flight_item/New()
 	. = ..()
 	flight_ticks_curr = flight_ticks_max


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Adds a verb that activates and deactivates jetpacks and wings, to be able to create macros and such.
<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Patata
rscadd: Adds Toggle-Flight verb to jetpacks and wings.
/:cl:
