### PR TITLE
Spec Ops English, Spartan ONI and CO Sangheili

### DIFF
--- a/code/modules/halo/covenant/jobs/sangheili.dm
+++ b/code/modules/halo/covenant/jobs/sangheili.dm
@@ -65,7 +65,7 @@
 	title = "Special Operations Sangheili"
 	supervisors = "the Shipmaster"
 	outfit_type = /decl/hierarchy/outfit/sangheili/specops/infiltrator
-	access = list(access_covenant, access_covenant_command, access_covenant_slipspace)
+	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
 	spawn_positions = 0
 	total_positions = 0
 	poplock_max = 1

--- a/code/modules/halo/covenant/jobs/unggoy.dm
+++ b/code/modules/halo/covenant/jobs/unggoy.dm
@@ -50,7 +50,7 @@
 	title = "Special Operations Unggoy"
 	supervisors = "the Elites"
 	outfit_type = /decl/hierarchy/outfit/unggoy/specops/infiltrator
-	access = list(access_covenant, access_covenant_command, access_covenant_slipspace)
+	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
 	spawn_positions = 0
 	total_positions = 0
 	poplock_max = 1

--- a/code/modules/halo/covenant/species/sangheili/sangheili_outfits.dm
+++ b/code/modules/halo/covenant/species/sangheili/sangheili_outfits.dm
@@ -171,6 +171,8 @@
 	l_pocket = null
 	r_pocket = null
 	l_hand = /obj/item/weapon/gun/energy/plasmapistol/stealth
+	r_hand = /obj/item/language_learner/unggoy_to_common
+
 	//
 	id_type = /obj/item/weapon/card/id/elite_specops
 	id_slot = slot_wear_id

--- a/code/modules/halo/covenant/species/unggoy/grunt_outfits.dm
+++ b/code/modules/halo/covenant/species/unggoy/grunt_outfits.dm
@@ -122,6 +122,7 @@
 	suit = /obj/item/clothing/suit/armor/special/unggoy_combat_harness/specops/infiltrator
 	belt = /obj/item/weapon/gun/projectile/needler/stealth
 	l_hand = /obj/item/weapon/gun/energy/plasmapistol/stealth
+	r_hand = /obj/item/language_learner/unggoy_to_common
 
 /decl/hierarchy/outfit/unggoy/specops/armed
 	name = "Armed Unggoy (Spec-Ops)"

--- a/code/modules/halo/unsc/jobs/officers_outfits.dm
+++ b/code/modules/halo/unsc/jobs/officers_outfits.dm
@@ -7,6 +7,7 @@
 	shoes = /obj/item/clothing/shoes/brown
 	back = /obj/item/weapon/material/machete/officersword
 	belt = /obj/item/weapon/gun/projectile/m6d_magnum/CO_magnum
+	l_hand = /obj/item/language_learner/human_to_sang
 	starting_accessories = list(/obj/item/clothing/accessory/rank/fleet/officer/o6)
 
 /decl/hierarchy/outfit/job/unsc/executive_officer

--- a/code/modules/halo/unsc/jobs/spartan_two.dm
+++ b/code/modules/halo/unsc/jobs/spartan_two.dm
@@ -22,6 +22,7 @@
 		access_unsc_gunnery,\
 		access_unsc_ids,\
 		access_unsc_odst,\
+		access_unsc_oni,\
 		access_unsc_specialist)
 	whitelisted_species = list(/datum/species/spartan)
 	pop_balance_mult = 3


### PR DESCRIPTION
:cl: Aroliacue
rscadd: Spec Ops Sangheili and Unggoy now have English learners, and can also access Covenant cargo.
rscadd: UNSC Commanding Officer has been given a Sangheili learner to give the role a bit more weight.
tweak: Spartans now have access to ONI.
/:cl:
