### PR TITLE
Brute vendor changes, Chieftain in crusade and remove Covenant spawns from revolution

### DIFF
--- a/code/modules/halo/covenant/jobs/jiralhanae.dm
+++ b/code/modules/halo/covenant/jobs/jiralhanae.dm
@@ -1,4 +1,15 @@
 
+/datum/job/covenant/brute_chieftain
+	title = "Jiralhanae Chieftain"
+	department_flag = COM
+	total_positions = 1
+	spawn_positions = 1
+	outfit_type = /decl/hierarchy/outfit/jiralhanae/covenant/chieftain
+	faction_whitelist = "Covenant"
+	whitelisted_species = list(/datum/species/brutes)
+	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
+	pop_balance_mult = 2.5
+
 /datum/job/covenant/brute_captain
 	title = "Jiralhanae Captain"
 	department_flag = COM

--- a/code/modules/halo/covenant/species/jiralhanae/clothing.dm
+++ b/code/modules/halo/covenant/species/jiralhanae/clothing.dm
@@ -267,7 +267,7 @@ obj/item/clothing/under/covenant/jiralhanae/blue/rolled
 	sprite_sheets = list("Jiralhanae" = JIRALHANAE_ICON_PATH_MOB)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	armor = list(melee = 50, bullet = 45, laser = 50, energy = 40, bomb = 35, bio = 20, rad = 20)
-	specials = list(/datum/armourspecials/shields/elite,/datum/armourspecials/shieldmonitor/sangheili)
+	specials = list(/datum/armourspecials/shields/elite,/datum/armourspecials/shieldmonitor/jiralhanae)
 	totalshields = 210
 	armor_thickness = 30
 	matter = list("nanolaminate" = 2)

--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -183,7 +183,7 @@
 		/obj/item/weapon/grenade/plasma = 0,
 		/obj/item/weapon/grenade/frag/spike = 0,
 		"Misc" = -1,
-		/obj/item/turret_deploy_kit/plasturret = 2,
+		/obj/item/turret_deploy_kit/plasturret = 0,
 	)
 	amounts = list(
 		/obj/item/weapon/gun/launcher/grenade/brute_shot = 3,
@@ -229,6 +229,9 @@
 		/obj/item/flight_item/covenant_pack = 0,
 		/obj/item/dumb_ai_chip/cov = 0,
 		/obj/item/stack/barbedwire/covenant/fifteen = 0,
+		/obj/item/weapon/plastique/covenant = 0,
+		/obj/item/weapon/plastique/breaching/covenant = 0,
+		/obj/item/weapon/plastique/breaching/longrange/covenant = 0,
 		/obj/item/weapon/armor_patch/cov = 0,
 		/obj/item/weapon/armor_patch/mini/cov = 0,
 		/obj/item/weapon/pinpointer/artifact = 0,
@@ -239,6 +242,9 @@
 		/obj/item/flight_item/covenant_pack = 1,
 		/obj/item/dumb_ai_chip/cov = 2,
 		/obj/item/stack/barbedwire/covenant/fifteen = 5,
+		/obj/item/weapon/plastique/covenant = 8,
+		/obj/item/weapon/plastique/breaching/covenant = 5,
+		/obj/item/weapon/plastique/breaching/longrange/covenant = 5,
 		/obj/item/clothing/accessory/storage/IFAK/cov = 20,
 		/obj/item/weapon/pinpointer/artifact = 2,
 	)

--- a/code/modules/halo/leader_support/job_overrides.dm
+++ b/code/modules/halo/leader_support/job_overrides.dm
@@ -50,6 +50,9 @@
 /datum/job/covenant/skirmmurmillo
 	command_rank = 1
 
+/datum/job/covenant/brute_chieftain
+	command_rank = 2
+	
 /datum/job/covenant/brute_captain
 	command_rank = 2
 

--- a/code/modules/halo/leader_support/supply_drop_variants.dm
+++ b/code/modules/halo/leader_support/supply_drop_variants.dm
@@ -135,6 +135,9 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 
 /obj/structure/closet/crate/supply_drop/cov/mass_ammo/WillContain()
 	return list(\
+	/obj/item/ammo_magazine/spiker,
+	/obj/item/ammo_magazine/spiker,
+	/obj/item/ammo_magazine/spiker,
 	/obj/item/ammo_magazine/needles,
 	/obj/item/ammo_magazine/needles,
 	/obj/item/ammo_magazine/needles,

--- a/code/modules/halo/misc/armourspecials/shieldmonitor.dm
+++ b/code/modules/halo/misc/armourspecials/shieldmonitor.dm
@@ -8,3 +8,6 @@
 
 /datum/armourspecials/shieldmonitor/sangheili
 	valid_helmets = list(/obj/item/clothing/head/helmet/sangheili)
+	
+/datum/armourspecials/shieldmonitor/jiralhanae
+	valid_helmets = list(/obj/item/clothing/head/helmet/jiralhanae/covenant/chieftain)

--- a/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
+++ b/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
@@ -84,6 +84,10 @@
 
 /* ROUNDSTART ONLY UBER RANKS */
 
+/datum/job/covenant/brute_chieftan/firefight
+	spawn_positions = 1
+	total_positions = 0
+
 /datum/job/covenant/brute_captain/firefight
 	spawn_positions = 1
 	total_positions = 0

--- a/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
+++ b/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
@@ -84,10 +84,6 @@
 
 /* ROUNDSTART ONLY UBER RANKS */
 
-/datum/job/covenant/brute_chieftan/firefight
-	spawn_positions = 1
-	total_positions = 0
-
 /datum/job/covenant/brute_captain/firefight
 	spawn_positions = 1
 	total_positions = 0

--- a/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
+++ b/maps/_gamemodes/firefight/subtypes/jobs_covenant.dm
@@ -84,6 +84,10 @@
 
 /* ROUNDSTART ONLY UBER RANKS */
 
+/datum/job/covenant/brute_chieftain/firefight
+	spawn_positions = 1
+	total_positions = 0
+	
 /datum/job/covenant/brute_captain/firefight
 	spawn_positions = 1
 	total_positions = 0

--- a/maps/_gamemodes/invasion/gamemode_revolution.dm
+++ b/maps/_gamemodes/invasion/gamemode_revolution.dm
@@ -21,8 +21,10 @@
 		/datum/job/covenant/unggoy_major,\
 		/datum/job/covenant/unggoy_ultra,\
 		/datum/job/covenant/unggoy_deacon,\
+		/datum/job/covenant/unggoy_heavy,\
 		/datum/job/covenant/skirmmurmillo,\
 		/datum/job/covenant/skirmcommando,\
+		/datum/job/covenant/skirmchampion,\
 		/datum/job/covenant/brute_minor,\
 		/datum/job/covenant/brute_major,\
 		/datum/job/covenant/brute_captain,\
@@ -30,6 +32,7 @@
 		/datum/job/covenant/yanmee_major,\
 		/datum/job/covenant/yanmee_ultra,\
 		/datum/job/covenant/yanmee_leader,\
+		/datum/job/covenant/mgalekgolo,\
 		/datum/job/unsc/spartan_two)
 
 /datum/game_mode/outer_colonies/revolution/setup_objectives()

--- a/maps/crusade/map.dm
+++ b/maps/crusade/map.dm
@@ -13,6 +13,7 @@
 
 	allowed_gamemodes = list("crusade")
 	allowed_jobs = list(\
+		/datum/job/covenant/brute_chieftain/firefight,\
 		/datum/job/covenant/brute_captain/firefight,\
 		/datum/job/covenant/brute_major/firefight,\
 		/datum/job/covenant/brute_minor/firefight,\


### PR DESCRIPTION
Brute vendors have always seemed odd compared to other species vendors. They are the only ones who get no breaching charges and have to pay 2 requisition points for a plasma turret. This usually results in them having to get others to vend these items for them from another vendor. This PR fixes this.

The only weapon brutes have in their armoury that they can resupply through ammo drops is the carbine, adding spiker ammo to covenant ammo drops should help the weapon last a bit longer in the field. This will hopefully make it more appealing compared to the very devastating at close ranges mauler. 

Currently Brute Chieftain is reserved to admin spawn completely, I have created a job for Chieftain and allowed it in Crusade so it can see some use in a PvE setting at least. Its shield monitor also did not work so I had to create a Jiralhanae type for use with the Chieftain.

Lastly the revolution game mode disallowed most Covenant roles but not all, since this is meant to be URF vs UNSC I have disallowed the remaining jobs.


:cl: OuterMonk
rscadd: Brute equipment vendors now have plasma and breaching charges
tweak: Brute weapons vendors no longer charge requisition points for plasma turrets
tweak: Spiker ammo is now present in Covenant ammo drops
rscadd: Brute Chieftain job  allowed in Crusade
tweak: Brute Chieftain now has a working shield monitor
tweak: Revolution no longer allows a Grunt heavy, Skirmisher champion and Hunters to spawn
/:cl:
