### PR TITLE
KV32 Ammo Compatability Fix

### DIFF
--- a/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
@@ -23,10 +23,10 @@
 	var/damage
 	switch (severity)
 		if (1.0)
-			damage = 80
+			damage = 120
 
 		if (2.0)
-			damage = 55
+			damage = 60
 
 		if(3.0)
 			damage = 30

--- a/code/modules/halo/weapons/shotguns.dm
+++ b/code/modules/halo/weapons/shotguns.dm
@@ -48,7 +48,7 @@
 	icon_state = "KV-32_unloaded"
 	item_state = "KV-32"
 	load_method = MAGAZINE
-	caliber = "shotgun"
+	caliber = "shotgunlowpower"
 	slot_flags = SLOT_BACK
 	magazine_type = /obj/item/ammo_magazine/kv32
 	one_hand_penalty = -1


### PR DESCRIPTION
:cl: XO-11
tweak: KV32 now actually accepts the correct ammo type.
tweak: Hunters now take a little more damage from higher grade explosions.
/:cl: