### PR TITLE
Fix pass

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -140,7 +140,7 @@ var/global/datum/controller/occupations/job_master
 						if(poplocked.total_positions == 0)
 							FreeRole(poplocked.title)
 							amt_job--
-						else
+						if(amt_job > 0)
 							poplocked.total_positions = amt_job
 
 				return 1

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -72,11 +72,12 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		else
 			var/list/exploded = list()
 			for(var/turf/T in trange(max_range, epicenter))
-				var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
+				var/dist_num = sqrt((T.x - x0)**2 + (T.y - y0)**2)
+				var/dist = 0
 
-				if(dist < devastation_range)		dist = 1
-				else if(dist < heavy_impact_range)	dist = 2
-				else if(dist < light_impact_range)	dist = 3
+				if(dist_num < devastation_range)		dist = 1
+				else if(dist_num < heavy_impact_range)	dist = 2
+				else if(dist_num < light_impact_range)	dist = 3
 				else								continue
 
 				T.ex_act(dist)
@@ -87,19 +88,20 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 					if(atom_movable in exploded)
 						continue
 					var/atom/movable/AM = atom_movable
-					if(AM && AM.simulated && !T.protects_atom(AM))
-						AM.ex_act(dist,epicenter)
-						exploded += AM
-		if(guaranteed_damage_range > 0)
-			for(var/mob/living/m in range(guaranteed_damage_range,epicenter))
-				var/mob/living/carbon/human/h = m
-				if(istype(h))
-					if(h.check_shields(guaranteed_damage*2, null, null, null, "the explosion"))
-						m.apply_damage(guaranteed_damage/2,BRUTE,,m.run_armor_check(null,"bomb"))
-						m.apply_damage(guaranteed_damage/2,BURN,,m.run_armor_check(null,"bomb"))
-				else
-					m.apply_damage(guaranteed_damage/2,BRUTE,,m.run_armor_check(null,"bomb"))
-					m.apply_damage(guaranteed_damage/2,BURN,,m.run_armor_check(null,"bomb"))
+					if(istype(AM,/mob/living/))
+						var/mob/living/m = AM
+						if(dist_num <= guaranteed_damage_range)
+							var/mob/living/carbon/human/h = m
+							if(istype(h))
+								if(h.check_shields(guaranteed_damage*2, null, null, null, "the explosion"))
+									m.apply_damage(guaranteed_damage/2,BRUTE,,m.run_armor_check(null,"bomb"))
+									m.apply_damage(guaranteed_damage/2,BURN,,m.run_armor_check(null,"bomb"))
+							else
+								m.apply_damage(guaranteed_damage/2,BRUTE,,m.run_armor_check(null,"bomb"))
+								m.apply_damage(guaranteed_damage/2,BURN,,m.run_armor_check(null,"bomb"))
+								if(AM && AM.simulated && !T.protects_atom(AM))
+									AM.ex_act(dist,epicenter)
+									exploded += AM
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare

--- a/code/modules/halo/covenant/species/huragok/outfit.dm
+++ b/code/modules/halo/covenant/species/huragok/outfit.dm
@@ -6,7 +6,7 @@
 	var/turf/h_loc = H.loc
 	var/mob/living/silicon/robot/huragok/huragok = new(h_loc)
 	huragok.faction = "Covenant"
-	huragok.ckey = H.ckey
+	H.mind.transfer_to(huragok)
 	huragok.Login()
 	qdel(H)
 	return huragok

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
@@ -1,6 +1,6 @@
 
 /mob/living/simple_animal/mgalekgolo/bullet_act(var/obj/item/projectile/Proj)
-	if(!(get_dir(src,Proj.starting) in get_allowed_attack_dirs()))
+	if(crouched && !(get_dir(src,Proj.starting) in get_allowed_attack_dirs()))
 		visible_message("<span class = 'danger'>The [Proj.name] is stopped by \the [name]'s armor plating.</span>")
 		return
 	. = ..()

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
@@ -23,7 +23,7 @@
 	var/damage
 	switch (severity)
 		if (1.0)
-			damage = 120
+			damage = 90
 
 		if (2.0)
 			damage = 60

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo_outfit.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo_outfit.dm
@@ -6,7 +6,7 @@
 	var/turf/h_loc = H.loc
 	var/mob/living/simple_animal/mgalekgolo/mgalekgolo = new(h_loc)
 	mgalekgolo.faction = "Covenant"
-	mgalekgolo.ckey = H.ckey
+	H.mind.transfer_to(mgalekgolo)
 	mgalekgolo.Login()
 	qdel(H)
 	return mgalekgolo

--- a/code/modules/halo/overmap/base_npc_ships.dm
+++ b/code/modules/halo/overmap/base_npc_ships.dm
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(om_base_sectors, list())
 	map_z = list()
 	lighting_overlays_initialised = FALSE
 	for(var/link in chosen_ship_datum.mapfile_links)
-		to_world("Loading Ship-Map: [link]... This may cause lag.")
+		message_admins("Loading Ship-Map: [link]... This may cause lag.")
 		sleep(10) //A small sleep to ensure the above message is printed before the loading operation commences.
 		var/z_to_load_at = shipmap_handler.get_next_usable_z()
 		sleep(10) //Wait a tick again, to ensure te map is actually loaded in

--- a/code/modules/halo/overmap/slipspace/damage_destroy.dm
+++ b/code/modules/halo/overmap/slipspace/damage_destroy.dm
@@ -1,4 +1,4 @@
-/*
+
 /obj/machinery/slipspace_engine/ex_act(var/severity)
 	return
 
@@ -6,4 +6,3 @@
 	if(om_obj && om_obj.loc == null)
 		do_slipspace(pick(block(locate(1,1,GLOB.using_map.overmap_z),locate(GLOB.using_map.overmap_size,GLOB.using_map.overmap_size,GLOB.using_map.overmap_z))))
 	. = ..()
-*/

--- a/code/modules/halo/overmap/slipspace/damage_destroy.dm
+++ b/code/modules/halo/overmap/slipspace/damage_destroy.dm
@@ -1,8 +1,9 @@
 
 /obj/machinery/slipspace_engine/ex_act(var/severity)
 	return
-
+/*
 /obj/machinery/slipspace_engine/Destroy()
 	if(om_obj && om_obj.loc == null)
 		do_slipspace(pick(block(locate(1,1,GLOB.using_map.overmap_z),locate(GLOB.using_map.overmap_size,GLOB.using_map.overmap_size,GLOB.using_map.overmap_z))))
 	. = ..()
+*/

--- a/code/modules/halo/overmap/weapons/MAC.dm
+++ b/code/modules/halo/overmap/weapons/MAC.dm
@@ -218,7 +218,7 @@
 	return
 
 /obj/machinery/overmap_weapon_console/mac/orbital_bombard/proc/bombard_impact(var/atom/hit_turf)
-	explosion(get_turf(hit_turf),4,6,7,20, adminlog = 0)
+	explosion(get_turf(hit_turf),5,7,9,20, adminlog = 0)
 
 /obj/machinery/overmap_weapon_console/mac/orbital_bombard/fire(var/atom/target,var/mob/user)
 	if(!do_power_check(user))
@@ -271,11 +271,7 @@
 	if(istype(impacted,/obj/effect/shield))
 		return 0
 	var/increase_from_damage = round(damage/250)
-	if(increase_from_damage > 2)
-		increase_from_damage -= 2
-		increase_from_damage = round(increase_from_damage * 0.5)
-		increase_from_damage += 2
-	explosion(get_turf(impacted),0 + increase_from_damage,2 + increase_from_damage,3 + increase_from_damage,4 + increase_from_damage, adminlog = 0)
+	explosion(get_turf(impacted),2 + increase_from_damage,4 + increase_from_damage,5 + increase_from_damage,8 + increase_from_damage, adminlog = 0)
 	if(!warned)
 		warned = 1
 		var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]

--- a/code/modules/halo/vehicles/types/ghost.dm
+++ b/code/modules/halo/vehicles/types/ghost.dm
@@ -24,6 +24,8 @@
 
 	move_sound = 'code/modules/halo/sounds/ghost_move.ogg'
 
+	vehicle_view_modifier = 1.5
+
 	light_color = "#C1CEFF"
 
 	can_smoke = 1

--- a/code/modules/halo/vehicles/types/mongoose.dm
+++ b/code/modules/halo/vehicles/types/mongoose.dm
@@ -19,6 +19,8 @@
 
 	vehicle_size = ITEM_SIZE_VEHICLE_SMALL
 
+	vehicle_view_modifier = 1.5
+
 	light_color = "#E1FDFF"
 
 	can_smoke = 1

--- a/code/modules/halo/vehicles/types/shadow.dm
+++ b/code/modules/halo/vehicles/types/shadow.dm
@@ -23,6 +23,8 @@
 
 	move_sound = 'code/modules/halo/sounds/ghost_move.ogg'
 
+	vehicle_view_modifier = 1.5
+
 	light_color = "#C1CEFF"
 
 	can_smoke = 1

--- a/code/modules/halo/vehicles/types/warthog.dm
+++ b/code/modules/halo/vehicles/types/warthog.dm
@@ -23,6 +23,8 @@
 
 	move_sound = 'code/modules/halo/sounds/warthog_move.ogg'
 
+	vehicle_view_modifier = 1.5
+
 	light_color = "#E1FDFF"
 
 	can_smoke = 1

--- a/code/modules/halo/weapons/ammo_12-7mm.dm
+++ b/code/modules/halo/weapons/ammo_12-7mm.dm
@@ -45,7 +45,7 @@
 
 /obj/item/projectile/bullet/m228
 	damage = 40
-	armor_penetration = 50
+	armor_penetration = 40
 
 /obj/item/ammo_casing/m228
 	desc = "A 12.7mm HP bullet casing."

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -356,8 +356,8 @@
 
 /obj/item/projectile/bullet/covenant/concussion_rifle
 	name = "heavy plasma round"
-	damage = 35
-	armor_penetration = 30
+	damage = 50
+	armor_penetration = 40
 	shield_damage = 50
 	step_delay = 0.75 //slower than most
 	icon = 'code/modules/halo/weapons/icons/Covenant_Projectiles.dmi'

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -105,14 +105,13 @@
 	var/obj/item/weapon/card/id/I = user.GetIdCard()
 	var/obj/item/organ/internal/stack/lace = user.GetLace()
 	if(I)
-		access_list += I.access
-	else if(lace)
-		access_list += lace.access
-	else
+		access_list |= I.access
+	if(lace)
+		access_list |= lace.access
+	if(!access_list.len)
 		if(loud)
 			to_chat(user, "<span class='notice'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
 		return 0
-
 	if(access_to_check in access_list)
 		return 1
 	else if(loud)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -101,13 +101,19 @@
 	if(!istype(user))
 		return 0
 
+	var/list/access_list = list()
 	var/obj/item/weapon/card/id/I = user.GetIdCard()
-	if(!I)
+	var/obj/item/organ/internal/stack/lace = user.GetLace()
+	if(I)
+		access_list += I.access
+	else if(lace)
+		access_list += lace.access
+	else
 		if(loud)
 			to_chat(user, "<span class='notice'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
 		return 0
 
-	if(access_to_check in I.access)
+	if(access_to_check in access_list)
 		return 1
 	else if(loud)
 		to_chat(user, "<span class='notice'>\The [computer] flashes an \"Access Denied\" warning.</span>")


### PR DESCRIPTION
closes #3123 

:cl: XO-11
tweak: Fixes the crew monitoring computer's ability to grab access from neural laces.
tweak: Tweaks popbalance system to be a bit more robust and reliable.
tweak: Lekgolo take less damage from explosions now that they're definitively outranged by AT weapons and tanks.
tweak: Light vehicles now have a higher view range.
tweak: Slipspace drives are now immune to explosions, as they should have been all along.
tweak: Tweaks MAC damage scaling to be a bit higher.
tweak: The concussion rifle has recieved a performance tweak
/:cl: