### PR TITLE
hidden techprint fix

### DIFF
--- a/code/modules/halo/research/_global.dm
+++ b/code/modules/halo/research/_global.dm
@@ -31,12 +31,12 @@ GLOBAL_VAR_INIT(tech_initialized, FALSE)
 		if(new_techprint.hidden)
 
 			//there should only be 1 entry in required_objs for hidden techs
-			if(new_techprint.required_objs.len > 1)
+			if(new_techprint.required_materials.len + new_techprint.required_reagents.len + new_techprint.required_objs.len > 1)
 				to_debug_listeners("TECH ERROR: hidden techprint [new_techprint.type] \
 					has more than 1 destroy trigger (len:[new_techprint.required_objs.len])! \
 					[english_list(new_techprint.required_objs)]")
 
-			for(var/checktype in new_techprint.required_objs)
+			for(var/checktype in new_techprint.required_materials + new_techprint.required_reagents + new_techprint.required_objs)
 
 				//they are indexed by the "destroy" type
 				//so if there is 2 hidden techs with the same destroy type, it's a problem

--- a/code/modules/halo/research/techprint/_techprint.dm
+++ b/code/modules/halo/research/techprint/_techprint.dm
@@ -16,7 +16,8 @@
 	var/list/required_reagents = list()		//"reagent name" = amount (checks anything that can hold reagents)
 	var/list/required_materials = list()	//"material name" = amount (only checks material stacks)
 	var/list/required_objs = list()			//obj type = "name" (the name can be anything)
-	//if hidden == TRUE then have exactly 1 type in required_objs
+	//if hidden == TRUE then have exactly 1 type/material/reagent in one of these three lists.
+	//Define required amount as 1; as it only checks for presence and not amount.
 
 	//tech prerequisites
 	var/list/tech_req_one = list()		//techprint type

--- a/code/modules/halo/research/techprint/checks.dm
+++ b/code/modules/halo/research/techprint/checks.dm
@@ -2,23 +2,24 @@
 /datum/techprint
 	var/debug_reagents = FALSE
 
-/datum/techprint/proc/check_reagents(var/obj/item/I, var/update_progress = FALSE)
+/datum/techprint/proc/check_reagents(var/obj/item/I, var/update_progress = FALSE, var/list/list_search = required_reagents)
 	. = FALSE
 
 	if(debug_reagents)	to_debug_listeners("/techprint/proc/check_reagents([I.type], [update_progress])")
 
-	if(required_reagents.len)
+	if(list_search.len)
 		//grab the reagents datum... the holder can be anything eg different beakers or syringes
 		var/datum/reagents/R = I.reagents
 		if(R)
 			var/success = FALSE
 			//loop over the needed chemicals
-			for(var/reagent_type in required_reagents)
+			for(var/reagent_type in list_search)
 				if(debug_reagents)	to_debug_listeners("	check_reagents() [reagent_type]")
-				var/result = R.has_reagent(reagent_type, required_reagents[reagent_type], debug_reagents)
+				var/result = R.has_reagent(reagent_type, list_search[reagent_type], debug_reagents)
 				if(debug_reagents)	to_debug_listeners("	check_reagents() result: [result]")
 				if(result)
 					if(update_progress)
+						//This doesn't use list_search because this is updating the techprint progress.
 						//potentially has more than one
 						required_reagents -= reagent_type
 						consumables_current += 1
@@ -30,24 +31,24 @@
 
 			return success
 
-/datum/techprint/proc/check_materials(var/obj/item/I, var/update_progress = FALSE)
+/datum/techprint/proc/check_materials(var/obj/item/I, var/update_progress = FALSE, var/list/list_search = required_materials)
 	. = FALSE
 
 	//only check material sheets for now
 	if(istype(I, /obj/item/stack/material))
 		var/obj/item/stack/material/M = I
 
-		if(required_materials.Find(M.default_type) && M.amount >= required_materials[M.default_type])
+		if(list_search.Find(M.default_type) && M.amount >= list_search[M.default_type])
 			if(update_progress)
 				required_materials -= M.default_type
 				consumables_current += 1
 
 			return TRUE
 
-/datum/techprint/proc/check_objs(var/obj/item/I, var/update_progress = FALSE)
+/datum/techprint/proc/check_objs(var/obj/item/I, var/update_progress = FALSE, var/list/list_search = required_objs)
 	. = FALSE
 
-	for(var/checktype in required_objs)
+	for(var/checktype in list_search)
 		//this will check subtypes as well
 		//ss13 code is inconsistent in that:
 		//		sometimes subtypes are the same as the parent but with tweaked stats

--- a/code/modules/halo/research/techprint/unknown.dm
+++ b/code/modules/halo/research/techprint/unknown.dm
@@ -15,7 +15,8 @@
 	var/list/results = list()
 	. = results
 	for(var/check_type in GLOB.techprints_hidden)
-		if(ispath(I.type, check_type))
+		var/list/check_list = list(check_type)
+		if(check_objs(I,FALSE,check_list) || check_materials(I,FALSE,check_list) || check_reagents(I,FALSE,check_list))
 			results += GLOB.techprints_hidden[check_type]
 
 /datum/techprint/unknown/UpdateReqsString()


### PR DESCRIPTION
:cl: XO-11
bugfix: This mostly affects the nanolaminate armour patch, but now hidden techprints should support reagents , materials and objects
/:cl: