### PR TITLE
Slowdown chem fix

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1874,7 +1874,6 @@
 #include "code\modules\halo\mobs\grenade_throwing.dm"
 #include "code\modules\halo\mobs\holster_verb.dm"
 #include "code\modules\halo\mobs\hostile.dm"
-#include "code\modules\halo\mobs\human_movement_delay.dm"
 #include "code\modules\halo\mobs\movement_sfx.dm"
 #include "code\modules\halo\mobs\simple_mob_ai.dm"
 #include "code\modules\halo\mobs\simplemob_radio.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -144,7 +144,7 @@ var/list/gamemode_cache = list()
 	var/walk_speed = 1
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
-	var/human_delay = 0
+	var/human_delay = 1
 	var/robot_delay = 0
 	var/monkey_delay = 0
 	var/alien_delay = 0

--- a/code/modules/halo/mobs/human_movement_delay.dm
+++ b/code/modules/halo/mobs/human_movement_delay.dm
@@ -1,8 +1,0 @@
-
-/mob/living/carbon/human/movement_delay()
-	. = ..()
-	if(CE_SLOWREMOVE in chem_effects) //Goes here because it checks the full tally first.
-		. =  max(0, . - SLOWDOWN_REMOVAL_CHEM_MAX_REMOVED)
-
-	if(CE_SPEEDBOOST in chem_effects)
-		. -= SPEEDBOOST_CHEM_SPEED_INCREASE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -25,7 +25,7 @@
 	if(can_feel_pain())
 		if(get_shock() >= 20) tally += (get_shock() / 30) //halloss shouldn't slow you down if you can't even feel it
 
-	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
+	if(buckled && istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(organ_name)
 			if(!E || E.is_stump())
@@ -42,8 +42,10 @@
 				equipment_slowdown += I.slowdown_general
 				equipment_slowdown += I.slowdown_per_slot[slot]
 
-		equipment_slowdown = max(equipment_slowdown - src.ignore_equipment_threshold, 0)
+		if(ignore_equipment_threshold && equipment_slowdown > ignore_equipment_threshold)
+			equipment_slowdown -= ignore_equipment_threshold
 		equipment_slowdown *= species.equipment_slowdown_multiplier
+
 		tally += equipment_slowdown
 
 		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
@@ -72,6 +74,12 @@
 	var/turf/T = get_turf(src)
 	if(src.elevation == T.elevation)
 		tally += T.get_movement_delay()
+
+	if(CE_SLOWREMOVE in chem_effects) //Goes here because it checks the full tally first.
+		tally =  max(0, tally - SLOWDOWN_REMOVAL_CHEM_MAX_REMOVED)
+
+	if(CE_SPEEDBOOST in chem_effects)
+		tally -= SPEEDBOOST_CHEM_SPEED_INCREASE
 
 	return (tally+config.human_delay)
 

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -226,9 +226,9 @@
 	if(gen.check_flag(MODEFLAG_HYPERKINETIC))
 		user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [I]!</span>")
 		if(I.damtype == BURN)
-			take_damage(I.force, SHIELD_DAMTYPE_HEAT)
+			take_damage(I.force/10, SHIELD_DAMTYPE_HEAT)
 		else if (I.damtype == BRUTE)
-			take_damage(I.force, SHIELD_DAMTYPE_PHYSICAL)
+			take_damage(I.force/10, SHIELD_DAMTYPE_PHYSICAL)
 		else
 			take_damage(I.force, SHIELD_DAMTYPE_EM)
 	else


### PR DESCRIPTION
:cl: XO-11
tweak: Slowdown is now calculated correctly, and Conc. Hyper should work.
/:cl:
This also needs a tweak to the config to set human_delay to 1 instead of 0; if it's set to 0. Otherwise, people are comically fast.