### PR TITLE
Changes Covenant Radiation

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -519,7 +519,7 @@
 
 	if(irradiate_non_cov > 0 && istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/h = user
-		if(istype(h.species,/datum/species/human))
+		if(istype(h.species,/datum/species/human) && user.faction != "Covenant")
 			h.rad_act(irradiate_non_cov)
 
 	if(screen_shake)


### PR DESCRIPTION
Makes it so radiation is faction level as well instead of just species.

Previously radiation was a pure species check, however now it checks both the species and the player faction. This should improve player experience in the event of conversion contracts and other admin shenanigans.

:cl: CommanderXor
tweak: Changes radiation from weapons to be a species and faction check instead of just species.
/:cl: