### PR TITLE
Finally, Kig-Yar Shield Fixes

### DIFF
--- a/code/modules/halo/weapons/covenant/shield_gauntlet.dm
+++ b/code/modules/halo/weapons/covenant/shield_gauntlet.dm
@@ -123,9 +123,11 @@
 	if(!(get_dir(src, starting) in get_blocked_attack_dirs()))
 		return 0
 
+	if(istype(P, /obj/item/projectile))
+		P.on_impact(src)
+
 	//did our shield absorb the shot?
 	if(drain_shield(damage))
-		P.on_impact(src)
 		//put a chatlog delay on warning the user
 		if(world.time >= time_next_warning)
 			time_next_warning = world.time + GAUNTLET_WARNING_DELAY

--- a/code/modules/halo/weapons/covenant/shield_gauntlet.dm
+++ b/code/modules/halo/weapons/covenant/shield_gauntlet.dm
@@ -124,7 +124,8 @@
 		return 0
 
 	//did our shield absorb the shot?
-	if(drain_shield(damage, P))
+	if(drain_shield(damage))
+		P.on_impact(src)
 		//put a chatlog delay on warning the user
 		if(world.time >= time_next_warning)
 			time_next_warning = world.time + GAUNTLET_WARNING_DELAY
@@ -159,12 +160,6 @@
 			GLOB.processing_objects |= src
 		shield_next_charge = world.time + shield_recharge_delay
 
-
-		//on_impact was being skipped and thats awful
-		if(istype(projectile, /obj/item/projectile))
-			var/obj/item/projectile/P = projectile
-			P.on_impact(src)
-
 		//subtract the damage
 		shield_current_charge -= damage
 
@@ -183,15 +178,6 @@
 		return 1
 
 	return 0
-
-/obj/item/clothing/gloves/shield_gauntlet/emp_act(severity) //basically how body shields handle emp but without the feedback messages because that is already handled by drain_shield
-	. = ..()
-	switch(severity)
-		if(1)
-			drain_shield(shield_max_charge/2)
-		if(2)
-			drain_shield(shield_max_charge)
-
 
 /obj/item/clothing/gloves/shield_gauntlet/update_icon()
 	if(connected_shield)

--- a/code/modules/halo/weapons/covenant/shield_gauntlet.dm
+++ b/code/modules/halo/weapons/covenant/shield_gauntlet.dm
@@ -123,11 +123,10 @@
 	if(!(get_dir(src, starting) in get_blocked_attack_dirs()))
 		return 0
 
-	if(istype(P, /obj/item/projectile))
-		P.on_impact(src)
-
 	//did our shield absorb the shot?
 	if(drain_shield(damage))
+		if(istype(P, /obj/item/projectile))
+			P.on_impact(src)
 		//put a chatlog delay on warning the user
 		if(world.time >= time_next_warning)
 			time_next_warning = world.time + GAUNTLET_WARNING_DELAY

--- a/code/modules/halo/weapons/covenant/shield_gauntlet.dm
+++ b/code/modules/halo/weapons/covenant/shield_gauntlet.dm
@@ -152,7 +152,7 @@
 
 	return allowed_attack_dirs*/
 
-/obj/item/clothing/gloves/shield_gauntlet/proc/drain_shield(var/damage, var/projectile)
+/obj/item/clothing/gloves/shield_gauntlet/proc/drain_shield(var/damage)
 	if(connected_shield)
 
 		//set a delay on recharging

--- a/code/modules/halo/weapons/covenant/shield_gauntlet.dm
+++ b/code/modules/halo/weapons/covenant/shield_gauntlet.dm
@@ -124,7 +124,7 @@
 		return 0
 
 	//did our shield absorb the shot?
-	if(drain_shield(damage))
+	if(drain_shield(damage, P))
 		//put a chatlog delay on warning the user
 		if(world.time >= time_next_warning)
 			time_next_warning = world.time + GAUNTLET_WARNING_DELAY
@@ -151,13 +151,19 @@
 
 	return allowed_attack_dirs*/
 
-/obj/item/clothing/gloves/shield_gauntlet/proc/drain_shield(var/damage)
+/obj/item/clothing/gloves/shield_gauntlet/proc/drain_shield(var/damage, var/projectile)
 	if(connected_shield)
 
 		//set a delay on recharging
 		if(!shield_next_charge)
 			GLOB.processing_objects |= src
 		shield_next_charge = world.time + shield_recharge_delay
+
+
+		//on_impact was being skipped and thats awful
+		if(istype(projectile, /obj/item/projectile))
+			var/obj/item/projectile/P = projectile
+			P.on_impact(src)
 
 		//subtract the damage
 		shield_current_charge -= damage
@@ -177,6 +183,15 @@
 		return 1
 
 	return 0
+
+/obj/item/clothing/gloves/shield_gauntlet/emp_act(severity) //basically how body shields handle emp but without the feedback messages because that is already handled by drain_shield
+	. = ..()
+	switch(severity)
+		if(1)
+			drain_shield(shield_max_charge/2)
+		if(2)
+			drain_shield(shield_max_charge)
+
 
 /obj/item/clothing/gloves/shield_gauntlet/update_icon()
 	if(connected_shield)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Fixes the kigyar gauntlet shields so they dont suck every projectile and their after-effects like a black hole.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Patata
rscadd: Kig-Yar gauntlet shields no longer swallow explosives.
/:cl:
