### PR TITLE
Supply Drop Improvements

### DIFF
--- a/code/modules/halo/leader_support/supply_drop_variants.dm
+++ b/code/modules/halo/leader_support/supply_drop_variants.dm
@@ -34,10 +34,10 @@
 	/obj/item/ammo_magazine/ma5b/m118,
 	/obj/item/ammo_magazine/ma5b/m118,
 	/obj/item/ammo_magazine/ma5b/m118,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
 	/obj/item/ammo_magazine/m392/m120,
 	/obj/item/ammo_magazine/m392/m120,
 	/obj/item/ammo_magazine/m392/m120,
@@ -50,6 +50,8 @@
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	/obj/item/ammo_box/shotgun,
 	/obj/item/ammo_box/shotgun,
 	)
@@ -89,6 +91,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_box/shotgun,
 	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	)
 
 /datum/support_option/supply_drop/mass_ammo/urf
@@ -108,10 +112,10 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/ma37/m118,
 	/obj/item/ammo_magazine/ma37/m118,
 	/obj/item/ammo_magazine/ma37/m118,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
-	/obj/item/ammo_magazine/m6d/m224,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
+	/obj/item/ammo_magazine/m6d/m225,
 	/obj/item/ammo_magazine/m392/m120,
 	/obj/item/ammo_magazine/m392/m120,
 	/obj/item/ammo_magazine/m392/m120,
@@ -124,10 +128,11 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
 	/obj/item/ammo_magazine/br55/m634,
+	/obj/item/ammo_box/shotgun,
+	/obj/item/ammo_box/shotgun,
 	/obj/item/ammo_box/shotgun,
 	/obj/item/ammo_box/shotgun,
 	)
-
 
 /datum/support_option/supply_drop/mass_ammo/cov
 	name = "Supply Drop (Covenant, Ammunition, Mass )"
@@ -144,6 +149,11 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/spiker,
 	/obj/item/ammo_magazine/spiker,
 	/obj/item/ammo_magazine/spiker,
+	/obj/item/ammo_magazine/spiker,
+	/obj/item/ammo_magazine/mauler,
+	/obj/item/ammo_magazine/mauler,
+	/obj/item/ammo_magazine/mauler,
+	/obj/item/ammo_magazine/mauler,
 	/obj/item/ammo_magazine/needles,
 	/obj/item/ammo_magazine/needles,
 	/obj/item/ammo_magazine/needles,
@@ -156,7 +166,6 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/ammo_magazine/rifleneedlepack,
 	/obj/item/ammo_magazine/rifleneedlepack,
 	/obj/item/ammo_magazine/rifleneedlepack,
-
 	)
 
 /datum/support_option/supply_drop/personalised_ammo//re-enabled for power/specialist roles and up only.
@@ -218,7 +227,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/weapon/storage/firstaid/combat/unsc,
 	/obj/item/weapon/storage/pill_bottle/bicaridine,
 	/obj/item/weapon/storage/pill_bottle/dermaline,
-	/obj/item/weapon/storage/pill_bottle/polypseudomorphine
+	/obj/item/weapon/storage/pill_bottle/polypseudomorphine,
+	/obj/item/weapon/reagent_containers/syringe/psychostimulant
 	)
 
 /datum/support_option/supply_drop/medical_drop/cov
@@ -239,7 +249,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/weapon/storage/firstaid/combat/unsc/cov,
 	/obj/item/weapon/storage/pill_bottle/covenant/bicaridine,
 	/obj/item/weapon/storage/pill_bottle/covenant/dermaline,
-	/obj/item/weapon/storage/pill_bottle/covenant/polypseudomorphine
+	/obj/item/weapon/storage/pill_bottle/covenant/polypseudomorphine,
+	/obj/item/weapon/reagent_containers/syringe/psychostimulant
 	)
 
 //RECON VEHICLE DROP//
@@ -266,7 +277,7 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	name = "Supply Drop (UNSC Construction/Reinforcement)"
 	desc = "Contains a variety of materials and some tools for construction and reinforcement of a position."
 	rank_required = 2
-	cooldown_inflict = 3 MINUTES
+	cooldown_inflict = 5 MINUTES
 	item_to_drop = /obj/structure/closet/crate/supply_drop/construction
 
 /obj/structure/closet/crate/supply_drop/construction
@@ -275,14 +286,12 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 
 /obj/structure/closet/crate/supply_drop/construction/WillContain()
 	return list(\
-	/obj/item/stack/material/steel/ten,
-	/obj/item/stack/material/steel/ten,
-	/obj/item/stack/material/steel/ten,
-	/obj/item/stack/material/steel/ten,
+	/obj/item/stack/material/steel/fifty,
 	/obj/item/stack/material/plasteel/ten,
 	/obj/item/stack/material/plasteel/ten,
-	/obj/item/weapon/wrench,
-	/obj/item/weapon/weldingtool,
+	/obj/item/stack/material/plasteel/ten,
+	/obj/item/weapon/storage/toolbox/mechanical
+	/obj/item/clothing/glasses/welding
 	)
 
 /datum/support_option/supply_drop/construction_drop/cov
@@ -297,13 +306,10 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 
 /obj/structure/closet/crate/supply_drop/cov/construction/WillContain()
 	return list(\
-	/obj/item/stack/material/steel/ten,
-	/obj/item/stack/material/steel/ten,
-	/obj/item/stack/material/steel/ten,
+	/obj/item/stack/material/steel/fifty,
 	/obj/item/stack/material/nanolaminate/ten,
 	/obj/item/stack/material/nanolaminate/ten,
-	/obj/item/stack/material/plasteel/ten,
-	/obj/item/stack/material/plasteel/ten,
-	/obj/item/weapon/wrench,
-	/obj/item/weapon/weldingtool,
+	/obj/item/stack/material/nanolaminate/ten,
+	/obj/item/weapon/storage/toolbox/covenant_mech
+	/obj/item/clothing/glasses/welding
 	)

--- a/code/modules/halo/leader_support/supply_drop_variants.dm
+++ b/code/modules/halo/leader_support/supply_drop_variants.dm
@@ -228,7 +228,7 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/weapon/storage/pill_bottle/bicaridine,
 	/obj/item/weapon/storage/pill_bottle/dermaline,
 	/obj/item/weapon/storage/pill_bottle/polypseudomorphine,
-	/obj/item/weapon/reagent_containers/syringe/psychostimulant
+	/obj/item/weapon/reagent_containers/syringe/psychostimulant,
 	)
 
 /datum/support_option/supply_drop/medical_drop/cov
@@ -250,7 +250,7 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/weapon/storage/pill_bottle/covenant/bicaridine,
 	/obj/item/weapon/storage/pill_bottle/covenant/dermaline,
 	/obj/item/weapon/storage/pill_bottle/covenant/polypseudomorphine,
-	/obj/item/weapon/reagent_containers/syringe/psychostimulant
+	/obj/item/weapon/reagent_containers/syringe/psychostimulant,
 	)
 
 //RECON VEHICLE DROP//
@@ -290,8 +290,8 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/stack/material/plasteel/ten,
 	/obj/item/stack/material/plasteel/ten,
 	/obj/item/stack/material/plasteel/ten,
-	/obj/item/weapon/storage/toolbox/mechanical
-	/obj/item/clothing/glasses/welding
+	/obj/item/weapon/storage/toolbox/mechanical,
+	/obj/item/clothing/glasses/welding,
 	)
 
 /datum/support_option/supply_drop/construction_drop/cov
@@ -310,6 +310,6 @@ obj/structure/closet/crate/supply_drop/mass_ammo/odst/WillContain()
 	/obj/item/stack/material/nanolaminate/ten,
 	/obj/item/stack/material/nanolaminate/ten,
 	/obj/item/stack/material/nanolaminate/ten,
-	/obj/item/weapon/storage/toolbox/covenant_mech
-	/obj/item/clothing/glasses/welding
+	/obj/item/weapon/storage/toolbox/covenant_mech,
+	/obj/item/clothing/glasses/welding,
 	)

--- a/code/modules/halo/medicine/combat.dm
+++ b/code/modules/halo/medicine/combat.dm
@@ -1,7 +1,7 @@
 // Combat medical equipment
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/combat
 	name = "combat stabilization autoinjector"
-	desc = "Contains a drug cocktail designed to help stabilized critically injured troops"
+	desc = "Contains a drug cocktail designed to help stabilize critically injured troops."
 	band_color = COLOR_RED
 
 	amount_per_transfer_from_this = 15
@@ -11,14 +11,14 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/necrosis
 	name = "tissue necrosis inhibitors"
-	desc = "Contains drugs that inhibit organ necrosis"
+	desc = "Contains drugs that inhibit organ necrosis."
 	band_color = COLOR_PURPLE
 
 	starts_with = list(/datum/reagent/peridaxon = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/antibiotic
 	name = "antibiotics autoinjector"
-	desc = "Contains a large dose of broad-spectrum antibiotics"
+	desc = "Contains a large dose of broad-spectrum antibiotics."
 	band_color = COLOR_DARK_GRAY
 
 	amount_per_transfer_from_this = 15
@@ -28,7 +28,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/painkiller
 	name = "oxycodone autoinjector"
-	desc = "Contains a large dose of highly effective painkillers"
+	desc = "Contains a large dose of highly effective painkillers."
 	band_color = COLOR_BLUE
 
 	amount_per_transfer_from_this = 10
@@ -38,7 +38,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/otomax
 	name = "otomax autoinjector"
-	desc = "Contains chemicals that reduce ear damage"
+	desc = "Contains chemicals that rapidly cure hearing loss."
 	band_color = COLOR_YELLOW
 
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
:cl: Aroliacue
tweak: Changed M6D M224 rounds in UNSC and URF supply drops to the M225 variant.
tweak: UNSC, URF and Covenant engineering supply drops now give 50 steel and 30 of the factions unique material, along with a mechanical toolbox and welding goggles. Cooldown has been increased from 3 minutes to 5 minutes.
tweak: Added 1 Psychostimulant syringe to UNSC, URF and Covenant medical supply drops.
tweak: UNSC and URF mass ammo drops now give an additional 2 shotgun shell boxes.
tweak: Gave Covenant mass ammo supply drops an additional spiker magazine and four mauler magazines.
/:cl: