### PR TITLE
simple spartan whitelist tweak

### DIFF
--- a/code/modules/halo/unsc/jobs/spartan_two.dm
+++ b/code/modules/halo/unsc/jobs/spartan_two.dm
@@ -4,7 +4,7 @@
 	total_positions = 0
 	spawn_positions = 0
 	account_allowed = 0
-	is_whitelisted = 1
+	faction_whitelist = "UNSC"
 	access = list(\
 		access_unsc,\
 		access_unsc_bridge,\


### PR DESCRIPTION
:cl: XO-11
rscadd: Ties the Spartan II Whitelist into the overall faction rather than a specialized sub whitelist
/:cl: