### PR TITLE
Wide ranging tweaks

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -83,6 +83,11 @@
 				for(var/datum/objective/O in F.all_objectives)
 					H.mind.objectives.Add(O)
 				show_objectives(H.mind)
+	//Popbalance system. We're spawning them in, now, so let's cut the popbalance deadlock.
+	if(spawn_faction)
+		var/datum/faction/my_faction = GLOB.factions_by_name[spawn_faction]
+		var/list/last_checked_lock = ticker.mode.last_checked_lock
+		last_checked_lock -= my_faction.type
 
 /datum/job/proc/get_outfit(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch)
 	if(alt_title && alt_titles)
@@ -262,11 +267,6 @@
 								to_chat(feedback, "<span class='boldannounce'>Joining as [title] is blocked due to [spawn_faction] faction overpop.</span>")
 							else
 								message_admins("NOTICE: Poplock check was failed, but we're in a deadlock state so we'll let it through.")
-								//feedback parameter is missing when the latejoin jobs list calls this proc to construct the jobs list
-								//see: /mob/new_player/proc/LateChoices() in modules/mob/new_player/new_player.dm
-								//We don't want to put ourselves back into a deadlocked position
-								if(feedback)
-									last_checked_lock.Cut()
 							//tell the admins, but dont spam them too much
 							if(world.time > GLOB.last_admin_notice_overpop + 30 SECONDS)
 								GLOB.last_admin_notice_overpop = world.time

--- a/code/modules/halo/covenant/jobs/tvoan.dm
+++ b/code/modules/halo/covenant/jobs/tvoan.dm
@@ -26,6 +26,7 @@
 	faction_whitelist = "Covenant"
 	whitelisted_species = list(/datum/species/kig_yar_skirmisher)
 	pop_balance_mult = 1.5 //They're worth a bit more than a marine due to their speed.
+ 	open_slot_on_death = 1 //Since the speed nerf, these aren't nearly as powerful as they used to be.
 
 /datum/job/covenant/skirmcommando
 	title = "T-Vaoan Commando"

--- a/code/modules/halo/covenant/jobs/tvoan.dm
+++ b/code/modules/halo/covenant/jobs/tvoan.dm
@@ -26,7 +26,7 @@
 	faction_whitelist = "Covenant"
 	whitelisted_species = list(/datum/species/kig_yar_skirmisher)
 	pop_balance_mult = 1.5 //They're worth a bit more than a marine due to their speed.
- 	open_slot_on_death = 1 //Since the speed nerf, these aren't nearly as powerful as they used to be.
+	open_slot_on_death = 1 //Since the speed nerf, these aren't nearly as powerful as they used to be.
 
 /datum/job/covenant/skirmcommando
 	title = "T-Vaoan Commando"

--- a/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
+++ b/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
@@ -29,9 +29,9 @@ GLOBAL_LIST_INIT(first_names_jiralhanae, world.file2list('code/modules/halo/cove
 	appearance_flags = HAS_SKIN_TONE | HAS_EYE_COLOR | NO_MARKING_COLOUR
 	radiation_mod = 0.6
 	spawn_flags = SPECIES_CAN_JOIN
-	brute_mod = 0.8
-	burn_mod = 0.8
-	pain_mod = 0.55
+	brute_mod = 0.65
+	burn_mod = 0.65
+	pain_mod = 0.8
 	adrenal_break_threshold = 200//Originally, this was lower, however, the higher threshold allows brutes
 	//to sustain a longer lasting lower-level painkill rather than having their adrenaline
 	//forcefully swapped for a very short term buff

--- a/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
+++ b/code/modules/halo/covenant/species/jiralhanae/jiralhanae.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(first_names_jiralhanae, world.file2list('code/modules/halo/cove
 	brute_mod = 0.65
 	burn_mod = 0.65
 	pain_mod = 0.8
-	adrenal_break_threshold = 200//Originally, this was lower, however, the higher threshold allows brutes
+	adrenal_break_threshold = 100//Originally, this was lower, however, the higher threshold allows brutes
 	//to sustain a longer lasting lower-level painkill rather than having their adrenaline
 	//forcefully swapped for a very short term buff
 	explosion_effect_mod = 0.5

--- a/code/modules/halo/vehicles/types/scorpion.dm
+++ b/code/modules/halo/vehicles/types/scorpion.dm
@@ -106,7 +106,7 @@
 	damtype = "bomb"
 	armor_penetration = 50
 	shield_damage = 240
-	steps_between_delays = 3
+	steps_between_delays = 2
 
 /obj/item/projectile/bullet/scorp_cannon/on_impact(var/atom/impacted)
 	explosion(get_turf(impacted),0,1,3,5,guaranteed_damage = 50,guaranteed_damage_range = 2)

--- a/code/modules/halo/vehicles/types/wraith.dm
+++ b/code/modules/halo/vehicles/types/wraith.dm
@@ -114,7 +114,7 @@
 
 /obj/item/projectile/bullet/covenant/wraith_cannon/setup_trajectory()
 	. = ..()
-	kill_count = get_dist(loc, original) + rand(-1,5) //Only overshoot, don't undershoot. Undershoot is an irritating player experience.
+	kill_count = get_dist(loc, original) + rand(-2,3) //Only overshoot, don't undershoot. Undershoot is an irritating player experience.
 
 /obj/item/projectile/bullet/covenant/wraith_cannon/Move(var/newloc,var/dir)
 	if(get_dist(loc,original) > (get_dist(starting,original)/2))

--- a/code/modules/halo/weapons/M392.dm
+++ b/code/modules/halo/weapons/M392.dm
@@ -71,9 +71,8 @@
 	desc = "A heavily modified M392 remade without a bullpup design and including a hardened barrel for a faster fire rate. Fires in bursts. Takes 7.62mm rounds."
 	fire_sound = 'code/modules/halo/sounds/innieDMRfirfix.ogg'
 	reload_sound = 'code/modules/halo/sounds/InnieDMRreload.ogg'
-	fire_delay = 8
-	burst_delay = 1.5
-	dispersion = list(0.26)
-	burst = 2
+	fire_delay = 5
+	dispersion = list(0)
+	burst = 1
 	accuracy = -2
 	scoped_accuracy = 0


### PR DESCRIPTION
:cl: XO-11
tweak: Brute stats have been tweaked to allow them to soak a gunfire a bit better as previously their organs were dying before they reached their pain threshold for unconsciousness making most of their upsides go to waste.
tweak: Both tanks have had some tweaks made to their main weapons to allow them to fit into the intended use case more easily.
tweak: Standard tvaoan slots now unlock upon death of the player using them.
tweak: Popbalance has had another pass to make it more usable and less prone to deadlocks.
tweak: The modified DMR has been tweaked again.
/:cl: