### PR TITLE
geminus URF ship

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3307,6 +3307,7 @@
 #include "interface\skin.dmf"
 #include "maps\_map_include.dm"
 #include "maps\_gamemodes\_popbalance.dm"
+#include "maps\_gamemodes\gamemode_overrides.dm"
 #include "maps\_gamemodes\randantag\randantag.dm"
 #include "maps\geminus_city\geminus_city.dm"
 #include "maps\~mapsystem\map_preferences.dm"

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -114,6 +114,10 @@ var/list/points_of_interest = list()
 		if(F)
 			F.flagship = src
 			F.get_flagship_name()	//update the archived name
+		var/datum/game_mode/outer_colonies/gamemode = ticker.mode
+		if(istype(gamemode))
+			if(!(F.type in gamemode.factions))
+				invisibility = 101
 
 	if(base && faction)
 		var/datum/faction/F = GLOB.factions_by_name[faction]

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -114,9 +114,8 @@ var/list/points_of_interest = list()
 		if(F)
 			F.flagship = src
 			F.get_flagship_name()	//update the archived name
-		var/datum/game_mode/outer_colonies/gamemode = ticker.mode
-		if(istype(gamemode))
-			if(!(F.type in gamemode.factions))
+		if(istype(ticker.mode,/datum/game_mode/outer_colonies))
+			if(!(F.type in ticker.mode:factions))
 				invisibility = 101
 
 	if(base && faction)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -114,8 +114,9 @@ var/list/points_of_interest = list()
 		if(F)
 			F.flagship = src
 			F.get_flagship_name()	//update the archived name
-		if(istype(ticker.mode,/datum/game_mode/outer_colonies))
-			if(!(F.type in ticker.mode:factions))
+		var/datum/game_mode/gm = ticker.mode
+		if(istype(gm) && gm.factions.len > 0)
+			if(!(F.type in ticker.mode.factions))
 				invisibility = 101
 
 	if(base && faction)

--- a/maps/_gamemodes/gamemode_overrides.dm
+++ b/maps/_gamemodes/gamemode_overrides.dm
@@ -1,0 +1,4 @@
+
+/datum/game_mode
+
+	var/list/factions = list()

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -16,7 +16,7 @@
 
 	var/safe_expire_warning = 0
 
-	var/list/factions = list(/datum/faction/unsc, /datum/faction/covenant, /datum/faction/insurrection)
+	factions = list(/datum/faction/unsc, /datum/faction/covenant, /datum/faction/insurrection)
 	var/list/endgame_fleets = list(/datum/faction/unsc)
 
 	var/list/overmap_hide = list()

--- a/maps/geminus_city/geminus_city.dm
+++ b/maps/geminus_city/geminus_city.dm
@@ -22,6 +22,7 @@
 	#include "innie_supply/supply_program.dm"
 	#include "innie_supply/supply_shuttle.dm"
 	*/
+	#include "../../maps/urf_flagship/includes.dm"
 
 	#include "../../code/modules/halo/supply/unsc.dm"
 	#include "../../code/modules/halo/supply/oni.dm"

--- a/maps/geminus_city/geminus_city.dm
+++ b/maps/geminus_city/geminus_city.dm
@@ -22,7 +22,6 @@
 	#include "innie_supply/supply_program.dm"
 	#include "innie_supply/supply_shuttle.dm"
 	*/
-	#include "../../maps/urf_flagship/includes.dm"
 
 	#include "../../code/modules/halo/supply/unsc.dm"
 	#include "../../code/modules/halo/supply/oni.dm"

--- a/maps/geminus_city/invasion_geminus.dm
+++ b/maps/geminus_city/invasion_geminus.dm
@@ -9,15 +9,16 @@
 #include "../Admin Planet/includes.dm"
 
 #include "../faction_bases/ODP_Cassius/ODP_Cassius.dm"
+
 /*
 #include "../SOE_Argentum/jobs.dm"
 #include "../SOE_Argentum/outfits.dm"
 #include "../SOE_Argentum/spawns.dm"
-
-#include "../urf_flagship/includes.dm"
-
 #include "../Asteroid Listening Post/includes.dm"
 */
+
+#include "../../maps/urf_flagship/includes.dm"
+
 #include "../CRS_Unyielding_Transgression/includes.dm"
 
 #include "invasion_geminus_jobdefs.dm"


### PR DESCRIPTION
Geminus should now load the URF flagship into the game.
No idea if the spawns are still functional.
I've added a system to handle these ships loading in outer-colonies modes that don't actually support them. In this case, it'll hide their ship-sprite, although the map will still be technically loaded and admins can reset the sprite's invisibility var to 0 to make it appear again.