### PR TITLE
Turns T'vaoan Champion into a roundstart role.

### DIFF
--- a/code/modules/halo/covenant/jobs/tvoan.dm
+++ b/code/modules/halo/covenant/jobs/tvoan.dm
@@ -39,10 +39,10 @@
 
 /datum/job/covenant/skirmchampion
 	title = "T-Vaoan Champion"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	outfit_type = /decl/hierarchy/outfit/skirmisher_champion
 	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
 	faction_whitelist = "Covenant"
 	whitelisted_species = list(/datum/species/kig_yar_skirmisher)
-	pop_balance_mult = 1.5 //They're worth a bit more than a marine due to their speed.
+	pop_balance_mult = 2 //They have stronger shield gauntlets than murmillos and the commando's holo decoy.


### PR DESCRIPTION
Kig-yar don't have a proper command role and champions are used very sparingly (really only in crusade). I figured I'd address both.

There is a hard limit of one per round, and they are worth 2 pop. Make it count. 

:cl: Tupinambis
rscadd: Tvaoan champion to modes where it was previously unavailable (eg: reclaimation)
/:cl:
