### PR TITLE
SoE Unwhitelist

### DIFF
--- a/code/modules/halo/insurrection/soe_jobs.dm
+++ b/code/modules/halo/insurrection/soe_jobs.dm
@@ -12,7 +12,7 @@
 	spawn_positions = 8
 	selection_color = "#ff0000"
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid, access_soe)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
 
 /datum/job/soe_commando_officer
@@ -28,7 +28,7 @@
 	spawn_positions = 2
 	selection_color = "#ff0000"
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss, access_soe, access_soe_officer)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
 
 /datum/job/soe_commando_captain
@@ -43,5 +43,5 @@
 	spawn_positions = 1
 	selection_color = "#ff0000"
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss,access_soe, access_soe_officer, access_soe_captain)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)

--- a/maps/URF Commando Ship/jobs.dm
+++ b/maps/URF Commando Ship/jobs.dm
@@ -13,7 +13,7 @@
 	spawn_positions = 8
 	selection_color = "#ff0000"
 	access = list(access_innie_prowler,access_innie_asteroid)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
 
 /datum/job/soe_commando_officer
@@ -29,7 +29,7 @@
 	spawn_positions = 1
 	selection_color = "#ff0000"
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
 
 /datum/job/soe_commando_captain
@@ -43,5 +43,5 @@
 	spawn_positions = 1
 	selection_color = "#ff0000"
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss)
-	is_whitelisted = 1
+	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)


### PR DESCRIPTION
:cl: Stingray
rscadd: Restores SoE to general Insurrection whitelist to match other factions, as requested by Socks.
/:cl:
