### PR TITLE
Adds Huragoks to Geminus City

### DIFF
--- a/maps/geminus_city/invasion_geminus_jobdefs.dm
+++ b/maps/geminus_city/invasion_geminus_jobdefs.dm
@@ -16,6 +16,7 @@
 		/datum/job/unsc_ai,\
 		/datum/job/colonist/unsc,\
 		/datum/job/covenant/AI,\
+		/datum/job/covenant/huragok,\
 		/datum/job/covenant/sangheili_minor,\
 		/datum/job/covenant/sangheili_major,\
 		/datum/job/covenant/sangheili_ultra,\


### PR DESCRIPTION
It is weird that huragoks weren't already enabled on geminus, seems like an oversight, this fixes that.

Resolves: https://github.com/HaloSpaceStation/HaloSpaceStation13/issues/3033

:cl: Tupinambis
rscadd: Adds Huragok to geminus
/:cl:
