### PR TITLE
Added attack_ai() to docking umbilical.

### DIFF
--- a/code/modules/halo/overmap/umbilicals.dm
+++ b/code/modules/halo/overmap/umbilicals.dm
@@ -217,6 +217,9 @@
 		ship_setup()
 	pick_entity_connect_disconnect(user)
 
+/obj/docking_umbilical/attack_ai(var/mob/user)
+	attack_hand(user)
+
 /obj/docking_umbilical/proc/umbi_rip()
 	if(isnull(current_connected))
 		return


### PR DESCRIPTION
AI weren't able to use the docking umbilicals. So I changed it so that they could. Why? Because there's no reason they can't or shouldn't. Realism shouldn't be a reason either alone.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: TheGandalf(GameMaster85)
bugfix: The AI is now able to access the mechanical operations of ship umbilicals.
/:cl:
