### PR TITLE
ensures hyperzine only applies to slowdowns, instead of resetting speedboosts

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -76,7 +76,8 @@
 		tally += T.get_movement_delay()
 
 	if(CE_SLOWREMOVE in chem_effects) //Goes here because it checks the full tally first.
-		tally =  max(0, tally - SLOWDOWN_REMOVAL_CHEM_MAX_REMOVED)
+		if(tally > 0)
+			tally = max(0, tally - SLOWDOWN_REMOVAL_CHEM_MAX_REMOVED)
 
 	if(CE_SPEEDBOOST in chem_effects)
 		tally -= SPEEDBOOST_CHEM_SPEED_INCREASE


### PR DESCRIPTION
title, no changelog because this is a backend bugfix