### PR TITLE
Innie cargo changes

### DIFF
--- a/code/modules/halo/insurrection/access_ids.dm
+++ b/code/modules/halo/insurrection/access_ids.dm
@@ -78,3 +78,9 @@
 	id = access_x52_rd
 	access_type = ACCESS_TYPE_SYNDICATE
 	desc = "X52 Research Director"
+
+/var/const/access_innie_cargo = 197
+/datum/access/innie_cargo
+	id = access_innie_cargo
+	access_type = ACCESS_TYPE_SYNDICATE
+	desc = "Insurrectionist Supply"

--- a/code/modules/halo/insurrection/innie_jobs.dm
+++ b/code/modules/halo/insurrection/innie_jobs.dm
@@ -61,7 +61,7 @@
 	latejoin_at_spawnpoints = 1
 	total_positions = 2
 	spawn_positions = 2
-	access = list(access_innie, access_innie_boss)
+	access = list(access_innie, access_innie_boss, access_innie_cargo)
 	selection_color = "#ff0000"
 	alt_titles = null
 
@@ -79,7 +79,7 @@
 	track_players = 1
 	total_positions = 1
 	spawn_positions = 1
-	access = list(access_innie, access_innie_boss)
+	access = list(access_innie, access_innie_boss, access_innie_cargo)
 	selection_color = "#ff0000"
 	faction_whitelist = "Insurrection"
 	alt_titles = null
@@ -96,6 +96,7 @@
 	whitelisted_species = list(/datum/species/orion)
 	total_positions = 2
 	spawn_positions = 2
+	access = list(access_innie, access_innie_boss, access_innie_cargo)
 	faction_whitelist = "Insurrection"
 
 /datum/job/insurrectionist_ai

--- a/code/modules/halo/insurrection/soe_jobs.dm
+++ b/code/modules/halo/insurrection/soe_jobs.dm
@@ -2,6 +2,8 @@
 	title = "SOE Commando"
 	spawn_faction = "Insurrection"
 	latejoin_at_spawnpoints = 1
+	generate_email = 1
+	account_allowed = 1
 	outfit_type = /decl/hierarchy/outfit/job/soe_commando
 	alt_titles = list("SOE Initiate",\
 	"SOE Trooper",\
@@ -14,11 +16,14 @@
 	access = list(access_innie,access_innie_prowler,access_innie_asteroid, access_soe)
 	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/soe_commando_officer
 	title = "SOE Commando Officer"
 	spawn_faction = "Insurrection"
 	latejoin_at_spawnpoints = 1
+	generate_email = 1
+	account_allowed = 1
 	outfit_type = /decl/hierarchy/outfit/job/soe_commando_officer
 	alt_titles = list("SOE Sergeant",\
 	"SOE Adjutant",\
@@ -27,14 +32,17 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#ff0000"
-	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss, access_soe, access_soe_officer)
+	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss, access_soe, access_soe_officer, access_innie_cargo)
 	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE
 
 /datum/job/soe_commando_captain
 	title = "SOE Commando Captain"
 	spawn_faction = "Insurrection"
 	latejoin_at_spawnpoints = 1
+	generate_email = 1
+	account_allowed = 1
 	outfit_type = /decl/hierarchy/outfit/job/soe_commando_captain
 	alt_titles = list("SOE Commander",\
 	"SOE Captain")
@@ -42,6 +50,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#ff0000"
-	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss,access_soe, access_soe_officer, access_soe_captain)
+	access = list(access_innie,access_innie_prowler,access_innie_asteroid,access_innie_asteroid_boss,access_soe, access_soe_officer, access_soe_captain, access_innie_cargo)
 	faction_whitelist = "Insurrection"
 	whitelisted_species = list(/datum/species/human)
+	loadout_allowed = TRUE

--- a/code/modules/halo/supply/innie.dm
+++ b/code/modules/halo/supply/innie.dm
@@ -31,7 +31,7 @@
 	name = "Insurrection supply management program"
 	faction_name = "Insurrection"
 	shuttle_name = "Insurrection Supply Shuttle"
-	req_access = access_innie_boss
+	req_access = access_innie_cargo
 
 
 

--- a/maps/urf_flagship/first_deck.dmm
+++ b/maps/urf_flagship/first_deck.dmm
@@ -15,7 +15,7 @@
 "ao" = (/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "ap" = (/obj/machinery/light/small{icon_state = "bulb1"; dir = 1},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "aq" = (/obj/machinery/door/airlock/hatch/maintenance,/obj/machinery/door/firedoor,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
-"ar" = (/obj/docking_umbilical/north,/turf/simulated/wall/r_wall,/area/urf_flagship/powercore)
+"ar" = (/obj/docking_umbilical/one_way/north{name = "URF Liberator Starboard"},/turf/simulated/wall/r_wall,/area/urf_flagship/powercore)
 "as" = (/turf/simulated/wall/r_wall,/area/urf_flagship/captainroom)
 "at" = (/obj/structure/barricade,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "au" = (/obj/effect/floor_decal/corner/red/three_quarters{icon_state = "corner_white_three_quarters"; dir = 8},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Centralhallway)
@@ -506,7 +506,7 @@
 "jL" = (/obj/structure/cable/blue{icon_state = "2-8"},/obj/structure/cable/blue{icon_state = "2-4"},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "jM" = (/obj/structure/cable/blue{icon_state = "1-8"},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "jN" = (/obj/structure/ai_terminal/innie,/turf/simulated/floor/tiled/dark,/area/urf_flagship/powercore)
-"jO" = (/obj/docking_umbilical/south,/turf/simulated/wall/r_wall,/area/urf_flagship/powercore)
+"jO" = (/obj/docking_umbilical/one_way/south{name = "URF Liberator Port"},/turf/simulated/wall/r_wall,/area/urf_flagship/powercore)
 "jP" = (/obj/structure/cable/blue{icon_state = "1-4"},/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "jQ" = (/obj/structure/cable/blue{icon_state = "4-8"},/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "jR" = (/obj/structure/cable/blue{icon_state = "4-8"},/obj/machinery/light/small,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
@@ -533,8 +533,9 @@
 "km" = (/obj/structure/closet/crate/radiation_gear,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "kn" = (/obj/effect/landmark/start/geminus_innie{name = "Insurrectionist Orion Defector"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "ko" = (/obj/effect/landmark/start/geminus_innie{name = "Insurrectionist Commander"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
-"kp" = (/obj/machinery/shuttle_fuel,/obj/machinery/power/apc/super{step_y = -24},/turf/simulated/floor/shuttle/red,/area/shuttle/innie_shuttle_transport)
+"kp" = (/obj/machinery/shuttle_fuel,/turf/simulated/floor/shuttle/red,/area/shuttle/innie_shuttle_transport)
 "kq" = (/obj/machinery/slipspace_engine/human{req_access = list(250)},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
+"kr" = (/obj/machinery/power/apc/super{step_y = 0},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/shuttle/innie_shuttle_transport)
 "ks" = (/obj/machinery/light/small{tag = "icon-bulb1 (EAST)"; icon_state = "bulb1"; dir = 4},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "kt" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/x52armor/medium,/obj/item/clothing/suit/storage/x52armor/medium,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "ku" = (/obj/structure/table/rack,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
@@ -638,7 +639,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdldAhBhBhBhBhBhBhraZaPgRglglglhQfXgn
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZhscThBhMhBhBhwcRaZaPhthtglhthtfXgngngngSgphukhhvhugbfXajfzajhxcvhyhyhyhyhyhyhyhyhyhyhzhycucvhAihgDgEgYdvhahbhHhdjihAcucvdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdscucvhJhJhKhJhJhKhJhJhJhKhLhjaEaKajamamamamamajcIfaeXZNeYamamameKamdxajamhTcPdzajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZaZaZhUhVhUhWchhcaZaPhthtglhthtfXhXkjhYkkgphuhviahugbfXajibajaEaKicididididieifidididideaaEaKebgFhChDhDhEhFhGimhdgFebaEaKgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtaEaKechjhjhggLioiphjhjhjhjecaEaKajamamamamamajcIkmisitiuiviviviwitixajamiycPcQajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPiqaPaPaPaPaPaPiqaPizhtglhOhtiBiCiDiEiEiFhukhhvhugbiBajfzajiGaKgeiHidididiIiIiIiJiIiKgeaEaKgfiLiigEkpikilikhHhdiNgfaEaKkfgtgtgtgtgtgtgtklgtgtgtgtgtgtgtgtkfaEaKggiOgGhgiPhjhiiQhggMiRggaEaKajatamamamamajajajiUajajamamamamamamcdamceamamajcfaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPglglglglglfXiVgpiWgbgbgTgbgbgbiYfXajfzajaEaKgeiZjaBagujcjdjejfjgjhgeaEaKgfgFbUiigEgEgEgEgEgEjkgfaEaKdcgtgtgtgtgtgtkggtgtgtgtgtgtgtgtgtdcaEaKgggGgGjljmjnjojmjlgNgNggaEaKfvatamamamamajjpjqjramajamamamamamamajbIbiamambKaCaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPglglglglglfXiVgpiWgbgbgTgbgbgbiYfXajfzajaEaKgeiZjaBagujcjdjejfjgjhgeaEaKgfgFbUiikrgEgEgEgEgEjkgfaEaKdcgtgtgtgtgtgtkggtgtgtgtgtgtgtgtgtdcaEaKgggGgGjljmjnjojmjlgNgNggaEaKfvatamamamamajjpjqjramajamamamamamamajbIbiamambKaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeJaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPgRglglglhSfXjsgpgbgbgngngngngnjtfXajjuajaEaTgegegegegegegegegegegegeaVaTgfgfgfgfgfgfgfgfgfgfgfgfaVaTdchPgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaVaTggggggggggggggggggggggggaVaKedatamamamamajfzisjvbbajbcbdjwbfbgbhajaNbibJamajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPhthtglhthtfXfXjxjyjzgnjAfOjAgngnfXajfzajaEjBfravavavavaxavavavavavfrjCfqfravavavavavavavavavavfrjCfqdckigtgtgtgtiTgtgtiTgtgtgtgtgtfGgtdcjCfqfravavavavavavavavavavfrjCbZajatamamamamajjDjEjFjpajajajajajajajajaNjGamamajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeJaPaPaPaPaPaPaPaPaPaPaPaPaPaPhthtglhthtfXfXfXfXfXgngngngngnjtfXajfzajfHaHfIaHaHaHaHaHaHaHaHjHdKfIaHaHfIjHaHaHaHaHdKaHaHjHaHfIaHaHdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcaHaHfIdKaHjHaHaHaHaHaHaHaHfIaHjIajamamamamamajjJjKjLjMajajajajajajajajajaBaBaBajaCaDaaaaaaaaaaaaaa

--- a/maps/urf_flagship/first_deck.dmm
+++ b/maps/urf_flagship/first_deck.dmm
@@ -61,13 +61,13 @@
 "bi" = (/obj/machinery/atmospherics/pipe/manifold/visible{dir = 4},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "bj" = (/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "bk" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Troopbunks)
-"bl" = (/obj/machinery/organ_printer/flesh{matter = 100; max_stored_matter = 100},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"bl" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = null; req_one_access = list(857,251)},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "bm" = (/obj/machinery/autosurgeon,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bn" = (/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bo" = (/obj/machinery/vending/medical,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bp" = (/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/structure/closet/crate/medical,/obj/effect/decal/cleanable/blood/splatter,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bq" = (/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/structure/closet/crate/medical,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
-"br" = (/obj/structure/table/standard,/obj/item/weapon/autopsy_scanner,/obj/item/weapon/defibrillator/loaded,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"br" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = null; req_one_access = list(857,251)},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "bs" = (/turf/simulated/floor/tiled,/area/shuttle/innie_shuttle_transport)
 "bt" = (/obj/machinery/chemical_dispenser/full,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bu" = (/obj/machinery/chem_master,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
@@ -89,12 +89,12 @@
 "bK" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/hatch,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "bL" = (/obj/machinery/light/small{dir = 1},/obj/machinery/camera/autoname/invis/innie_base,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "bM" = (/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
-"bN" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = list(858)},/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
+"bN" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = null; req_one_access = list(857,251)},/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "bO" = (/obj/structure/bed,/obj/item/weapon/bedsheet/hos,/obj/effect/landmark/start/commando_captain_spawn,/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "bP" = (/obj/machinery/door/airlock/hatch,/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "bQ" = (/obj/structure/closet/walllocker/emerglocker/west,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Troopbunks)
 "bR" = (/obj/machinery/light/small{icon_state = "bulb1"; dir = 8},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
-"bS" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/closet/walllocker/emerglocker/west,/obj/effect/landmark/start/x52_rd,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"bS" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/closet/walllocker/emerglocker/west,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bT" = (/obj/effect/landmark/start/x52,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "bU" = (/obj/effect/shuttle_landmark/innie_berth_transport,/turf/simulated/floor/tiled,/area/shuttle/innie_shuttle_transport)
 "bV" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/machinery/power/apc{dir = 4; name = "APC"; pixel_x = 24; pixel_y = 0},/obj/structure/cable/blue{icon_state = "0-2"},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
@@ -158,10 +158,10 @@
 "db" = (/obj/structure/ai_routing_node/innie,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "dc" = (/turf/simulated/wall/r_wall,/area/urf_flagship/Centralhallway)
 "dd" = (/obj/structure/table/standard,/obj/item/weapon/hand_labeler,/obj/item/weapon/storage/box/beakers,/obj/item/weapon/storage/box/pillbottles,/obj/item/weapon/storage/box/pillbottles,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
-"de" = (/obj/machinery/power/apc{dir = 2; name = "south bump"; pixel_x = 0; pixel_y = -24},/obj/machinery/shuttle_fuel,/turf/simulated/floor/shuttle/red,/area/shuttle/innie_shuttle_transport)
+"de" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = null; req_one_access = list(857,251)},/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "df" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4},/turf/simulated/floor/tiled,/area/urf_flagship/janitorial)
 "dg" = (/turf/simulated/floor/tiled,/area/urf_flagship/storageroom)
-"dh" = (/obj/machinery/door/airlock/halo{name = "Cargo Supply Ship"; req_access = list(251)},/turf/simulated/floor/shuttle/yellow,/area/shuttle/innie_shuttle_supply)
+"dh" = (/obj/machinery/door/airlock/halo{name = "Cargo Supply Ship"; req_access = list(250)},/turf/simulated/floor/shuttle/yellow,/area/shuttle/innie_shuttle_supply)
 "di" = (/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/shuttle/yellow,/area/shuttle/innie_shuttle_supply)
 "dj" = (/obj/structure/ai_routing_node/innie,/turf/simulated/floor/shuttle/yellow,/area/shuttle/innie_shuttle_supply)
 "dk" = (/obj/structure/cable/blue{icon_state = "1-2"},/turf/simulated/floor/tiled,/area/urf_flagship/storageroom)
@@ -188,7 +188,7 @@
 "dF" = (/obj/machinery/light/small{dir = 1},/obj/structure/ai_routing_node/innie,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "dG" = (/obj/structure/flora/pottedplant/minitree,/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "dH" = (/obj/structure/cable/blue{icon_state = "1-2"},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Troopbunks)
-"dI" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/gloves,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"dI" = (/obj/structure/cable/blue{icon_state = "1-2"},/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = null; req_one_access = list(857,251)},/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "dJ" = (/obj/effect/landmark/start/x52_rd,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "dK" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Centralhallway)
 "dL" = (/obj/machinery/iv_drip,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
@@ -224,13 +224,13 @@
 "ep" = (/obj/machinery/power/apc{dir = 4; name = "APC"; pixel_x = 24; pixel_y = 0},/obj/structure/cable/blue{icon_state = "0-8"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "eq" = (/obj/structure/table/standard,/obj/item/device/flashlight/lamp/green,/obj/structure/closet/walllocker/emerglocker/south,/obj/machinery/light{dir = 2; icon_state = "tube1"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "er" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 4},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
-"es" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/masks,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"es" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/machinery/organ_printer/flesh/mapped,/obj/item/weapon/reagent_containers/food/snacks/meat/beef,/obj/item/weapon/reagent_containers/food/snacks/meat/beef,/obj/item/weapon/reagent_containers/food/snacks/meat/beef,/obj/item/weapon/reagent_containers/food/snacks/meat/beef,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "et" = (/obj/structure/table/standard,/obj/item/weapon/storage/firstaid/surgery,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "eu" = (/obj/machinery/optable,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "ev" = (/obj/structure/table/standard,/obj/item/weapon/tank/anesthetic,/obj/item/clothing/mask/breath/anesthetic,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "ew" = (/obj/machinery/iv_drip,/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 1},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
-"ex" = (/obj/item/weapon/storage/firstaid/empty,/obj/structure/table/standard,/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
-"ey" = (/obj/item/weapon/storage/firstaid/adv,/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"ex" = (/obj/structure/table/standard,/obj/item/weapon/autopsy_scanner,/obj/item/weapon/defibrillator/loaded,/obj/item/weapon/storage/box/gloves,/obj/item/weapon/storage/box/masks,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
+"ey" = (/obj/machinery/organ_printer/robot/mapped,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "ez" = (/obj/item/weapon/storage/firstaid/toxin,/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "eA" = (/obj/item/weapon/storage/firstaid/o2,/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "eB" = (/obj/item/weapon/storage/firstaid/combat,/obj/structure/table/standard,/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
@@ -250,7 +250,7 @@
 "eP" = (/obj/machinery/power/apc{dir = 4; name = "APC"; pixel_x = 24; pixel_y = 0},/obj/structure/cable/blue{icon_state = "0-2"},/obj/effect/bomblocation,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
 "eQ" = (/obj/structure/computerframe{anchored = 1; dir = 8; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "computer"; layer = 2; level = 1; tag = "icon-computer (WEST)"},/obj/machinery/shuttle_spawner/multi_choice/urf{dir = 8; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "nav"},/obj/effect/bomblocation,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
 "eR" = (/obj/effect/bomblocation,/mob/living/simple_animal/cat/fluff/reno,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
-"eS" = (/obj/structure/cable/blue{icon_state = "1-2"},/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = list(858)},/obj/machinery/door/firedoor,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
+"eS" = (/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/machinery/bodyscanner{dir = 4},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "eT" = (/obj/machinery/door/airlock/multi_tile/halo/blast{dir = 1},/obj/structure/cable/blue{icon_state = "1-2"},/obj/machinery/door/firedoor/multi_tile,/turf/simulated/floor/tiled/dark,/area/urf_flagship/Troopbunks)
 "eU" = (/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 9},/obj/structure/cable/blue{icon_state = "1-2"},/obj/structure/cable/blue{icon_state = "2-4"},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Centralhallway)
 "eV" = (/obj/effect/floor_decal/corner/red{icon_state = "corner_white"; dir = 6},/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/structure/cable/blue{icon_state = "1-8"},/turf/simulated/floor/tiled/dark,/area/urf_flagship/Centralhallway)
@@ -303,7 +303,7 @@
 "fQ" = (/obj/machinery/camera/autoname/invis/innie_base{icon_state = "camera"; dir = 8},/turf/simulated/floor/tiled/dark,/area/urf_flagship/powercore)
 "fR" = (/obj/machinery/pointbased_vending/armory/innie_armor,/turf/simulated/floor/tiled/dark,/area/urf_flagship/Troopbunks)
 "fS" = (/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
-"fT" = (/obj/machinery/slipspace_engine/human,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
+"fT" = (/obj/machinery/body_scanconsole{dir = 8},/turf/simulated/floor/tiled,/area/urf_flagship/medicalbay)
 "fU" = (/obj/machinery/squad_camera_console{icon_state = "camera_console"; dir = 1},/obj/item/squad_manager,/obj/effect/bomblocation,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
 "fV" = (/obj/machinery/nav_computer/innie,/obj/effect/bomblocation,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
 "fW" = (/obj/structure/computerframe{anchored = 1; dir = 8; icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "computer"; layer = 2; level = 1; tag = "icon-computer (WEST)"},/obj/machinery/overmap_weapon_console/deck_gun_control/local/missile_control{icon = 'code/modules/halo/icons/machinery/computer.dmi'; icon_state = "nav"; dir = 8},/obj/effect/bomblocation,/turf/simulated/floor/tech,/area/urf_flagship/Bridge)
@@ -533,7 +533,8 @@
 "km" = (/obj/structure/closet/crate/radiation_gear,/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "kn" = (/obj/effect/landmark/start/geminus_innie{name = "Insurrectionist Orion Defector"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "ko" = (/obj/effect/landmark/start/geminus_innie{name = "Insurrectionist Commander"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
-"kr" = (/obj/machinery/door/airlock/hatch{name = "Captain's Quarters"; req_access = list(858)},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
+"kp" = (/obj/machinery/shuttle_fuel,/obj/machinery/power/apc/super{step_y = -24},/turf/simulated/floor/shuttle/red,/area/shuttle/innie_shuttle_transport)
+"kq" = (/obj/machinery/slipspace_engine/human{req_access = list(250)},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
 "ks" = (/obj/machinery/light/small{tag = "icon-bulb1 (EAST)"; icon_state = "bulb1"; dir = 4},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "kt" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/x52armor/medium,/obj/item/clothing/suit/storage/x52armor/medium,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "ku" = (/obj/structure/table/rack,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
@@ -620,23 +621,23 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeIaPaPaPananananananan
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPanananananananfRgigBhohogBgifRananajamajamajajajajajajajajajajajajajajajajajajajajamajamajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajamajajajajajajajajajamedatamamamamamamamajajajajajajajajajajajaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeIaPaPaPaPaPaPaPaPaPaPaPaPaPaPasasasasasangOaSaSiraSaSaSaSaSgaanajamajaqajajajajajajarajajajajajajajajajajajajajaqajaqajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaqajajajajajajajajajamajatamamamamamamamajajajajajajajajaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeIaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPasasaspRkuasgOaSaSjWaSaSjWiraSgCanajamajauavawavavaxavavavavavavavawaxavawavavavavavavavaxavavawavavdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcavavawavaxavavavavavavavaxawavayajajazaAazajajajajaqajajamamamamamamamajaBaBaBajaCaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPasbMkrbMksasananananjZaSanananananajamajaEaFaGaHaHaHaHaHaHaHaHaHdKaGaIaJaGaHaHaHaHaHdKaHaHaHaHaGaIaJdcgtgtgtgtgtgteZgtgtgteZgtgtgtfGgtdcaIaJaGdKaHaHaHaHaHaHaHaHaHaGaIaKajajaLaMaLajajamaoamamajajajajajajajajaNaOamamajaCaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPasbMbrbMksasananananjZaSanananananajamajaEaFaGaHaHaHaHaHaHaHaHaHdKaGaIaJaGaHaHaHaHaHdKaHaHaHaHaGaIaJdcgtgtgtgtgtgteZgtgtgteZgtgtgtfGgtdcaIaJaGdKaHaHaHaHaHaHaHaHaHaGaIaKajajaLaMaLajajamaoamamajajajajajajajajaNaOamamajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPasksasktkuasaQaRaQanaSaSanaQaRaQanajamajaEaTaUaUaUaUaUaUaUaUaUaUaUaUaVaTaWaWaWaWaWaWaWaWaWaWaWaWaVaTdchmgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaVaTaXaXaXaXaXaXaXaXaXaXaXaXaVaKajajaLaLaLajajaYCFbabbajbcbdbebfbgbhajaNbiamamajaCaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaskrasasasasbjcpknanbkirankncpbjanajamajaEaKaUblbmbnbobpbqakakbtbuaUaEaKaWbvbwbwbwbxbwbwbwbwbyaWaEaKdcgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtdcaEaKaXbzbAbBbCbDbBbAbEbFbAaXaEaKajajajbGajajajamamamamajbHamamamamamajbIbibJambKaCaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPasblasasasasbjcpknanbkirankncpbjanajamajaEaKaUbnbmbnbobpbqakakbtbuaUaEaKaWbvbwbwbwbxbwbwbwbwbyaWaEaKdcgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtdcaEaKaXbzbAbBbCbDbBbAbEbFbAaXaEaKajajajbGajajajamamamamajbHamamamamamajbIbibJambKaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPiqaPaPaPaPaPaPiqaPbLbMbNbMbOasanbPananbQaSananbPananajbRajaEaKaUbSbnbnkabnbTbnbTkabVaUaEaKaWbWeDeDeDeDeDeDeDeDbYaWaEbZgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtaEbZaXcabCbEbBbAbFbzbFbFcbaXaEaKajccaLaLaLccajajajaqajajamamamamamamcdamceamamajcfaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZaZaZcgchcgcichcRaZaPcjckasclcmiAcnaSaSaScogPaSaSaScqijajaoajaEcrcscscscscscscscscscsctcscucvbwcweDcxcycyczcAcBcCcDbwcucvdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdscucvcEcEcEcEcEcEcEcEcEcEcFcGaEaKajcHaLaLaLccajcIcJamamcKcLcLcLcMamcNajamcOcPcQajaCaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZcScThBhlhBhBcUcRaZaPcVcWasbNasasanbPanancXcYananbPananajamajaEcZdabnkabnbndbkbalddbnbndWaEaKdXdgdhcycycydidjcBcCdkdXaEaKkfgtgtgtgtgtgthNgtgtgtgtgtgtgtgtgtkfaEaKdfcGcGcGcGdmdncGcGcGcGdfaEbZajdoaLdpaLdqajcIdrcLtWdtamamamcJamdxajamdycPdzajaCaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdldAhBhBhBhBhBhBdBaZaPdDdEdFbMdGaskocpknandHaSankncpbjanajamajaEcZaUdIdJdJbrdLbnbTbTkadMaUaEaKaWdNeDcydOcycycycBcCdPaWaEaKdchPgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaEaKaXdQbDbFdRdRbBbFdSdTdUaXaEaKajccaLaLaLdVajamamamamamamWhiteeamefajegamehajajajaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdCdAhBhBdYeiejhBhBekaZbMbMeneoepasaQeqaQandHaSanaQeqaQanajamajzVcZaUeseteuevewexeyezeAeBaUWnaKaWeCbXeDeDeDeDeDeDeDeEaWWnaKdchZgtgtgtgtgtiTjXgtiTgtgtgtgtgthZdcWnaKaXbAbFbFbAeFeGdSeHeHbAaXWnaKajccaLaLaLccajamamamamamamamameKeLeMajajeNajajajajajaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZelhBhBhBemcieOhBhBePaZasaseSasasasananananeTaSanananananajaqajeUeVaUaUaUaUaUaUaUaUaUaUaUaUaVaKaWaWaWaWaWaWaWaWaWaWaWaWaVaTdcdcdcdcjYgtdcdcdcdcdcdcjYgtdcdcdcdcaVaTaXaXaXaXaXaXaXaXaXaXaXaXaVaKajajajbGajajajeWeXeYamamamfaeXfbfcajajajajajajaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZcScThBhlhBhBcUcRaZaPcVcWasdeasasanbPanancXcYananbPananajamajaEcZdabnkabnbndbkbalddbnbndWaEaKdXdgdhcycycydidjcBcCdkdXaEaKkfgtgtgtgtgtgthNgtgtgtgtgtgtgtgtgtkfaEaKdfcGcGcGcGdmdncGcGcGcGdfaEbZajdoaLdpaLdqajcIdrcLtWdtamamamcJamdxajamdycPdzajaCaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdldAhBhBhBhBhBhBdBaZaPdDdEdFbMdGaskocpknandHaSankncpbjanajamajaEcZaUesdJdJexdLbnbTbTkadMaUaEaKaWdNeDcydOcycycycBcCdPaWaEaKdchPgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaEaKaXdQbDbFdRdRbBbFdSdTdUaXaEaKajccaLaLaLdVajamamamamamamWhiteeamefajegamehajajajaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdCdAhBhBdYeiejhBhBekaZbMbMeneoepasaQeqaQandHaSanaQeqaQanajamajzVcZaUeyeteueveweSfTezeAeBaUWnaKaWeCbXeDeDeDeDeDeDeDeEaWWnaKdchZgtgtgtgtgtiTjXgtiTgtgtgtgtgthZdcWnaKaXbAbFbFbAeFeGdSeHeHbAaXWnaKajccaLaLaLccajamamamamamamamameKeLeMajajeNajajajajajaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZelhBhBhBemcieOhBhBePaZasasdIasasasananananeTaSanananananajaqajeUeVaUaUaUaUaUaUaUaUaUaUaUaUaVaKaWaWaWaWaWaWaWaWaWaWaWaWaVaTdcdcdcdcjYgtdcdcdcdcdcdcjYgtdcdcdcdcaVaTaXaXaXaXaXaXaXaXaXaXaXaXaVaKajajajbGajajajeWeXeYamamamfaeXfbfcajajajajajajaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPeQdAhBeRhBfdcieOhBiMfefffhfifjfkfkfkflfkfkfifmfkfifkiSfkfkfnfofhfpfqfravavavavaxavavavavavfrfsfqftavavavaviXavaxavavavfrfufqfravavavavavavfravavfravavavavavavfrfufqfravaxavavavavavavavaxfrfuaKfvfvfwjbfwfvamamamfxeXeXeXfyamfzfAamfBajajajaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPfgdAhBfCfDfEfFeOhBhBhBfKfHaGaHaHaHfIaHaHaHaGfJaHaGaHaHaHaHdKfLdKfNaFaGaHaHaHaHaHaHaHaHaHdZaGaIaJaGaHaHaHaHaHaHaHaHaHdZaGaIaJaGaHaHaHaHaHaHaGaHaHaGaHaHaHaHaHaHaGaIaJaGdKaHaHaHaHaHaHaHaHaHaGaIaKedfvfPfQfPfveramamfScLcLcLcMamfzfAfTfBajajajaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPfgdAhBfCfDfEfFeOhBhBhBfKfHaGaHaHaHfIaHaHaHaGfJaHaGaHaHaHaHdKfLdKfNaFaGaHaHaHaHaHaHaHaHaHdZaGaIaJaGaHaHaHaHaHaHaHaHaHdZaGaIaJaGaHaHaHaHaHaHaGaHaHaGaHaHaHaHaHaHaGaIaJaGdKaHaHaHaHaHaHaHaHaHaGaIaKedfvfPfQfPfveramamfScLcLcLcMamfzfAkqfBajajajaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZfMhBhBhBfUcieOhBhBfVaZfXfYfZfYfXfXfXfXfXfXkcgbfXfXfXfXfXajgcajgdaTgegegegegegegegegegegegeaVaTgfgfgfgfgfgfgfgfgfgfgfgfgtaTdcdcdcdcjYgtdcdcdcdcdcdcjYgtdcdcdcdcgtaTggggggggggggggggggggggggaVaKajajajbGajajajghcLdtamamamdrcLgjfcajajajajajajaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZfWdAhBhBdYeigkhBfDekaPglglglglgmfXkdgngnkegpgbgogqgrgsfXajfzajLwaKgegugvgwgxAOJlgxgygzgAgeWnaKgfdwhAhAhAjjhAhAhAhAhegfWnaKdchZgtgtgtgtgteZjXgteZgtgtgtgtgthZdcWnaKgggGgGgHgIgJgKgJgLgMgNggWnbZajamatatatamajamamamamamamamameKeLeMajajeNajajajajajaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaZdldAhBhBhBhBhBhBhraZaPgRglglglhQfXgngnkdgSgpgbgbgbgbgTfXajfzajgdaKgegUgVgygxgygygxgygVgWgeaEaKgfdubsgDgEgEgEgEgEgEhIgfaEbZdchPgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaEbZgghfgGhghhhihjhhhggMhkggaEaKajamamamamamajamamamamamamWhithpamefajhqamehajajajaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZhscThBhMhBhBhwcRaZaPhthtglhthtfXgngngngSgphukhhvhugbfXajfzajhxcvhyhyhyhyhyhyhyhyhyhyhzhycucvhAihgDgEgYdvhahbhHhdjihAcucvdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdsdscucvhJhJhKhJhJhKhJhJhJhKhLhjaEaKajamamamamamajcIfaeXZNeYamamameKamdxajamhTcPdzajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaZaZaZhUhVhUhWchhcaZaPhthtglhthtfXhXkjhYkkgphuhviahugbfXajibajaEaKicididididieifidididideaaEaKebgFhChDhDhEhFhGimhdgFebaEaKgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtgtaEaKechjhjhggLioiphjhjhjhjecaEaKajamamamamamajcIkmisitiuiviviviwitixajamiycPcQajaCaDaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPiqaPaPaPaPaPaPiqaPizhtglhOhtiBiCiDiEiEiFhukhhvhugbiBajfzajiGaKgeiHidididiIiIiIiJiIiKgeaEaKgfiLiigEdeikilikhHhdiNgfaEaKkfgtgtgtgtgtgtgtklgtgtgtgtgtgtgtgtkfaEaKggiOgGhgiPhjhiiQhggMiRggaEaKajatamamamamajajajiUajajamamamamamamcdamceamamajcfaDaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPiqaPaPaPaPaPaPiqaPizhtglhOhtiBiCiDiEiEiFhukhhvhugbiBajfzajiGaKgeiHidididiIiIiIiJiIiKgeaEaKgfiLiigEkpikilikhHhdiNgfaEaKkfgtgtgtgtgtgtgtklgtgtgtgtgtgtgtgtkfaEaKggiOgGhgiPhjhiiQhggMiRggaEaKajatamamamamajajajiUajajamamamamamamcdamceamamajcfaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPglglglglglfXiVgpiWgbgbgTgbgbgbiYfXajfzajaEaKgeiZjaBagujcjdjejfjgjhgeaEaKgfgFbUiigEgEgEgEgEgEjkgfaEaKdcgtgtgtgtgtgtkggtgtgtgtgtgtgtgtgtdcaEaKgggGgGjljmjnjojmjlgNgNggaEaKfvatamamamamajjpjqjramajamamamamamamajbIbiamambKaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeJaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPgRglglglhSfXjsgpgbgbgngngngngnjtfXajjuajaEaTgegegegegegegegegegegegeaVaTgfgfgfgfgfgfgfgfgfgfgfgfaVaTdchPgtgtgtgtgtgtgtgtgtgtgtgtgtgthndcaVaTggggggggggggggggggggggggaVaKedatamamamamajfzisjvbbajbcbdjwbfbgbhajaNbibJamajaCaDaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPaPhthtglhthtfXfXjxjyjzgnjAfOjAgngnfXajfzajaEjBfravavavavaxavavavavavfrjCfqfravavavavavavavavavavfrjCfqdckigtgtgtgtiTgtgtiTgtgtgtgtgtfGgtdcjCfqfravavavavavavavavavavfrjCbZajatamamamamajjDjEjFjpajajajajajajajajaNjGamamajaCaDaaaaaaaaaaaaaa

--- a/maps/urf_flagship/first_deck.dmm
+++ b/maps/urf_flagship/first_deck.dmm
@@ -535,7 +535,7 @@
 "ko" = (/obj/effect/landmark/start/geminus_innie{name = "Insurrectionist Commander"},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/Troopbunks)
 "kp" = (/obj/machinery/shuttle_fuel,/turf/simulated/floor/shuttle/red,/area/shuttle/innie_shuttle_transport)
 "kq" = (/obj/machinery/slipspace_engine/human{req_access = list(250)},/turf/simulated/floor/plating,/area/urf_flagship/powercore)
-"kr" = (/obj/machinery/power/apc/super{step_y = 0},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/shuttle/innie_shuttle_transport)
+"kr" = (/obj/machinery/power/apc/super,/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/shuttle/innie_shuttle_transport)
 "ks" = (/obj/machinery/light/small{tag = "icon-bulb1 (EAST)"; icon_state = "bulb1"; dir = 4},/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "kt" = (/obj/structure/table/rack,/obj/item/clothing/suit/storage/x52armor/medium,/obj/item/clothing/suit/storage/x52armor/medium,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)
 "ku" = (/obj/structure/table/rack,/turf/simulated/floor/holofloor/wood,/area/urf_flagship/captainroom)


### PR DESCRIPTION
Going through the changes, as usual.
1. Its locked to SOE Captains as of now, so no one ever uses it, still locked to officers so not anyone can walk in.
2. Allows other roles than just officers to unload the shuttle, does not give them computer access however.
3. Basic medbay requirements
4. Every other base(ODP/CRS) have secure umbis, so Liberator should too.
5. Getting stuck on the mission site because you forgot to charge the APC sucks.
6. Should've been done before, they needed this.
7. Good to have.
8. Innie slipspace drive being locked to UNSC Command was really funny, but that needed fixing.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: CaptainCamo
maptweak: Insurrectionist Ship Captain quarters can be accessed by Innie officers now.
maptweak: Insurrectionist cargo shuttle door can be accessed by every insurrectionist now.
maptweak: Insurrectionist medbay now has a body scanner and prosthetic printer
maptweak: URF Liberator umbis are one way now.
rscadd: SOE gloves are now insulated and heat proofed, that means they dont get shocked by doors and can take light tubes from walls now
tweak: Innie mission shuttle APC has a larger power cell now
tweak: Orion defectors, SOE officers, and SOE captains can access innie cargo now
tweak: SOE get custom loadout items and bank accounts now
bugfix: Innie slipspace drive can be used by innies now.
tweak: The following roles now have access to supply drops Tvoan champion, Sanghelli Zealot, Sanghelli Honor Guard, Sanghelli Spec Ops, Minor Prophet, SOE Commando Officer, SOE Commando Leader.
tweak: The following roles, as well as any with proper supply drops, have access to personal supply drops Tvoan commando, Tvoan murmillo, Sanghelli Major, Sanghelli Minor, Unggoy Spec Ops, Unggoy Ultra, Unggoy Heavy, Brute Major, Brute Minor, Yanmee Ultra, UNSC Specialist, UNSC Hellbringer, SOE Commando
tweak: Tvoan commando now only has personal supply drops.
 /:cl:
