### PR TITLE
Gives UNSC and URF ammo drops shotgun shell boxes

### DIFF
--- a/code/modules/halo/leader_support/supply_drop_variants.dm
+++ b/code/modules/halo/leader_support/supply_drop_variants.dm
@@ -50,6 +50,8 @@
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	)
 
 /datum/support_option/supply_drop/mass_ammo/odst
@@ -85,6 +87,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	)
 
 /datum/support_option/supply_drop/mass_ammo/urf
@@ -120,6 +124,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	)
 
 


### PR DESCRIPTION
Again but better
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Antonio72
rscadd: Adds two boxes of shotgun shells to the regular UNSC mass ammo drop, the ODST ammo drop and the URF ammo drop two boxes of shotgun shells
/:cl:
