### PR TITLE
Adds a multitool to the UNSC utility belt.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -83,7 +83,6 @@
 	new /obj/item/weapon/weldingtool(src)
 	new /obj/item/weapon/crowbar(src)
 	new /obj/item/weapon/wirecutters(src)
-	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -83,6 +83,7 @@
 	new /obj/item/weapon/weldingtool(src)
 	new /obj/item/weapon/crowbar(src)
 	new /obj/item/weapon/wirecutters(src)
+	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 
 

--- a/code/modules/halo/machinery/gunvendors.dm
+++ b/code/modules/halo/machinery/gunvendors.dm
@@ -182,6 +182,7 @@
 					"Miscellaneous" = -1,
 					/obj/item/flight_item/bullfrog_pack = 0,
 					/obj/item/stack/barbedwire/fifteen = 0,
+					/obj/item/device/multitool = 0,
 					/obj/item/weapon/armor_patch = 0,
 					/obj/item/weapon/storage/firstaid/unsc = 0,
 					/obj/item/device/binoculars = 0,


### PR DESCRIPTION
Wow, one line of code.
Fixes #3106.
:cl: Getbrecked
tweak: The UNSC Misc Equipment Vendor now contains a multitool.
/:cl:
