### PR TITLE
Disables the globals_access MD5 check

### DIFF
--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -239,8 +239,6 @@ function run_byond_tests {
         ./install-byond.sh || exit 1
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
-    run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '64977a374130ff88a7f38d730e77a478 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
It seems to often not work and baystation removed it alltogether in 2022 (also removing the globals_access file and doing a big refactor).

This is basically just disabling the check for now, being able to do the refactor at a bit later time.