### PR TITLE
Removes scope pop up menu, merges use-scope(sidearm) into use-scope.

### DIFF
--- a/code/modules/halo/weapons/BR85.dm
+++ b/code/modules/halo/weapons/BR85.dm
@@ -31,12 +31,8 @@
 /obj/item/weapon/gun/projectile/br85/can_use_when_prone()
 	return 1
 
-/obj/item/weapon/gun/projectile/br85/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
+
 
 /obj/item/weapon/gun/projectile/br85/update_icon()
 	if(ammo_magazine)

--- a/code/modules/halo/weapons/M6C.dm
+++ b/code/modules/halo/weapons/M6C.dm
@@ -25,12 +25,7 @@
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_icon.dmi'
 
-/obj/item/weapon/gun/projectile/m6c_magnum/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope (Sidearm)"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/m6c_magnum/update_icon()
 	if(ammo_magazine)

--- a/code/modules/halo/weapons/M6D.dm
+++ b/code/modules/halo/weapons/M6D.dm
@@ -40,12 +40,7 @@
 		icon_state = "magnum_unloaded"
 	. = ..()
 
-/obj/item/weapon/gun/projectile/m6d_magnum/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope (Sidearm)"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/m6d_magnum/CO_magnum
 	name = "\improper CO\'s Magnum"

--- a/code/modules/halo/weapons/M6S.dm
+++ b/code/modules/halo/weapons/M6S.dm
@@ -26,12 +26,7 @@
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_icon.dmi'
 
-/obj/item/weapon/gun/projectile/m6c_magnum_s/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope (Sidearm)"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/m6c_magnum_s/update_icon()
 	if(ammo_magazine)

--- a/code/modules/halo/weapons/M7.dm
+++ b/code/modules/halo/weapons/M7.dm
@@ -64,11 +64,6 @@
 	list(mode_name="extended bursts",  burst=8, dispersion=list(0.3, 0.3, 0.4, 0.5, 0.6, 0.8, 1.1))
 	)
 
-/obj/item/weapon/gun/projectile/m7_smg/silenced/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
-
 	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/m7_smg/silenced/update_icon()

--- a/code/modules/halo/weapons/SDSR10.dm
+++ b/code/modules/halo/weapons/SDSR10.dm
@@ -23,12 +23,7 @@
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
 		)
 
-/obj/item/weapon/gun/energy/SDSR_10/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
 
 //SDSS PROJECTILE
 /obj/item/projectile/SDSS_proj

--- a/code/modules/halo/weapons/SRS99.dm
+++ b/code/modules/halo/weapons/SRS99.dm
@@ -37,12 +37,7 @@
 /obj/item/weapon/gun/projectile/srs99_sniper/can_use_when_prone()
 	return 1
 
-/obj/item/weapon/gun/projectile/srs99_sniper/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
 
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/srs99_sniper/update_icon()
 	if(ammo_magazine)

--- a/code/modules/halo/weapons/_guns.dm
+++ b/code/modules/halo/weapons/_guns.dm
@@ -14,6 +14,7 @@
 /obj/item/weapon/gun/Initialize()
 	. = ..()
 	if(scope_zoom_amount != 0)
+		verbs += /obj/item/weapon/gun/proc/use_scope
 		create_scope_actions(0)
 		if(max_zoom_amount == 0)
 			max_zoom_amount = scope_zoom_amount

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -36,12 +36,6 @@
 /obj/item/weapon/gun/projectile/type51carbine/can_use_when_prone()
 	return 1
 
-/obj/item/weapon/gun/projectile/type51carbine/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
-
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/projectile/type51carbine/load_ammo(var/item/I,var/mob/user)
 	unload_ammo(user,1)
@@ -101,12 +95,6 @@
 /obj/item/weapon/gun/energy/beam_rifle/can_use_when_prone()
 	return 1
 
-/obj/item/weapon/gun/energy/beam_rifle/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
-
-	toggle_scope(usr, scope_zoom_amount)
 
 /obj/item/weapon/gun/energy/beam_rifle/proc/cov_plasma_recharge_tick()
 	if(max_shots > 0)
@@ -152,9 +140,3 @@
 /obj/item/weapon/gun/projectile/type31needlerifle/can_use_when_prone()
 	return 1
 
-/obj/item/weapon/gun/projectile/type31needlerifle/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
-
-	toggle_scope(usr, scope_zoom_amount)

--- a/code/modules/halo/weapons/spartan_laser.dm
+++ b/code/modules/halo/weapons/spartan_laser.dm
@@ -39,12 +39,6 @@
 	burst = 2
 	burst_delay = 2.5
 
-/obj/item/weapon/gun/energy/spartanlaser/verb/scope()
-	set category = "Weapon"
-	set name = "Use Scope"
-	set popup_menu = 1
-
-	toggle_scope(usr,scope_zoom_amount)
 
 /obj/item/projectile/beam/spartan
 	name = "spartan laser"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -796,6 +796,11 @@
 /obj/item/weapon/gun/proc/use_scope()
 	set category = "Weapon"
 	set name = "Use Scope" //Gives slightly less info to the user but also allows for easy macro use.
-	set popup_menu = 1
+	set src = usr.contents
+	var/obj/item/weapon/gun/G = usr.get_active_hand()
+	if(!G) return
+	src = G
+	if (scope_zoom_amount == 0) return
 
 	toggle_scope(usr, scope_zoom_amount)
+

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -796,7 +796,7 @@
 /obj/item/weapon/gun/proc/use_scope()
 	set category = "Weapon"
 	set name = "Use Scope" //Gives slightly less info to the user but also allows for easy macro use.
-	set src = usr.contents
+
 	var/obj/item/weapon/gun/G = usr.get_active_hand()
 	if(!G) return
 	src = G


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Changes scopes to check your active hand for a scoped weapon instead of a pop up menu (why would you want to scope with a weapon not in your active hand?), allowing for a far easier and less clunkier system to use. 

removes the use-scope(sidearm) verb, since all guns that use it will now use use-scope as there is no need for a verb to split the two anymore.

Removes all gun's scope verbs, instead grants the verb use-scope to any weapon with a zoom amount larger than 1.
<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Joe4444
tweak: tweaks the scope system to check active hand instead of giving you a pop up menu
rscdel: Removed use scope sidearm verb  Any gun that used that will now use use scope.
/:cl:
