### PR TITLE
Whitelists Spartan & Shipmaster again

### DIFF
--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -397,6 +397,13 @@
 	icon_state = "id"
 	item_state = "card-id"
 
+/obj/item/weapon/card/id/spartan
+	name = "Spartan ID Badge"
+	desc = "An identification card worn by members of the Spartan-II program."
+	icon = 'code/modules/halo/icons/objs/(Placeholder)card.dmi'
+	icon_state = "id"
+	item_state = "card-id"
+
 /obj/item/clothing/gloves/thick/unsc //Combined effect of SWAT gloves and insulated gloves
 	desc = "Standard Issue UNSC Marine Gloves."
 	name = "Olive UNSC Combat gloves"

--- a/code/modules/halo/covenant/jobs/sangheili.dm
+++ b/code/modules/halo/covenant/jobs/sangheili.dm
@@ -8,7 +8,7 @@
 	poplock_divisor = 9
 	track_players = TRUE
 	outfit_type = /decl/hierarchy/outfit/sangheili/shipmaster
-	faction_whitelist = "Covenant"
+	is_whitelisted = 1
 	whitelisted_species = list(/datum/species/sangheili)
 	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
 	pop_balance_mult = 3

--- a/code/modules/halo/unsc/jobs/spartan_two.dm
+++ b/code/modules/halo/unsc/jobs/spartan_two.dm
@@ -1,10 +1,10 @@
 /datum/job/unsc/spartan_two
 	title = "Spartan II"
-	outfit_type = /decl/hierarchy/outfit/spartan_two
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two
 	total_positions = 0
 	spawn_positions = 0
 	account_allowed = 0
-	faction_whitelist = "UNSC"
+	is_whitelisted = 1
 	access = list(\
 		access_unsc,\
 		access_unsc_bridge,\

--- a/code/modules/halo/unsc/jobs/spartan_two_outfits.dm
+++ b/code/modules/halo/unsc/jobs/spartan_two_outfits.dm
@@ -1,5 +1,5 @@
 
-/decl/hierarchy/outfit/spartan_two
+/decl/hierarchy/outfit/job/unsc/spartan_two
 	name = "Spartan II"
 	uniform = /obj/item/clothing/under/spartan_internal
 	suit = /obj/item/clothing/suit/armor/special/spartan
@@ -9,8 +9,7 @@
 	l_ear = /obj/item/device/radio/headset/unsc/spartan
 	suit_store = /obj/item/weapon/tank/emergency/oxygen/double
 	starting_accessories = list(/obj/item/clothing/accessory/rank/fleet/enlisted/e9)
-	pda_slot = null
-	pda_type = null
+	id_type = /obj/item/weapon/card/id/spartan
 	flags = 0
 
 /decl/hierarchy/outfit/job/adminspawn_marine/spartan
@@ -18,6 +17,7 @@
 
 	uniform = /obj/item/clothing/under/spartan_internal
 	suit = /obj/item/clothing/suit/armor/special/spartan
+	mask = null
 	gloves = /obj/item/clothing/gloves/spartan
 	shoes = /obj/item/clothing/shoes/magboots/spartan
 	head = /obj/item/clothing/head/helmet/spartan
@@ -29,6 +29,7 @@
 	r_ear = /obj/item/weapon/reagent_containers/syringe/biofoam
 	l_pocket =/obj/item/weapon/grenade/frag/m9_hedp
 	r_pocket = /obj/item/weapon/armor_patch
+	id_type = /obj/item/weapon/card/id/spartan
 	flags = 0
 
 /decl/hierarchy/outfit/job/adminspawn_marine/spartan/br55

--- a/maps/_gamemodes/firefight/subtypes/jobs_unsc.dm
+++ b/maps/_gamemodes/firefight/subtypes/jobs_unsc.dm
@@ -46,7 +46,7 @@ Cael May 2020
 /datum/job/unsc/spartan_two/firefight
 	total_positions = 1
 	spawn_positions = 1
-	outfit_type = /decl/hierarchy/outfit/spartan_two/firefight
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two/firefight
 	alt_titles = list()
 	spawnpoint_override = null
 	fallback_spawnpoint = null
@@ -114,7 +114,7 @@ Cael May 2020
 	l_pocket = /obj/item/ammo_magazine/m7/m443
 	r_pocket = /obj/item/weapon/gun/projectile/m6c_magnum_s
 
-/decl/hierarchy/outfit/spartan_two/firefight
+/decl/hierarchy/outfit/job/unsc/spartan_two/firefight
 	name = "Spartan II (firefight)"
 
 	//a starting weapon

--- a/maps/slayer/slayer_jobs.dm
+++ b/maps/slayer/slayer_jobs.dm
@@ -5,7 +5,7 @@
 	create_record = 0
 	account_allowed = 0
 	generate_email = 0
-	outfit_type = /decl/hierarchy/outfit/spartan_two/red_team
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two/red_team
 	total_positions = -1
 	spawn_positions = -1
 	track_players = 1
@@ -18,7 +18,7 @@
 	create_record = 0
 	account_allowed = 0
 	generate_email = 0
-	outfit_type = /decl/hierarchy/outfit/spartan_two/blue_team
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two/blue_team
 	total_positions = -1
 	spawn_positions = -1
 	track_players = 1
@@ -30,7 +30,7 @@
 	create_record = 0
 	account_allowed = 0
 	generate_email = 0
-	outfit_type = /decl/hierarchy/outfit/spartan_two/red_team
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two/red_team
 	total_positions = -1
 	spawn_positions = -1
 	track_players = 1
@@ -54,7 +54,7 @@
 	create_record = 0
 	account_allowed = 0
 	generate_email = 0
-	outfit_type = /decl/hierarchy/outfit/spartan_two/red_team
+	outfit_type = /decl/hierarchy/outfit/job/unsc/spartan_two/red_team
 	total_positions = -1
 	spawn_positions = -1
 	track_players = 1

--- a/maps/slayer/slayer_outfits.dm
+++ b/maps/slayer/slayer_outfits.dm
@@ -1,12 +1,12 @@
 
-/decl/hierarchy/outfit/spartan_two/red_team
+/decl/hierarchy/outfit/job/unsc/spartan_two/red_team
 	name = "Red Team Spartan"
 	suit = /obj/item/clothing/suit/armor/special/spartan/red
 	head = /obj/item/clothing/head/helmet/spartan/red
 	l_hand = /obj/item/weapon/gun/projectile/m6d_magnum
 	r_hand = /obj/item/weapon/material/knife/combat_knife
 
-/decl/hierarchy/outfit/spartan_two/blue_team
+/decl/hierarchy/outfit/job/unsc/spartan_two/blue_team
 	name = "Blue Team Spartan"
 	suit = /obj/item/clothing/suit/armor/special/spartan/blue
 	head = /obj/item/clothing/head/helmet/spartan/blue


### PR DESCRIPTION
Admin-facing: Fixed up an issue with my adminspawn spartans where they inherited a mask I didn't want.
:cl: Stingray
tweak: Puts spartan & shipmaster back to their original whitelist status
tweak: Spartans now spawn with an ID.
/:cl:
