### PR TITLE
De-legitimises the cheap tactic of slipspace-driving important round objectives

### DIFF
--- a/code/modules/halo/overmap/slipspace/_slipspace.dm
+++ b/code/modules/halo/overmap/slipspace/_slipspace.dm
@@ -1,4 +1,6 @@
 
+GLOBAL_LIST_EMPTY(disallow_slipdrive_explosion_zs)
+
 /obj/machinery/slipspace_engine
 	name = "Slipspace Engine"
 	desc = "An advanced machine capable of generating a safe bubble around the ship before entry into slipspace."

--- a/code/modules/halo/overmap/slipspace/core.dm
+++ b/code/modules/halo/overmap/slipspace/core.dm
@@ -10,7 +10,7 @@
 //CORE PAYLOADS//
 /obj/payload/slipspace_core
 	name = "Slipspace Core"
-	desc = "The core of a slipspace device, detached and armed."
+	desc = "The core of a slipspace device, detached and ready to arm."
 	icon_state = "core"
 	activeoverlay =  "core_active"
 	w_class = ITEM_SIZE_HUGE
@@ -21,6 +21,10 @@
 	seconds_to_disarm = 30 // 30 sesconds to disarm.
 
 /obj/payload/slipspace_core/attack_hand(var/mob/living/carbon/human/user)
+	var/turf/t = get_turf(src)
+	if(t.z in GLOB.disallow_slipdrive_explosion_zs)
+		to_chat(user,"<span class = 'warning'>[src] hums for a moment, then stops. Something must be interfering with the slipspace field.</span>")
+		return
 	. = ..()
 	if(exploding && !disarming)
 		for(var/mob/player in GLOB.mobs_in_sectors[map_sectors["[z]"]])

--- a/maps/_gamemodes/invasion/gamemode.dm
+++ b/maps/_gamemodes/invasion/gamemode.dm
@@ -69,6 +69,10 @@
 		//this is normally bad practice, but it seems to work fine in byond
 		factions.Add(F)
 
+	//Setup slipdrive-overload blocking.
+	for(var/obj/effect/overmap/om in list(GLOB.UNSC.base,GLOB.COVENANT.base,GLOB.INSURRECTION.base))
+		GLOB.disallow_slipdrive_explosion_zs |= om.map_z
+
 /datum/game_mode/outer_colonies/proc/setup_objectives()
 
 	//setup covenant objectives

--- a/maps/base_assault_neutral_base/gm.dm
+++ b/maps/base_assault_neutral_base/gm.dm
@@ -47,6 +47,10 @@
 	GLOB.COVENANT.setup_faction_objectives(list(/datum/objective/colony_capture/cov))
 	next_score_display = world.time + ship_lockdown_duration + SCORE_DISPLAY_DELAY
 
+	//Setup slipdrive-overload blocking.
+	for(var/obj/effect/overmap/om in list(GLOB.UNSC.base,GLOB.UNSC.flagship,GLOB.COVENANT.base,GLOB.COVENANT.flagship,GLOB.INSURRECTION.base,GLOB.INSURRECTION.flagship))
+		GLOB.disallow_slipdrive_explosion_zs |= om.map_z
+
 /datum/game_mode/base_assault/neutral/proc/do_display(var/list/display_to,var/sender_name,var/percentile,var/enemy_percentile,var/points_ours,var/points_enemy)
 	for(var/datum/mind/mind in display_to)
 		if(mind.current)


### PR DESCRIPTION
Slipspace bombs now check a global list of z-levels, and fail to arm if the z-level they are on is in there. Two modes now auto-add each sides' bases to this list. (Base Assault; Invasion)
:cl: XO-11
tweak: Slipspace drives can no longer be used to bypass important map objectives.
/:cl: