### PR TITLE
ONI Cargo Fixes and Reduction of Equipment in Vendors

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2165,6 +2165,7 @@
 #include "code\modules\halo\unsc\supply\medical.dm"
 #include "code\modules\halo\unsc\supply\misc.dm"
 #include "code\modules\halo\unsc\supply\NPCs.dm"
+#include "code\modules\halo\unsc\supply\onispecial.dm"
 #include "code\modules\halo\unsc\supply\regammo.dm"
 #include "code\modules\halo\unsc\supply\specammo.dm"
 #include "code\modules\halo\unsc\supply\weapons.dm"

--- a/code/modules/halo/factions/player_factions.dm
+++ b/code/modules/halo/factions/player_factions.dm
@@ -23,7 +23,7 @@
 		/mob/living/simple_animal/hostile/covenant/drone/ranged = 5)
 	default_radio_channel = RADIO_COV
 	special_jobs = list(/datum/job/covenant/mgalekgolo)
-	income = 1000
+	income = 600 //Higher than UNSC/ONI as they don't have an easy way to make money and also don't have purchases split
 	contraband_gear = "Covenant"
 
 /datum/faction/covenant/Initialize()
@@ -66,7 +66,7 @@
 		/mob/living/simple_animal/hostile/battledog/pmc = 2,\
 		/mob/living/simple_animal/hostile/battledog/odst = 1)
 	default_radio_channel = RADIO_SQUAD
-	income = 1000
+	income = 400
 	special_jobs = list(/datum/job/unsc/spartan_two)
 
 /datum/faction/unsc/Initialize()
@@ -96,7 +96,7 @@
 		/mob/living/simple_animal/hostile/battledog/odst = 1,\
 		/mob/living/simple_animal/hostile/unsc/spartan_two = 1)
 	default_radio_channel = RADIO_ONI
-	income = 1000
+	income = 400
 	income_delay = 15 MINUTES
 
 /datum/faction/oni/Initialize()

--- a/code/modules/halo/machinery/pointbased_vendor.dm
+++ b/code/modules/halo/machinery/pointbased_vendor.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(mobs_to_reqdatum,list())
 		if(custom_prod_amt)
 			product.amount = custom_prod_amt
 		else
-			product.amount = 50
+			product.amount = 30
 
 		src.product_records.Add(product)
 

--- a/code/modules/halo/trade/trade_items/bars.dm
+++ b/code/modules/halo/trade/trade_items/bars.dm
@@ -8,7 +8,7 @@
 	item_type = /obj/item/stack/material/iron
 	category = "ore"
 	quantity = 0
-	value = 100
+	value = 50
 	trader_weight = 0
 
 /datum/trade_item/sheet_silver
@@ -16,7 +16,7 @@
 	item_type = /obj/item/stack/material/silver
 	category = "ore"
 	quantity = 0
-	value = 200
+	value = 100
 	trader_weight = 0
 
 /datum/trade_item/sheet_gold
@@ -24,7 +24,7 @@
 	item_type = /obj/item/stack/material/gold
 	category = "ore"
 	quantity = 0
-	value = 300
+	value = 150
 	trader_weight = 0
 
 /datum/trade_item/sheet_diamond
@@ -32,7 +32,7 @@
 	item_type = /obj/item/stack/material/diamond
 	category = "ore"
 	quantity = 0
-	value = 1000
+	value = 300
 	trader_weight = 0
 
 /datum/trade_item/sheet_phoron
@@ -48,7 +48,7 @@
 	item_type = /obj/item/stack/material/uranium
 	category = "ore"
 	quantity = 0
-	value = 500
+	value = 250
 	trader_weight = 0
 
 /datum/trade_item/sheet_steel
@@ -56,7 +56,7 @@
 	item_type = /obj/item/stack/material/steel
 	category = "ore"
 	quantity = 150
-	value = 300
+	value = 50
 	trader_weight = 1
 
 /datum/trade_item/sheet_hydrogen
@@ -64,5 +64,13 @@
 	item_type = /obj/item/stack/material/mhydrogen
 	category = "ore"
 	quantity = 0
-	value = 200
+	value = 100
 	trader_weight = 0
+
+/datum/trade_item/sheet_platinum
+	name = "platinum sheets"
+	item_type = /obj/item/stack/material
+	category = "ore"
+	quantity = 20
+	value = 150
+	trader_weight = 1

--- a/code/modules/halo/unsc/supply/NPCs.dm
+++ b/code/modules/halo/unsc/supply/NPCs.dm
@@ -3,7 +3,21 @@
 	faction_lock = "UNSC"
 	containertype = null
 
-/decl/hierarchy/supply_pack/unsc_npcs/o2_can
+/decl/hierarchy/supply_pack/unsc_npcs/marine
+	name = "UNSC Marine (1)"
+	contains = list(/mob/living/simple_animal/hostile/unsc/marine = 1)
+	cost = 500
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_npcs
+	name = "ONI Reinforcements"
+	faction_lock = "ONI"
+	containertype = null
+
+/decl/hierarchy/supply_pack/oni_npcs/marine
 	name = "UNSC Marine (1)"
 	contains = list(/mob/living/simple_animal/hostile/unsc/marine = 1)
 	cost = 500

--- a/code/modules/halo/unsc/supply/engineering.dm
+++ b/code/modules/halo/unsc/supply/engineering.dm
@@ -104,3 +104,114 @@
 	contains = list(/obj/item/stack/material/plasteel/fifty = 4)
 	cost = 275
 	containername = "\improper Plasteel Shipment Crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_engineering
+	name = "ONI Engineering Supplies"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* TEN SHEETS */
+
+/decl/hierarchy/supply_pack/oni_engineering/diamond
+	name = "Diamonds (10 Sheets)"
+	contains = list(/obj/item/stack/material/diamond/ten = 1)
+	cost = 100
+	containername = "\improper Diamonds Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/gold
+	name = "Gold (10 Sheets)"
+	contains = list(/obj/item/stack/material/gold/ten = 1)
+	cost = 50
+	containername = "\improper Gold Ingots Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/phoron
+	name = "Phoron (10 Sheets)"
+	contains = list(/obj/item/stack/material/phoron/ten = 1)
+	cost = 50
+	containername = "\improper Small Phoron Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/plasteelten
+	name = "Plasteel (10 Sheets)"
+	contains = list(/obj/item/stack/material/plasteel/ten = 1)
+	cost = 20
+	containername = "\improper Small Plasteel Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/silver
+	name = "Silver (10 Sheets)"
+	contains = list(/obj/item/stack/material/silver/ten = 1)
+	cost = 50
+	containername = "\improper Silver Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/uranium
+	name = "Uranium (10 Sheets)"
+	contains = list(/obj/item/stack/material/uranium/ten = 1)
+	cost = 100
+	containername = "\improper Uranium Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/platinum
+	name = "Platinum (10 Sheets)"
+	contains = list(/obj/item/stack/material/platinum/ten = 1)
+	cost = 50
+	containername = "\improper Platinum Crate"
+
+/* FIFTY SHEETS */
+
+/decl/hierarchy/supply_pack/oni_engineering/ocpfifty
+	name = "Osmium Carbide Plasteel (50 Sheets)"
+	contains = list(/obj/item/stack/material/ocp/fifty = 1)
+	cost = 50
+	containername = "\improper Bulk Osmium Carbide Plasteel Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/plasteelfifty
+	name = "Plasteel (50 Sheets)"
+	contains = list(/obj/item/stack/material/plasteel/fifty = 1)
+	cost = 75
+	containername = "\improper Bulk Plasteel Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/marble
+	name = "Marble (50 Sheets)"
+	contains = list(/obj/item/stack/material/marble/fifty = 1)
+	cost = 50
+	containername = "\improper Bulk Marble Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/glass
+	name = "Glass (50 Sheets)"
+	contains = list(/obj/item/stack/material/glass/fifty = 1)
+	cost = 10
+	containername = "\improper Bulk Glass Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/wood
+	name = "Wood (50 Sheets)"
+	contains = list(/obj/item/stack/material/wood/fifty = 1)
+	cost = 10
+	containername = "\improper Bulk Wood Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/plastic
+	name = "Plastic (50 Sheets)"
+	contains = list(/obj/item/stack/material/plastic/fifty = 1)
+	cost = 10
+	containername = "\improper Bulk Plastic Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/steel
+	name = "Steel (50 Sheets)"
+	contains = list(/obj/item/stack/material/steel/fifty = 1)
+	cost = 10
+	containername = "\improper Bulk Steel Crate"
+
+/* TWO HUNDRED SHEETS */
+
+/decl/hierarchy/supply_pack/oni_engineering/steelshipment
+	name = "Steel (200 Sheets)"
+	contains = list(/obj/item/stack/material/steel/fifty = 4)
+	cost = 40
+	containername = "\improper Steel Shipment Crate"
+
+/decl/hierarchy/supply_pack/oni_engineering/plasteelshipment
+	name = "Plasteel (200 Sheets)"
+	contains = list(/obj/item/stack/material/plasteel/fifty = 4)
+	cost = 275
+	containername = "\improper Plasteel Shipment Crate"

--- a/code/modules/halo/unsc/supply/eva.dm
+++ b/code/modules/halo/unsc/supply/eva.dm
@@ -25,3 +25,35 @@
 	contains = list(/obj/item/weapon/tank/air = 3)
 	cost = 50
 	containername = "\improper Air Tanks Crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_eva
+	name = "ONI EVA Equipment"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* EVA SUITS */
+
+/decl/hierarchy/supply_pack/oni_eva/evasuit
+	name = "UNSC Marine EVA Suit (1 Suit)"
+	contains = list(/obj/item/weapon/storage/box/large/armorset/eva = 1)
+	cost = 300
+	containername = "\improper EVA Suit Crate"
+
+/* ATMOS */
+
+/decl/hierarchy/supply_pack/oni_eva/o2_can
+	name = "O2 Canister (1)"
+	containertype = /obj/structure/largecrate //Requires a larger crate to fit
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen = 1)
+	cost = 100
+	containername = "\improper O2 Canister Crate"
+
+/decl/hierarchy/supply_pack/oni_eva/airtanks
+	name = "Air Tanks (3)"
+	contains = list(/obj/item/weapon/tank/air = 3)
+	cost = 50
+	containername = "\improper Air Tanks Crate"

--- a/code/modules/halo/unsc/supply/explosives.dm
+++ b/code/modules/halo/unsc/supply/explosives.dm
@@ -62,3 +62,72 @@
 	cost = 700
 	contains = list(/obj/item/weapon/plastique/breaching/longrange = 4)
 	containername = "\improper Piercing Breaching Charge crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_explosives
+	name = "ONI Explosives"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* GRENADES */
+
+/decl/hierarchy/supply_pack/oni_explosives/fragnade
+	name = "M9 Fragmentation grenades (2 boxes)"
+	contains = list(/obj/item/weapon/storage/box/m9_frag = 2)
+	cost = 200
+	containername = "\improper M9 grenades crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/smokenade
+	name = "Smoke grenades (6)"
+	contains = list(/obj/item/weapon/grenade/smokebomb = 6)
+	cost = 50
+	containername = "\improper Smoke grenades crate"
+
+/* LANDMINES */
+
+/decl/hierarchy/supply_pack/oni_explosives/fragmine
+	name = "Fragmentation Land Mines (6 mines)"
+	contains = list(/obj/item/device/landmine/frag = 6)
+	cost = 800
+	containername = "\improper Frag Mine Crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/hemine
+	name = "High Explosive Land Mines (6 mines)"
+	contains = list(/obj/item/device/landmine/explosive = 6)
+	cost = 800
+	containername = "\improper HE Mine Crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/empmine
+	name = "Electromagnetic Pulse Land Mines (3 mines)"
+	contains = list(/obj/item/device/landmine/emp = 3)
+	cost = 1000
+	containername = "\improper EMP Mine Crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/incmine
+	name = "Incendiary Land Mines (3 mines)"
+	contains = list(/obj/item/device/landmine/flame = 3)
+	cost = 1000
+	containername = "\improper Incendiary Mine Crate"
+
+/* BREACHING CHARGES */
+
+/decl/hierarchy/supply_pack/oni_explosives/plastique
+	name = "C12 Breaching Charges (4)"
+	cost = 200
+	contains = list(/obj/item/weapon/plastique = 4)
+	containername = "\improper C12 Breaching Charge crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/plastique_breaching
+	name = "Large Breaching Charges (4)"
+	cost = 500
+	contains = list(/obj/item/weapon/plastique/breaching = 4)
+	containername = "\improper Breaching Charge crate"
+
+/decl/hierarchy/supply_pack/oni_explosives/plastique_breachingpierce
+	name = "Piercing Breaching Charges (4)"
+	cost = 700
+	contains = list(/obj/item/weapon/plastique/breaching/longrange = 4)
+	containername = "\improper Piercing Breaching Charge crate"

--- a/code/modules/halo/unsc/supply/food.dm
+++ b/code/modules/halo/unsc/supply/food.dm
@@ -22,3 +22,30 @@
 	contains = list(/obj/item/weapon/storage/box/MRE/Spaghetti = 5)
 	cost = 25
 	containername = "\improper Spaghetti MRE Crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_food
+	name = "ONI MREs"
+	faction_lock = "UNSC"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/decl/hierarchy/supply_pack/oni_food/mre_chicken
+	name = "Chicken MRE (5 packages)"
+	contains = list(/obj/item/weapon/storage/box/MRE/Chicken = 5)
+	cost = 25
+	containername = "\improper Chicken MRE Crate"
+
+/decl/hierarchy/supply_pack/oni_food/mre_pizza
+	name = "Pizza MRE (5 packages)"
+	contains = list(/obj/item/weapon/storage/box/MRE/Pizza = 5)
+	cost = 25
+	containername = "\improper Pizza MRE Crate"
+
+/decl/hierarchy/supply_pack/oni_food/mre_spaghetti
+	name = "Spaghetti MRE (5 packages)"
+	contains = list(/obj/item/weapon/storage/box/MRE/Spaghetti = 5)
+	cost = 25
+	containername = "\improper Spaghetti MRE Crate"

--- a/code/modules/halo/unsc/supply/medical.dm
+++ b/code/modules/halo/unsc/supply/medical.dm
@@ -91,3 +91,101 @@
 	)
 	cost = 800
 	containername = "\improper Medical FOB Kit (DO NOT OPEN UNTIL IN POSITION)"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_medical
+	name = "ONI Medical Supplies"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* SANITIZATION */
+
+/decl/hierarchy/supply_pack/oni_medical/cleaning_supplies
+	name = "Cleaning Supplies"
+	contains = list(
+	/obj/item/weapon/reagent_containers/spray/cleaner = 1,
+	/obj/item/weapon/soap = 2,
+	/obj/item/weapon/storage/bag/trash = 1,
+	)
+	cost = 20
+	containername = "\improper Cleaning Supplies Crate"
+
+/* MEDICAL KITS */
+
+/decl/hierarchy/supply_pack/oni_medical/firstaid
+	name = "First Aid Packs (4 packs)"
+	contains = list(/obj/item/weapon/storage/firstaid/unsc = 4)
+	cost = 200
+	containername = "\improper First Aid Crate"
+
+/decl/hierarchy/supply_pack/oni_medical/biofoam
+	name = "Biofoam Crate (10 syringes)"
+	contains = list(/obj/item/weapon/reagent_containers/syringe/biofoam = 10)
+	cost = 250
+	containername = "\improper Biofoam Crate"
+
+/decl/hierarchy/supply_pack/oni_medical/traumakits
+	name = "Field Trauma Kits (3 packs)"
+	contains = list(/obj/item/weapon/storage/firstaid/combat/unsc = 3)
+	cost = 200
+	containername = "\improper Field Trauma Crate"
+
+/decl/hierarchy/supply_pack/oni_medical/pillkit
+	name = "Medical Pill Kit (2 Bicardine, Dermaline, Hyronalin Bottles)"
+	contains = list(
+	/obj/item/weapon/storage/pill_bottle/bicaridine = 2,
+	/obj/item/weapon/storage/pill_bottle/dermaline = 2,
+	/obj/item/weapon/storage/pill_bottle/hyronalin = 2,
+	)
+	cost = 150
+	containername = "\improper Pill Kit Crate"
+
+/decl/hierarchy/supply_pack/oni_medical/psychostimulantpack
+	name = "Psychostimulants (5 Syringes)"
+	contains = list(/obj/item/weapon/reagent_containers/syringe/psychostimulant = 5)
+	cost = 200
+	containername = "\improper Psychostimulant Crate"
+
+/* MISC EQUIPMENT */
+
+/decl/hierarchy/supply_pack/oni_medical/stasisbags
+	name = "Stasis Bags (3 Bags)"
+	contains = list(/obj/item/bodybag/cryobag = 3)
+	cost = 250
+	containername = "\improper Stasis Bag Crate"
+
+/decl/hierarchy/supply_pack/oni_medical/autopsykit
+	name = "Autopsy Kit"
+	contains = list(
+	/obj/item/weapon/storage/firstaid/surgery = 1,
+	/obj/item/weapon/autopsy_scanner = 1,
+	/obj/item/weapon/storage/fancy/vials = 1,
+	/obj/item/device/healthanalyzer = 1,
+	/obj/item/device/camera = 1,
+	/obj/item/weapon/storage/briefcase/crimekit = 1,
+	/obj/item/device/reagent_scanner/adv = 1,
+	)
+	cost = 150
+	containername = "\improper Autopsy Kit"
+
+/decl/hierarchy/supply_pack/oni_medical/medfob
+	name = "Medical FOB Kit"
+	containertype = /obj/structure/largecrate //Requires a larger crate to fit
+	contains = list(
+	/obj/machinery/iv_drip = 1,
+	/obj/structure/bed/roller = 1,
+	/obj/item/weapon/tank/anesthetic = 2,
+	/obj/item/clothing/mask/breath/anesthetic = 2,
+	/obj/item/weapon/defibrillator/loaded = 1,
+	/obj/item/weapon/reagent_containers/blood/OMinus = 4,
+	/obj/item/weapon/reagent_containers/spray/cleaner = 1,
+	/obj/item/weapon/storage/firstaid/surgery = 1,
+	/obj/item/weapon/storage/box/gloves = 1,
+	/obj/item/weapon/storage/box/masks = 1,
+	/obj/item/weapon/storage/box/bodybags = 1,
+	)
+	cost = 800
+	containername = "\improper Medical FOB Kit (DO NOT OPEN UNTIL IN POSITION)"

--- a/code/modules/halo/unsc/supply/misc.dm
+++ b/code/modules/halo/unsc/supply/misc.dm
@@ -48,3 +48,58 @@
 	contains = list(/obj/item/weapon/pinpointer/artifact = 1)
 	cost = 10000
 	containername = "\improper Artifact Pinpointers crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_misc
+	name = "ONI Miscellaneous Equipment"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* LIGHTS */
+
+/decl/hierarchy/supply_pack/oni_misc/floodlight
+	name = "Floodlight (1)"
+	contains = list(/obj/machinery/floodlight = 1)
+	cost = 100
+	containertype = null
+
+/decl/hierarchy/supply_pack/oni_misc/flare
+	name = "Flares (8)"
+	contains = list(/obj/item/device/flashlight/flare = 8)
+	cost = 50
+	containername = "\improper Flares Crate"
+
+/decl/hierarchy/supply_pack/oni_misc/glowstick
+	name = "Glowsticks (10)"
+	contains = list(/obj/item/device/flashlight/glowstick = 10)
+	cost = 50
+	containername = "\improper Glowsticks Crate"
+
+/decl/hierarchy/supply_pack/oni_misc/nvgs
+	name = "Improved Night Vision Goggles (2)"
+	contains = list(/obj/item/clothing/glasses/tacgoggles = 2)
+	cost = 500
+	containername = "\improper NVGs Crate"
+
+/* PINPOINTERS */
+
+/decl/hierarchy/supply_pack/oni_misc/bomb_pinpointer
+	name = "Bomb Plant Pinpointer (1)"
+	contains = list(/obj/item/weapon/pinpointer/advpinpointer/bombplantlocator = 1)
+	cost = 50
+	containername = "\improper Bomb Plant Pinpointer crate"
+
+/decl/hierarchy/supply_pack/oni_misc/scanpoint_locator
+	name = "Signal Interception Device (1)"
+	contains = list(/obj/item/weapon/pinpointer/scanpoint_locator/unsc = 1)
+	cost = 200
+	containername = "\improper Scanpoint Pinpointer crate"
+
+/decl/hierarchy/supply_pack/oni_misc/artifact_pinpointer
+	name = "Artifact Pinpointer (1)"
+	contains = list(/obj/item/weapon/pinpointer/artifact = 1)
+	cost = 5000
+	containername = "\improper Artifact Pinpointers crate"

--- a/code/modules/halo/unsc/supply/onispecial.dm
+++ b/code/modules/halo/unsc/supply/onispecial.dm
@@ -1,0 +1,64 @@
+/decl/hierarchy/supply_pack/oni_special
+	name = "ONI Restricted Goods"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* FUN STUFF. Keep expensive as it can really change the game probably idk */
+
+/decl/hierarchy/supply_pack/oni_special/floodtox
+	name = "Contagious Biological Sample"
+	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/floodtox = 1)
+	cost = 10000
+	containername = "\improper Biological Sample crate"
+
+/* MATERIALS - Expensive so that ONI hopefully doesn't powergame research. Not all items included, just in case they somehow do. */
+
+/decl/hierarchy/supply_pack/oni_special/plasma_core
+	name = "Plasma Core (1)"
+	contains = list(/obj/item/plasma_core = 1)
+	cost = 700
+	containername = "\improper Plasma Core crate"
+
+/decl/hierarchy/supply_pack/oni_special/nanolaminate
+	name = "Nanolaminate (10 sheets)"
+	contains = list(/obj/item/stack/material/nanolaminate/ten = 1)
+	cost = 500
+	containername = "\improper Plasma Core crate"
+
+/decl/hierarchy/supply_pack/oni_special/pinkcrystal
+	name = "Pink Crystal (1)"
+	contains = list(/obj/item/crystal/pink = 1)
+	cost = 550
+	containername = "\improper Crystal crate"
+
+/decl/hierarchy/supply_pack/oni_special/greencrystal
+	name = "Green Crystal (1)"
+	contains = list(/obj/item/crystal = 1)
+	cost = 550
+	containername = "\improper Crystal crate"
+
+/decl/hierarchy/supply_pack/oni_special/orange
+	name = "Orange Crystal (1)"
+	contains = list(/obj/item/crystal/orange = 1)
+	cost = 550
+	containername = "\improper Crystal crate"
+
+/* Expensive Covvie weapons. No ammo included besides whatever's in the magazine. */
+
+/decl/hierarchy/supply_pack/oni_special/plasma_rifle
+	name = "Type-25 Plasma Rifle (1)"
+	contains = list(/obj/item/weapon/gun/energy/plasmarifle = 1)
+	cost = 1500
+	containername = "\improper Plasma Rifle crate"
+
+/decl/hierarchy/supply_pack/oni_special/needler
+	name = "Type-33 Needler (1)"
+	contains = list(/obj/item/weapon/gun/projectile/needler = 1)
+	cost = 1500
+	containername = "\improper Needler crate"
+
+/decl/hierarchy/supply_pack/oni_special/carbine
+	name = "Type-51 Carbine (1)"
+	contains = list(/obj/item/weapon/gun/projectile/type51carbine = 1)
+	cost = 1500
+	containername = "\improper Carbine crate"

--- a/code/modules/halo/unsc/supply/regammo.dm
+++ b/code/modules/halo/unsc/supply/regammo.dm
@@ -134,3 +134,144 @@
 	cost = 200
 	contains = list(/obj/item/ammo_magazine/HMG_boxmag = 2)
 	containername = "\improper HMG box magazines crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_ammo
+	name = "ONI Regular Ammunition"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* M6D */
+
+/decl/hierarchy/supply_pack/oni_ammo/m6d_m224 //Surplus ammo.
+	name = "M6D 12.7mm M224 magazines (2x7 boxes)"
+	cost = 25
+	contains = list(/obj/item/weapon/storage/box/m6d_m224 = 2)
+	containername = "\improper M6D ammo crate (M224)"
+
+/decl/hierarchy/supply_pack/oni_ammo/m6d_m225 //Standard ammunition for M6D Magnum.
+	name = "M6D 12.7mm M225 (HE) magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/m6d_m225 = 2)
+	containername = "\improper M6D ammo crate (M225)"
+
+/* M6S */
+
+/decl/hierarchy/supply_pack/oni_ammo/m6s_m224 //Surplus ammo.
+	name = "M6S 12.7mm M224 magazines (2x7 boxes)"
+	cost = 25
+	contains = list(/obj/item/weapon/storage/box/m6s_m224 = 2)
+	containername = "\improper M6S ammo crate (M224)"
+
+/decl/hierarchy/supply_pack/oni_ammo/m6s_m225 //Standard ammunition for M6S ODST Magnum.
+	name = "M6S 12.7mm M225 (HE) magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/m6s_m225 = 2)
+	containername = "\improper M6S ammo crate (M225)"
+
+/* MA5B */
+
+/decl/hierarchy/supply_pack/oni_ammo/ma5b_m118 //Standard ammunition for MA5B Assault Rifle.
+	name = "MA5B 7.62mm M118 magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/ma5b_m118 = 2)
+	containername = "\improper MA5B ammo crate (M118)"
+
+/* M392 */
+
+/decl/hierarchy/supply_pack/oni_ammo/m392_m120 //Designated Marksman Rifle.
+	name = "M392 7.62mm M120 magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/m392_m120 = 2)
+	containername = "\improper M392 ammo crate (M120)"
+
+/* M739 */
+
+/decl/hierarchy/supply_pack/oni_ammo/m739_m118 //M739 Light Machinegun.
+	name = "M739 7.62mm M118 box magazines (2x3 boxes)"
+	cost = 100
+	contains = list(/obj/item/weapon/storage/box/large/m739_m118 = 2)
+	containername = "\improper M739 ammo crate (M118)"
+
+/* Shotgun */
+
+/decl/hierarchy/supply_pack/oni_ammo/shotgun_pellet //Regular shotgun ammo.
+	name = "Shotgun pellet ammunition (4 quickloader boxes)"
+	cost = 50
+	contains = list(/obj/item/ammo_box/shotgun = 4)
+	containername = "\improper Shotgun pellet crate"
+
+/decl/hierarchy/supply_pack/oni_ammo/shotgun_slug //Shotgun slugs.
+	name = "Shotgun slug ammunition (4 quickloader boxes)"
+	cost = 50
+	contains = list(/obj/item/ammo_box/shotgun/slug = 4)
+	containername = "\improper Shotgun slug crate"
+
+/* M5 */
+
+/decl/hierarchy/supply_pack/oni_ammo/m7_m443 //Standard ammunition for M7 SMG.
+	name = "M7 5mm M443 magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/m7_m443 = 2)
+	containername = "\improper M5 ammo crate (M443)"
+
+/* SRS99 */
+
+/decl/hierarchy/supply_pack/oni_ammo/srs99_m232 //Standard ammo for SRS99 Sniper Rifle.
+	name = "SRS99 14.5mm M232 magazines (2x4 boxes)"
+	cost = 200
+	contains = list(/obj/item/weapon/storage/box/srs99_m232 = 2)
+	containername = "\improper SRS99 ammo crate (M232)"
+
+/* BR55 */
+
+/decl/hierarchy/supply_pack/oni_ammo/br55_m634 //Standard ammo for BR55 Battle Rifle.
+	name = "BR55 9.5mm M634 magazines (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/br55_m634 = 2)
+	containername = "\improper BR55 ammo crate (M634)"
+
+/* M41 */
+
+/decl/hierarchy/supply_pack/oni_ammo/m19_spanker //Missiles for SRS Missile Launcher.
+	name = "M19 SPNKr rockets (3 dual tubes)"
+	cost = 200
+	contains = list(/obj/item/ammo_magazine/spnkr = 3)
+	containername = "\improper M19 SPNKr crate"
+
+/* M301 */
+
+/decl/hierarchy/supply_pack/oni_ammo/g40mm_he //HE rounds for MA5B underbarrel grenade launcher.
+	name = "M301 40mm HE crate (1x7 box)"
+	cost = 500
+	contains = list(/obj/item/weapon/storage/box/g40mm_he = 1)
+	containername = "\improper M301 40mm HE crate (1x7 box)"
+
+/decl/hierarchy/supply_pack/oni_ammo/g40mm_frag //Frag rounds for underbarrel.
+	name = "M301 40mm Fragmentation crate (1x7 box)"
+	cost = 500
+	contains = list(/obj/item/weapon/storage/box/g40mm_frag = 1)
+	containername = "\improper M301 40mm Fragmentation crate (1x7 box)"
+
+/decl/hierarchy/supply_pack/oni_ammo/g40mm_smoke //Smoke rounds for underbarrel.
+	name = "M301 40mm Smoke crate (1x7 box)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/g40mm_smoke = 1)
+	containername = "\improper M301 40mm Smoke crate (1x7 box)"
+
+/decl/hierarchy/supply_pack/oni_ammo/g40mm_misc //Flare rounds.
+	name = "M301 40mm Miscellaneous crate (2x7 boxes)"
+	cost = 50
+	contains = list(/obj/item/weapon/storage/box/g40mm_misc = 2)
+	containername = "\improper M301 40mm Miscellaneous crate (2x7 boxes)"
+
+/* TURRET */
+
+/decl/hierarchy/supply_pack/oni_ammo/hmg //Replacement ammo boxes for deployable HMG turret.
+	name = "HMG box magazines (2 magazines)"
+	cost = 200
+	contains = list(/obj/item/ammo_magazine/HMG_boxmag = 2)
+	containername = "\improper HMG box magazines crate"

--- a/code/modules/halo/unsc/supply/specammo.dm
+++ b/code/modules/halo/unsc/supply/specammo.dm
@@ -62,3 +62,72 @@
 	cost = 500
 	contains = list(/obj/item/weapon/storage/box/srs99_m235 = 2)
 	containername = "\improper SRS99 ammo crate (M235 HEAP)"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_specammo
+	name = "ONI Special Ammunition"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* M6D */
+
+/decl/hierarchy/supply_pack/oni_specammo/m6d_m228 //Semi-Armor-Piercing High-Pen. Breaks armor.
+	name = "M6D 12.7mm M228 (HP) magazines (2x7 boxes)"
+	cost = 100
+	contains = list(/obj/item/weapon/storage/box/m6d_m228 = 2)
+	containername = "\improper M6D ammo crate (M228)"
+
+/* M6S */
+
+/decl/hierarchy/supply_pack/oni_specammo/m6s_m228 //Semi-Armor-Piercing High-Pen. Breaks armor.
+	name = "M6S 12.7mm M228 (HP) magazines (2x7 boxes)"
+	cost = 100
+	contains = list(/obj/item/weapon/storage/box/m6s_m228 = 2)
+	containername = "\improper M6S ammo crate (M228)"
+
+/* MA5B */
+
+/decl/hierarchy/supply_pack/oni_specammo/ma5b_ttr //Tactical Training Rounds. Less-than-lethal.
+	name = "MA5B 7.62mm M118-TTR training magazines (2x7 boxes)"
+	cost = 25
+	contains = list(/obj/item/weapon/storage/box/ma5b_ttr = 2)
+	containername = "\improper MA5B ammo crate (M118-TTR)"
+
+/* M90 */
+
+/decl/hierarchy/supply_pack/oni_specammo/shotgun_beanbag //Less-than-lethal ammo.
+	name = "Shotgun beanbag ammunition (4 quickloader boxes)"
+	cost = 25
+	contains = list(/obj/item/ammo_box/shotgun/beanbag = 4)
+	containername = "\improper Shotgun beanbag crate"
+
+/* M5 */
+
+/decl/hierarchy/supply_pack/oni_specammo/m5_m443_rubber //Alternative less-than-lethal ammo.
+	name = "M5 5mm M443 rubber magazines (2x7 boxes)"
+	cost = 25
+	contains = list(/obj/item/weapon/storage/box/m7_rubber = 2)
+	containername = "\improper M5 ammo crate (M443 rubber)"
+
+/* SRS99 */
+
+/decl/hierarchy/supply_pack/oni_specammo/srs99_m233 //Same as M232 but the projectile's invisible.
+	name = "SRS99 14.5mm M233 tracerless magazines (2x4 boxes)"
+	cost = 200
+	contains = list(/obj/item/weapon/storage/box/srs99_m233 = 2)
+	containername = "\improper SRS99 ammo crate (M233 tracerless)"
+
+/decl/hierarchy/supply_pack/oni_specammo/srs99_m234 //High Velocity Armor Piercing.
+	name = "SRS99 14.5mm M234 HVAP magazines (2x4 boxes)"
+	cost = 500
+	contains = list(/obj/item/weapon/storage/box/srs99_m234 = 2)
+	containername = "\improper SRS99 ammo crate (M234 HVAP)"
+
+/decl/hierarchy/supply_pack/oni_specammo/srs99_m235 //High Explosive SRS99 rounds.
+	name = "SRS99 14.5mm M235 HEAP magazines (2x4 boxes)"
+	cost = 500
+	contains = list(/obj/item/weapon/storage/box/srs99_m235 = 2)
+	containername = "\improper SRS99 ammo crate (M235 HEAP)"

--- a/code/modules/halo/unsc/supply/weapons.dm
+++ b/code/modules/halo/unsc/supply/weapons.dm
@@ -83,3 +83,93 @@
 	cost = 600
 	contains = list(/obj/item/turret_deploy_kit/chaingun = 1)
 	containername = "\improper Chaingun Turret Kit crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_weapons
+	name = "ONI Weapons"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/* MELEE */
+
+/decl/hierarchy/supply_pack/oni_weapons/melee_knife
+	name = "Combat Knives (3)"
+	cost = 25
+	contains = list(
+		/obj/item/weapon/material/knife/combat_knife = 3)
+	containername = "\improper Combat Knife crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/melee_machete
+	name = "Machetes (3)"
+	cost = 50
+	contains = list(
+		/obj/item/weapon/material/machete = 3)
+	containername = "\improper Machete crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/melee_humbler
+	name = "Humbler Stun Batons (3)"
+	cost = 50
+	contains = list(
+		/obj/item/weapon/melee/baton/humbler = 3)
+	containername = "\improper Humbler Stun Baton crate"
+
+/* FIREARMS */
+
+/decl/hierarchy/supply_pack/oni_weapons/m6d
+	name = "M6D Magnums (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/m6d_magnum = 3)
+	containername = "\improper M6D Magnum crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/ma5b_ar
+	name = "MA5B Assault Rifles (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/ma5b_ar = 3)
+	containername = "\improper MA5B Assault Rifle crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/br55
+	name = "BR55 Battle Rifles (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/br55 = 3)
+	containername = "\improper BR55 Battle Rifle crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/m392_dmr
+	name = "M392 Designated Marksman Rifles (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/m392_dmr = 3)
+	containername = "\improper M392 Designated Marksman Rifle crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/m90_ts
+	name = "M90 Tactical Shotguns (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/shotgun/pump/m90_ts = 3)
+	containername = "\improper M90 Tactical Shotgun crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/m7_smg
+	name = "M7 Submachine Guns (3)"
+	cost = 100
+	contains = list(
+		/obj/item/weapon/gun/projectile/m7_smg = 3)
+	containername = "\improper M7 Submachine Gun crate"
+
+/* TURRETS */
+
+/decl/hierarchy/supply_pack/oni_weapons/hmg_kit
+	name = "HMG Turret Kit"
+	cost = 600
+	contains = list(/obj/item/turret_deploy_kit/HMG = 1)
+	containername = "\improper HMG Turret Kit crate"
+
+/decl/hierarchy/supply_pack/oni_weapons/chaingun_kit
+	name = "Chaingun Turret Kit"
+	cost = 600
+	contains = list(/obj/item/turret_deploy_kit/chaingun = 1)
+	containername = "\improper Chaingun Turret Kit crate"

--- a/code/modules/halo/weapons/covenant/brute.dm
+++ b/code/modules/halo/weapons/covenant/brute.dm
@@ -83,7 +83,7 @@
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
 	)
 	lunge_dist = 3
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	matter = list("duridium" = 1)
 
 /obj/item/weapon/gun/projectile/spiker/update_icon()
@@ -160,7 +160,7 @@
 	item_state_slots = list(slot_l_hand_str = "mauler", slot_r_hand_str = "mauler")
 	sprite_sheets = list("Kig-Yar" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons.dmi')
 	lunge_dist = 3
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	matter = list("duridium" = 1)
 
 /obj/item/weapon/gun/projectile/mauler/update_icon()
@@ -222,7 +222,7 @@
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi',
 	)
 	item_state_slots = list(slot_l_hand_str = "gravhammer", slot_r_hand_str = "gravhammer", slot_back_str = "back_hammer")
-	salvage_components = list(/obj/item/plasma_core = 3)
+	salvage_components = list()
 	matter = list("nanolaminate" = 2, "duridium" = 3)
 	var/unique_afterattack = 1
 
@@ -263,7 +263,7 @@
 	force = 40
 	lunge_dist = 4
 	hitsound = "swing_hit"
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	item_state_slots = list(slot_l_hand_str = "gravlesshammer", slot_r_hand_str = "gravlesshammer", slot_back_str = "back_hammer")
 	sprite_sheets = list(\
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
@@ -293,7 +293,7 @@
 	sprite_sheets = list("Default" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons.dmi',
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
 	)
-	salvage_components = list(/obj/item/plasma_core = 2)
+	salvage_components = list()
 	matter = list("nanolaminate" = 2, "kemocite" = 1, "duridium" = 1)
 
 	whitelisted_grenades = list(/obj/item/weapon/grenade/brute_shot)

--- a/code/modules/halo/weapons/covenant/brute.dm
+++ b/code/modules/halo/weapons/covenant/brute.dm
@@ -31,6 +31,7 @@
 	num_fragments = 250 //50 more than a high yield frag bomb
 
 	lunge_dist = 3
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("duridium" = 1, "kemocite" = 1)
 
 /obj/item/weapon/grenade/frag/spike/can_embed()
@@ -82,6 +83,7 @@
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
 	)
 	lunge_dist = 3
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("duridium" = 1)
 
 /obj/item/weapon/gun/projectile/spiker/update_icon()
@@ -158,6 +160,7 @@
 	item_state_slots = list(slot_l_hand_str = "mauler", slot_r_hand_str = "mauler")
 	sprite_sheets = list("Kig-Yar" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons.dmi')
 	lunge_dist = 3
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("duridium" = 1)
 
 /obj/item/weapon/gun/projectile/mauler/update_icon()
@@ -219,6 +222,7 @@
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi',
 	)
 	item_state_slots = list(slot_l_hand_str = "gravhammer", slot_r_hand_str = "gravhammer", slot_back_str = "back_hammer")
+	salvage_components = list(/obj/item/plasma_core = 3)
 	matter = list("nanolaminate" = 2, "duridium" = 3)
 	var/unique_afterattack = 1
 
@@ -259,6 +263,7 @@
 	force = 40
 	lunge_dist = 4
 	hitsound = "swing_hit"
+	salvage_components = list(/obj/item/plasma_core)
 	item_state_slots = list(slot_l_hand_str = "gravlesshammer", slot_r_hand_str = "gravlesshammer", slot_back_str = "back_hammer")
 	sprite_sheets = list(\
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
@@ -288,6 +293,7 @@
 	sprite_sheets = list("Default" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons.dmi',
 	"Jiralhanae" = 'code/modules/halo/covenant/species/jiralhanae/jiralhanae_weapons_big.dmi'
 	)
+	salvage_components = list(/obj/item/plasma_core = 2)
 	matter = list("nanolaminate" = 2, "kemocite" = 1, "duridium" = 1)
 
 	whitelisted_grenades = list(/obj/item/weapon/grenade/brute_shot)

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -35,7 +35,7 @@
 	alt_explosion_range = 3
 	alt_explosion_damage_max = 40
 	matter = list("nanolaminate" = 1, "kemocite" = 1)
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	item_state_slots = list(slot_l_hand_str = "plasma_nade_off", slot_r_hand_str = "plasma_nade_off")
 	item_icons = list(\
 		slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi', \

--- a/code/modules/halo/weapons/covenant/launchers.dm
+++ b/code/modules/halo/weapons/covenant/launchers.dm
@@ -27,7 +27,7 @@
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_missile.dmi'
 	wielded_item_state = "fuelrod-wielded"
-	salvage_components = list(/obj/item/plasma_core = 3)
+	salvage_components = list()
 	matter = list("nanolaminate" = 2, "kemocite" = 1)
 	slowdown_general = 0.5
 	scope_zoom_amount = 1.5

--- a/code/modules/halo/weapons/covenant/launchers.dm
+++ b/code/modules/halo/weapons/covenant/launchers.dm
@@ -27,7 +27,7 @@
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_missile.dmi'
 	wielded_item_state = "fuelrod-wielded"
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list(/obj/item/plasma_core = 3)
 	matter = list("nanolaminate" = 2, "kemocite" = 1)
 	slowdown_general = 0.5
 	scope_zoom_amount = 1.5

--- a/code/modules/halo/weapons/covenant/lmg.dm
+++ b/code/modules/halo/weapons/covenant/lmg.dm
@@ -21,7 +21,7 @@
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
 		)
 	wielded_item_state = "repeater-wielded"
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list(/obj/item/plasma_core = 2)
 	matter = list("nanolaminate" = 2)
 	hud_bullet_usebar = 1
 	overheat_capacity = 121

--- a/code/modules/halo/weapons/covenant/melee.dm
+++ b/code/modules/halo/weapons/covenant/melee.dm
@@ -26,6 +26,7 @@
 	slot_flags = SLOT_POCKET | SLOT_BELT
 	activate_sound = 'code/modules/halo/sounds/Energysworddeploy.ogg'
 	deactivate_sound = 'code/modules/halo/sounds/Energysworddeactivate.ogg'
+	salvage_components = list(/obj/item/plasma_core = 3)
 	matter = list("nanolaminate" = 1)
 
 	lunge_dist = ESWORD_LEAP_DIST
@@ -144,6 +145,7 @@
 	icon_state = "en_dag_handle"
 	icon_state_deployed = "en_dag_deploy"
 	w_class = ITEM_SIZE_SMALL
+	salvage_components = list(/obj/item/plasma_core = 1)
 	active_force = 30
 	active_throwforce = 12
 	armor_penetration = 70
@@ -232,6 +234,7 @@ Luckily, this isn't a downside due to the explosive properties of such a large a
 	edge = 1
 	sharp = 1
 	armor_penetration = 70
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("nanolaminate" = 1)
 	var/explode_delay = 10 SECONDS
 	var/explode_at = -1

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -148,6 +148,7 @@
 	hud_bullet_reffile = 'code/modules/halo/icons/hud_display/hud_bullet_5x6.dmi'
 	hud_bullet_iconstate = "needle"
 	slowdown_general = 0
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("nanolaminate" = 1)
 	auto_eject = 1
 	auto_eject_sound = null

--- a/code/modules/halo/weapons/covenant/pistols.dm
+++ b/code/modules/halo/weapons/covenant/pistols.dm
@@ -148,7 +148,7 @@
 	hud_bullet_reffile = 'code/modules/halo/icons/hud_display/hud_bullet_5x6.dmi'
 	hud_bullet_iconstate = "needle"
 	slowdown_general = 0
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	matter = list("nanolaminate" = 1)
 	auto_eject = 1
 	auto_eject_sound = null

--- a/code/modules/halo/weapons/covenant/rifles.dm
+++ b/code/modules/halo/weapons/covenant/rifles.dm
@@ -71,6 +71,8 @@
 	icon_state = "concussion_rifle"
 	item_state = "concussion_rifle"
 	fire_sound = 'code/modules/halo/sounds/conc_rifle_fire.ogg'
+	salvage_components = list(/obj/item/plasma_core)
+	matter = list("nanolaminate" = 1)
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/concussion_rifle
 	one_hand_penalty = -1

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -20,6 +20,7 @@
 	accuracy = 1
 	wielded_item_state = "carbine-wielded"
 	speed_reload_time = -1 //already auto-ejects
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("nanolaminate" = 1)
 	hud_bullet_row_num = 9
 	hud_bullet_reffile = 'code/modules/halo/icons/hud_display/hud_bullet_7x8.dmi'
@@ -82,7 +83,7 @@
 
 	alt_charge_method = 1
 	matter = list("nanolaminate" = 2)
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list(/obj/item/plasma_core = 2)
 
 	item_icons = list(
 		slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi',
@@ -127,6 +128,7 @@
 	accuracy = -1
 	scoped_accuracy = 2
 	wielded_item_state = "needlerifle-wielded"
+	salvage_components = list(/obj/item/plasma_core)
 	matter = list("nanolaminate" = 1)
 
 	item_icons = list(

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -20,7 +20,7 @@
 	accuracy = 1
 	wielded_item_state = "carbine-wielded"
 	speed_reload_time = -1 //already auto-ejects
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	matter = list("nanolaminate" = 1)
 	hud_bullet_row_num = 9
 	hud_bullet_reffile = 'code/modules/halo/icons/hud_display/hud_bullet_7x8.dmi'
@@ -128,7 +128,7 @@
 	accuracy = -1
 	scoped_accuracy = 2
 	wielded_item_state = "needlerifle-wielded"
-	salvage_components = list(/obj/item/plasma_core)
+	salvage_components = list()
 	matter = list("nanolaminate" = 1)
 
 	item_icons = list(


### PR DESCRIPTION
:cl: Aroliacue
rscadd: Added new ONI category Restricted Goods with special purchaseables for research.
tweak: Fixed ONI Cargo not showing up.
tweak: Lowered counts of items in vendors to 30 from 50.
tweak: Adjusted value of tradeable items.
tweak: Reduced cargo income amounts. Funds can still be made via NPC traders.
/:cl: