### PR TITLE
Gives the regal shipmaster armor sprites to normal shipmaster armor

### DIFF
--- a/code/modules/halo/covenant/species/sangheili/clothing.dm
+++ b/code/modules/halo/covenant/species/sangheili/clothing.dm
@@ -329,23 +329,14 @@
 	name = "Sangheili Helmet (Shipmaster)"
 	desc = "Head armour, to be used with the Sangheili Combat Harness."
 	icon = SANGHEILI_ARMOUR_ICON
-	icon_state = "zealot_helm_obj"
-	item_state = "zealot_helm"
+	icon_state = "regal_helm_obj"
+	item_state = "regal_helm"
 
 /obj/item/clothing/suit/armor/special/combatharness/shipmaster
 	name = "Sangheili Combat Harness (Shipmaster)"
-	icon_state = "zealot_chest_obj"
-	item_state = "zealot_chest"
-	totalshields = 270
-
-/obj/item/clothing/suit/armor/special/combatharness/shipmaster/regal
 	icon_state = "regal_chest_obj"
 	item_state = "regal_chest"
-	///Purely an alt-set for shipmaster, sprites by Dawson
-
-/obj/item/clothing/head/helmet/sangheili/shipmaster/regal
-	icon_state = "regal_helm_obj"
-	item_state = "regal_helm"
+	totalshields = 270
 
 /obj/item/clothing/shoes/sangheili/shipmaster
 	name = "Sanghelli Leg Armour (Shipmaster)"


### PR DESCRIPTION
Takes the regal shipmaster outfit icons and delivers it to the normal shipmaster outfit to differentiate them from zealots. XO greenlit this but I never bothered doing it until now lol

:cl: DawsonKeyes
rscadd: shipmaster now has drip
/:cl:
