### PR TITLE
Pocket system generalisation + Minor tweaks

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -54,6 +54,7 @@
 	/obj/item/device/healthanalyzer,\
 	/obj/item/weapon/storage/pill_bottle,\
 	/obj/item/stack/medical,\
+	/obj/item/weapon/grenade,\
 	)
 
 #define CANDLE_LUM 3 // For how bright candles are.

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -9,6 +9,53 @@
 
 #define ARMOUR_THICKNESS_DAMAGE_CAP 4
 
+#define MEDIC_BELT_CANHOLD list(\
+	/obj/item/ammo_magazine/m7,\
+	/obj/item/ammo_magazine/m6d,\
+	/obj/item/ammo_magazine/m6s,\
+	/obj/item/projectile/bullet/covenant/needles,\
+	/obj/item/weapon/storage/firstaid/unsc,\
+	/obj/item/weapon/storage/firstaid/erk,\
+	/obj/item/weapon/storage/firstaid/combat/unsc,\
+	/obj/item/device/healthanalyzer,\
+	/obj/item/weapon/reagent_containers/dropper,\
+	/obj/item/weapon/reagent_containers/glass/beaker,\
+	/obj/item/weapon/reagent_containers/glass/bottle,\
+	/obj/item/weapon/reagent_containers/syringe,\
+	/obj/item/weapon/flame/lighter/zippo,\
+	/obj/item/weapon/storage/fancy/cigarettes,\
+	/obj/item/weapon/storage/pill_bottle,\
+	/obj/item/stack/medical,\
+	/obj/item/device/flashlight/pen,\
+	/obj/item/clothing/mask/surgical,\
+	/obj/item/clothing/head/surgery,\
+	/obj/item/clothing/gloves/latex,\
+	/obj/item/weapon/reagent_containers/hypospray,\
+	/obj/item/clothing/glasses/hud/health\
+	)
+
+#define AMMO_BELT_CANHOLD list(\
+	/obj/item/weapon/material/knife/combat_knife,\
+	/obj/item/weapon/melee/blamite,\
+	/obj/item/weapon/melee/energy/elite_sword,\
+	/obj/item/ammo_magazine,\
+	/obj/item/ammo_box,\
+	/obj/item/weapon/armor_patch,\
+	/obj/item/ammo_casing,\
+	/obj/item/weapon/plastique,\
+	/obj/item/weapon/tank/emergency/oxygen\
+	)
+
+#define ARMOUR_POCKET_CANHOLD list(\
+	/obj/item/ammo_magazine,\
+	/obj/item/ammo_box,\
+	/obj/item/weapon/armor_patch,\
+	/obj/item/ammo_casing,\
+	/obj/item/device/healthanalyzer,\
+	/obj/item/weapon/storage/pill_bottle,\
+	/obj/item/stack/medical,\
+	)
+
 #define CANDLE_LUM 3 // For how bright candles are.
 
 // Item inventory slot bitmasks.

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -1,13 +1,13 @@
 //A storage item intended to be used by other items to provide storage functionality.
 //Types that use this should consider overriding emp_act() and hear_talk(), unless they shield their contents somehow.
 /obj/item/weapon/storage/internal
+	name = "Storage Pocket"
 	var/obj/item/master_item
 	cant_hold = list()
 
 /obj/item/weapon/storage/internal/New(obj/item/MI)
 	master_item = MI
 	loc = master_item
-	name = master_item.name
 	verbs -= /obj/item/verb/verb_pickup	//make sure this is never picked up.
 	..()
 
@@ -91,9 +91,13 @@
 	return master_item.Adjacent(neighbor)
 
 // Used by webbings, coat pockets, etc
-/obj/item/weapon/storage/internal/pockets/New(var/newloc, var/slots, var/slot_size,var/startingitems)
+/obj/item/weapon/storage/internal/pockets/New(var/newloc, var/slots, var/slot_size,var/startingitems,var/canhold,var/pocketname)
 	storage_slots = slots
 	max_w_class = slot_size
+	if(canhold)
+		can_hold = canhold
+	if(pocketname)
+		name = pocketname
 	if(startingitems)
 		startswith = startingitems
 	..()

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -4,6 +4,7 @@
 	name = "Storage Pocket"
 	var/obj/item/master_item
 	cant_hold = list()
+	use_dynamic_slowdown = 0
 
 /obj/item/weapon/storage/internal/New(obj/item/MI)
 	master_item = MI

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -43,7 +43,7 @@
 		var/w_class_mod = A.w_class
 		if(!(A in inv_toplevel))
 			w_class_mod -= 1
-		if(w_class_mod != 0)
+		if(w_class_mod <= 1)//Let's not make tiny items count.
 			slowdown_total += base_storage_cost(A.w_class) * BACKPACK_SLOWDOWN_MOD
 		inv -= A
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -169,12 +169,13 @@
 
 	//see code/modules/halo/clothing/armour_patch.dm
 	if(pocket_curr)
-		var/numpock = "a"
-		var/plural = ""
-		if(pockets_all)
-			numpock = "[pockets_all.len+1]"
-			plural = "s"
-		to_chat(user,"<span class='info'>It has [numpock] distinct pocket[plural]</span>")
+		var/pocket_output = ""
+		for(var/obj/pocket in list(pocket_curr) + pockets_all)
+			if(pocket_output != "")
+				pocket_output += ", "
+			pocket_output += "[pocket.name]"
+
+		to_chat(user,"<span class='info'>Pockets: [pocket_output]</span>")
 
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -13,6 +13,17 @@
 	var/blood_overlay_type = "uniformblood"
 	var/visible_name = "Unknown"
 
+	//We're giving everything the ability to handle pockets. Let's see how this goes.
+	var/obj/item/weapon/storage/internal/pockets/pocket_curr = null //Our current (last opened) pocket.
+	var/list/pockets_all = null //A list containing all pockets on this item that were not opened last.
+
+/obj/item/clothing/Destroy()
+	QDEL_NULL(pocket_curr)
+	for(var/pocket in pockets_all)
+		pockets_all -= pocket
+		qdel(pocket)
+	. = ..()
+
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()
 	return
@@ -123,6 +134,47 @@
 		icon = sprite_sheets_obj[target_species]
 	else
 		icon = initial(icon)
+
+/obj/item/clothing/attack_hand(mob/user as mob)
+	if (pocket_curr)
+		if(pockets_all && user.s_active == pocket_curr)//If our open storage is our pocket, let's go forward by one.
+			pocket_curr.close(user)
+			pockets_all += pocket_curr
+			pocket_curr = pockets_all[1]
+			pockets_all -= pocket_curr
+		if(pocket_curr.handle_attack_hand(user))
+			..(user)
+	else
+		..(user)
+
+/obj/item/clothing/MouseDrop(obj/over_object as obj)
+	if (!pocket_curr || pocket_curr.handle_mousedrop(usr, over_object))
+		..(over_object)
+
+/obj/item/clothing/attackby(obj/item/W as obj, mob/user as mob)
+	..()
+	if(!(W in accessories))		//Make sure that an accessory wasn't successfully attached to suit.
+		pocket_curr.attackby(W, user)
+
+/obj/item/clothing/emp_act(severity)
+	if(pocket_curr)
+		if(pockets_all)
+			for(var/obj/pocket in pockets_all)
+				pocket.emp_act(severity)
+		pocket_curr.emp_act(severity)
+	..()
+
+/obj/item/clothing/examine(var/mob/user)
+	. = ..()
+
+	//see code/modules/halo/clothing/armour_patch.dm
+	if(pocket_curr)
+		var/numpock = "a"
+		var/plural = ""
+		if(pockets_all)
+			numpock = "[pockets_all.len+1]"
+			plural = "s"
+		to_chat(user,"<span class='info'>It has [numpock] distinct pocket[plural]</span>")
 
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects
@@ -705,11 +757,6 @@ BLIND     // can't see anything
 
 	if(has_sensor == SUIT_HAS_SENSORS && sensor_mode != SUIT_SENSOR_OFF)
 		GLOB.emp_candidates.Add(src)
-/*
-/obj/item/clothing/glasses/hud/tactical/Destroy()
-	GLOB.emp_candidates.Remove(src)
-	. = ..()
-*/
 
 /obj/item/clothing/under/get_mob_overlay(mob/user_mob, slot)
 	var/image/ret = ..()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/suit/storage/New()
 	..()
-	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 2, slot_size = ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD) //two slots, fit only pocket sized items
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD) //two slots, fit only pocket sized items
 
 //Jackets with buttons, used for labcoats, IA jackets, First Responder jackets, and brown jackets.
 /obj/item/clothing/suit/storage/toggle

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/suit/storage/New()
 	..()
-	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 2, slot_size = ITEM_SIZE_SMALL) //two slots, fit only pocket sized items
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 2, slot_size = ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD) //two slots, fit only pocket sized items
 
 //Jackets with buttons, used for labcoats, IA jackets, First Responder jackets, and brown jackets.
 /obj/item/clothing/suit/storage/toggle

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,30 +1,6 @@
-/obj/item/clothing/suit/storage
-	var/obj/item/weapon/storage/internal/pockets/pockets
-
 /obj/item/clothing/suit/storage/New()
 	..()
-	pockets = new/obj/item/weapon/storage/internal/pockets(src, slots = 2, slot_size = 2) //two slots, fit only pocket sized items
-
-/obj/item/clothing/suit/storage/Destroy()
-	QDEL_NULL(pockets)
-	. = ..()
-
-/obj/item/clothing/suit/storage/attack_hand(mob/user as mob)
-	if (pockets.handle_attack_hand(user))
-		..(user)
-
-/obj/item/clothing/suit/storage/MouseDrop(obj/over_object as obj)
-	if (pockets.handle_mousedrop(usr, over_object))
-		..(over_object)
-
-/obj/item/clothing/suit/storage/attackby(obj/item/W as obj, mob/user as mob)
-	..()
-	if(!(W in accessories))		//Make sure that an accessory wasn't successfully attached to suit.
-		pockets.attackby(W, user)
-
-/obj/item/clothing/suit/storage/emp_act(severity)
-	pockets.emp_act(severity)
-	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 2, slot_size = ITEM_SIZE_SMALL) //two slots, fit only pocket sized items
 
 //Jackets with buttons, used for labcoats, IA jackets, First Responder jackets, and brown jackets.
 /obj/item/clothing/suit/storage/toggle
@@ -51,9 +27,9 @@
 
 /obj/item/clothing/suit/storage/vest/merc/New()
 	..()
-	pockets = new/obj/item/weapon/storage/internal/pockets(src, slots = 4, slot_size = 2)
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 4, slot_size = 2)
 
 
 /obj/item/clothing/suit/storage/vest/tactical/New()
 	..()
-	pockets = new/obj/item/weapon/storage/internal/pockets(src, slots = 4, slot_size = 2)
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, slots = 4, slot_size = 2)

--- a/code/modules/halo/Forerunner/species/knight/knight.dm
+++ b/code/modules/halo/Forerunner/species/knight/knight.dm
@@ -148,7 +148,7 @@
 	icon = 'code/modules/halo/Forerunner/species/knight/knight.dmi'
 	icon_state = "knight_elegiast"
 	robotic = ORGAN_ROBOT
-	max_damage = 200
+	max_damage = 800
 
 /obj/item/organ/external/chest/knight
 	robotic = ORGAN_ROBOT

--- a/code/modules/halo/Forerunner/species/knight/knight_armour.dm
+++ b/code/modules/halo/Forerunner/species/knight/knight_armour.dm
@@ -67,6 +67,15 @@
 
 	species_restricted = list("Knight")
 
+/obj/item/clothing/suit/armor/special/knight_armour/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+	if(!pockets_all)
+		pockets_all = list()
+	pockets_all += list(\
+	new/obj/item/weapon/storage/internal/pockets(src, 2, ITEM_SIZE_HUGE,null,list(/obj/item/weapon/gun),"Weapon Materialiser"),\
+	)
+
 /obj/item/clothing/shoes/magboots/knight_boots
 	name = "Knight Legs"
 	desc = "Armoured legs, to be fitted to the chassis of a Promethean Knight"

--- a/code/modules/halo/clothing/civilian.dm
+++ b/code/modules/halo/clothing/civilian.dm
@@ -17,6 +17,7 @@
 /obj/item/clothing/suit/armor/vest/police/New()
 	. =..()
 	slowdown_per_slot[slot_wear_suit] = 2
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/suit/armor/vest/police_medium//medium armor
 	name = "medium ballistic vest"
@@ -37,6 +38,8 @@
 /obj/item/clothing/suit/armor/vest/police_medium/New()//speeds are factoring other gear and chasing people on foot, meant to encourage using lighter armors to reduce meta
 	. = ..()
 	slowdown_per_slot[slot_wear_suit] = -1
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 
 /obj/item/clothing/suit/storage/vest/tactical/police//light armor
 	name = "light ballistic vest"
@@ -56,6 +59,7 @@
 /obj/item/clothing/suit/storage/vest/tactical/police/New()
 	. = ..()
 	slowdown_per_slot[slot_wear_suit] = -2
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/mask/balaclava/tactical/police
 	name = "police balaclava"

--- a/code/modules/halo/clothing/insurrectionists.dm
+++ b/code/modules/halo/clothing/insurrectionists.dm
@@ -488,6 +488,10 @@
 	cold_protection = UPPER_TORSO | LOWER_TORSO | ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 
+/obj/item/clothing/suit/armor/innie/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/mask/innie/shemagh
 	name = "Shemagh"
 	desc = "A headdress designed to keep out dust and protect against the sun."
@@ -523,6 +527,10 @@
 	armor_thickness = 40
 	slowdown_general = 1.2
 	siemens_coefficient = 0.7
+
+/obj/item/clothing/suit/bomb_suit/security/colossus/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/head/bomb_hood/security/colossus
 	name = "Colossus Helm"
@@ -583,6 +591,8 @@
 /obj/item/clothing/suit/justice/zeal/New()
 	. = ..()
 	slowdown_per_slot[slot_wear_suit] = 1
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 
 /obj/item/clothing/head/helmet/zeal
 	name = "Zeal Scout Suit Helmet"

--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -249,6 +249,10 @@
 	allowed = list(/obj/item/weapon/tank)
 	armor = list(melee = 50, bullet = 45, laser = 50, energy = 40, bomb = 35, bio = 20, rad = 20) //Same armour as marines, but innate spacesuit slowdown and limited choice of suitstore
 
+/obj/item/clothing/suit/space/void/unsc/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/head/helmet/space/void/unsc
 	name = "\improper Salvage Helmet"
 	desc = "A universally used helmet to protect one's head against the vacuum when doing EVA."
@@ -323,6 +327,10 @@
 	w_class = ITEM_SIZE_HUGE
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/weapon/tank)
 	armor = list(melee = 50, bullet = 45, laser = 50, energy = 40, bomb = 35, bio = 20, rad = 20)
+
+/obj/item/clothing/suit/spaceeva/eva/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/head/helmet/eva/marine
 	name = "\improper EVA Marine Helmet"

--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -147,7 +147,6 @@
 	. = ..()
 	slowdown_per_slot[slot_wear_suit] = -0.1
 
-
 /obj/item/clothing/shoes/marine
 	name = "Olive VZG7 Armored Boots"
 	desc = "Standard issue combat boots for the UNSC Marines, worn as a part of the Marine BDU."
@@ -187,15 +186,7 @@
 	item_state = "UNSC Marine Ammo Belt"
 	storage_slots = 7
 
-	can_hold = list(\
-	/obj/item/weapon/material/knife/combat_knife,
-	/obj/item/ammo_magazine,
-	/obj/item/ammo_box,
-	/obj/item/weapon/armor_patch,
-	/obj/item/ammo_casing,
-	/obj/item/weapon/plastique,
-	/obj/item/weapon/tank/emergency/oxygen
-	)
+	can_hold = AMMO_BELT_CANHOLD
 
 /obj/item/weapon/storage/belt/marine_medic
 	name = "Medical Supplies Storage Belt"

--- a/code/modules/halo/clothing/odst.dm
+++ b/code/modules/halo/clothing/odst.dm
@@ -70,6 +70,7 @@
 /obj/item/clothing/suit/armor/special/odst/New()
 	. = ..()
 	slowdown_per_slot[slot_wear_suit] = -0.1 //A slight speed boost for those wearing odst armour.
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/shoes/magboots/odst
 	name = "ODST Magboots"

--- a/code/modules/halo/clothing/spartan_armour.dm
+++ b/code/modules/halo/clothing/spartan_armour.dm
@@ -66,6 +66,10 @@
 	totalshields = 170 //10 less than major.
 	item_state_slots = list(slot_l_hand_str = "syndicate-black", slot_r_hand_str = "syndicate-black")
 
+/obj/item/clothing/suit/armor/special/spartan/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/special/spartan/ui_action_click()
 	self_destruct(usr)
 

--- a/code/modules/halo/clothing/spartan_armour.dm
+++ b/code/modules/halo/clothing/spartan_armour.dm
@@ -29,7 +29,9 @@
 
 	integrated_hud = /obj/item/clothing/glasses/hud/tactical/spartan_hud
 
-
+/obj/item/clothing/head/helmet/spartan/New()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src, 1, ITEM_SIZE_SMALL,null,list(/obj/item/device/paicard,/obj/item/weapon/aicard),"AI Storage")
+	..()
 
 /obj/item/clothing/suit/armor/special/spartan
 	name = "MJOLNIR Powered Assault Armor Mark IV"

--- a/code/modules/halo/clothing/urf_commando.dm
+++ b/code/modules/halo/clothing/urf_commando.dm
@@ -93,6 +93,10 @@
 	var/slots = 4
 	var/max_w_class = ITEM_SIZE_SMALL
 
+/obj/item/clothing/suit/armor/special/urfc/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/special/soe
 	name = "SOE Spacesuit"
 	desc = "Heavyweight, somewhat durable armour issued to commandos for increased survivability in space."
@@ -112,6 +116,10 @@
 	item_state_slots = list(slot_l_hand_str = "urf_armor", slot_r_hand_str = "urf_armor")
 	armor_thickness = 20
 	slowdown_general = 1
+
+/obj/item/clothing/suit/armor/special/soe/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 //SHOES
 

--- a/code/modules/halo/covenant/items/ammo_belt.dm
+++ b/code/modules/halo/covenant/items/ammo_belt.dm
@@ -13,15 +13,7 @@
 		"Sangheili" = null\
 		)
 
-	can_hold = list(/obj/item/ammo_magazine,\
-		/obj/item/ammo_box,\
-		/obj/item/ammo_casing,\
-		/obj/item/weapon/melee/blamite,\
-		/obj/item/weapon/melee/energy/elite_sword,\
-		/obj/item/clothing/gloves/shield_gauntlet,\
-		/obj/item/weapon/armor_patch,\
-		/obj/item/weapon/plastique,\
-		/obj/item/weapon/tank/emergency/oxygen)
+	can_hold = AMMO_BELT_CANHOLD
 
 /obj/item/weapon/storage/belt/covenant_medic
 	name = "Covenant Medical Belt"
@@ -37,30 +29,10 @@
 		)
 	storage_slots = 5
 
-	can_hold = list(/obj/item/weapon/storage/firstaid/unsc,\
-	/obj/item/weapon/storage/firstaid/erk,\
-	/obj/item/weapon/storage/firstaid/combat/unsc,\
-	/obj/item/projectile/bullet/covenant/needles,
-	/obj/item/device/healthanalyzer,
-	/obj/item/weapon/reagent_containers/dropper,
-	/obj/item/weapon/reagent_containers/glass/beaker,
-	/obj/item/weapon/reagent_containers/glass/bottle,
-	/obj/item/weapon/reagent_containers/syringe,
-	/obj/item/weapon/flame/lighter/zippo,
-	/obj/item/weapon/storage/fancy/cigarettes,
-	/obj/item/weapon/storage/pill_bottle,
-	/obj/item/stack/medical,
-	/obj/item/device/flashlight/pen,
-	/obj/item/clothing/mask/surgical,
-	/obj/item/clothing/head/surgery,
-	/obj/item/clothing/gloves/latex,
-	/obj/item/weapon/reagent_containers/hypospray,
-	/obj/item/clothing/glasses/hud/health
-	)
+	can_hold = MEDIC_BELT_CANHOLD
 
 /obj/item/clothing/accessory/storage/bandolier/covenant
 	name = "Covenant Bandolier"
 	desc = "A lightweight synthetic bandolier made by the covenant to carry small items"
 	icon = 'tools.dmi'
 	icon_state = "covbandolier"
-//Exactly the same as the human variant, but cannont hold Grenades. This may be changed once plasma grenades are less insta-kill.

--- a/code/modules/halo/covenant/species/jiralhanae/clothing.dm
+++ b/code/modules/halo/covenant/species/jiralhanae/clothing.dm
@@ -165,6 +165,10 @@ obj/item/clothing/under/covenant/jiralhanae/blue/rolled
 		/obj/item/weapon/gun/projectile/spiker,/obj/item/weapon/gun/projectile/mauler,\
 		/obj/item/weapon/gun/energy/plasmapistol, /obj/item/weapon/gun/energy/plasmarifle, /obj/item/weapon/gun/energy/plasmarifle/brute)
 
+/obj/item/clothing/suit/armor/jiralhanae/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/jiralhanae/major
 	name = "Jiralhanae Major Chest Armour"
 	icon_state = "armour_major"
@@ -275,6 +279,10 @@ obj/item/clothing/under/covenant/jiralhanae/blue/rolled
 		/obj/item/weapon/grenade/plasma,/obj/item/weapon/grenade/frag/spike,/obj/item/weapon/grenade/brute_shot,/obj/item/weapon/grenade/toxic_gas,\
 		/obj/item/weapon/gun/projectile/spiker,/obj/item/weapon/gun/projectile/mauler,\
 		/obj/item/weapon/gun/energy/plasmapistol, /obj/item/weapon/gun/energy/plasmarifle, /obj/item/weapon/gun/energy/plasmarifle/brute)
+
+/obj/item/clothing/suit/armor/special/chieftain/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2,ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /* SHOES */
 

--- a/code/modules/halo/covenant/species/kigyar/clothing.dm
+++ b/code/modules/halo/covenant/species/kigyar/clothing.dm
@@ -64,6 +64,10 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	matter = list("nanolaminate" = 1)
 
+/obj/item/clothing/suit/armor/kigyar/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/kigyar/major
 	name = "Kig-Yar Major Combat Harness"
 	icon_state = "scout_major"

--- a/code/modules/halo/covenant/species/kigyar/kigyar_ranger.dm
+++ b/code/modules/halo/covenant/species/kigyar/kigyar_ranger.dm
@@ -29,6 +29,11 @@
 		/obj/item/ammo_magazine/needles,\
 		/obj/item/weapon/gun/projectile/needler)
 
+/obj/item/clothing/suit/armor/ranger_kigyar/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
+
 /obj/item/clothing/shoes/magboots/ranger_kigyar
 	name = "Kig-yar ranger magboots"
 	desc = "A pair of boots made for ranger kig-yars. Useful in harsh, low gravity enviroments.Allows the user to remain fixed to a spacecraft without the use of artificial gravity."

--- a/code/modules/halo/covenant/species/sangheili/clothing.dm
+++ b/code/modules/halo/covenant/species/sangheili/clothing.dm
@@ -51,6 +51,10 @@
 	max_suitstore_w_class = ITEM_SIZE_HUGE
 	matter = list("nanolaminate" = 2)
 
+/obj/item/clothing/suit/armor/special/combatharness/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/shoes/sangheili
 	name = "Sanghelli Leg Armour"
 	desc = "Leg armour, to be used with the Sangheili Combat Harness."

--- a/code/modules/halo/covenant/species/sanshyuum/clothing.dm
+++ b/code/modules/halo/covenant/species/sanshyuum/clothing.dm
@@ -11,6 +11,10 @@
 	species_restricted = list("San Shyuum")
 	unacidable = 1
 
+/obj/item/clothing/suit/prophet_robe/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/under/prophet_internal
 	name = "San Shyuum Undersuit"
 	desc = "To be worn under San Shyuum robes"
@@ -30,6 +34,10 @@
 	species_restricted = list("San Shyuum")
 	specials = list(/datum/armourspecials/shields/elite,/datum/armourspecials/gear/prophet_jumpsuit)
 	totalshields = 270 //Zealot Tier
+
+/obj/item/clothing/suit/armor/special/shielded_prophet_robe/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
 
 /obj/item/clothing/suit/armor/special/shielded_prophet_robe/santa
 	name = "Cheerful Robe"

--- a/code/modules/halo/covenant/species/tvoan/skirmisher_armour.dm
+++ b/code/modules/halo/covenant/species/tvoan/skirmisher_armour.dm
@@ -12,6 +12,10 @@
 	body_parts_covered = ARMS|UPPER_TORSO|LOWER_TORSO
 	matter = list("nanolaminate" = 1)
 
+/obj/item/clothing/suit/armor/special/skirmisher/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/special/skirmisher/major
 	name = "T\'Vaoan Major harness"
 	icon_state = "major_obj"

--- a/code/modules/halo/covenant/species/unggoy/armour.dm
+++ b/code/modules/halo/covenant/species/unggoy/armour.dm
@@ -21,6 +21,10 @@
 	//5 less all-round protection compared to marines and high ranking grunts
 	armor = list(melee = 50, bullet = 45, laser = 50, energy = 40, bomb = 35, bio = 25, rad = 25)
 
+/obj/item/clothing/suit/armor/special/unggoy_combat_harness/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/special/unggoy_combat_harness/major
 	name = "Unggoy Combat Harness (Major)"
 	icon_state = "combatharness_major"

--- a/code/modules/halo/covenant/species/yanmee/clothing.dm
+++ b/code/modules/halo/covenant/species/yanmee/clothing.dm
@@ -52,6 +52,10 @@
 	canremove = 0
 	unacidable = 1
 
+/obj/item/clothing/suit/armor/special/yanmee/New()
+	..()
+	pocket_curr = new/obj/item/weapon/storage/internal/pockets(src,2, ITEM_SIZE_SMALL,null,ARMOUR_POCKET_CANHOLD)
+
 /obj/item/clothing/suit/armor/special/yanmee/major
 	icon_state = "major_harness"
 	item_state = "major_harness"

--- a/code/modules/halo/weapons/M7.dm
+++ b/code/modules/halo/weapons/M7.dm
@@ -64,8 +64,6 @@
 	list(mode_name="extended bursts",  burst=8, dispersion=list(0.3, 0.3, 0.4, 0.5, 0.6, 0.8, 1.1))
 	)
 
-	toggle_scope(usr, scope_zoom_amount)
-
 /obj/item/weapon/gun/projectile/m7_smg/silenced/update_icon()
 	if(ammo_magazine)
 		icon_state = "m7smgs"


### PR DESCRIPTION
:cl: XO-11
tweak: Generalises the pocket system, allowing for more flexibility in what items have pockets. Clothing may also now have multiple pockets.
tweak: Spartan helmets now have a pocket that allows PAI and AI cards.
tweak: Most faction armour has gained a 2 slot pocket with restrictions similar to the ammo belt, with some medical items allowed.
tweak: Pocket storage no longer counts towards dynamic storage slowdown.
tweak: Tiny size items no longer count towards dynamic storage slowdown.
/:cl: