### PR TITLE
Update covvendors.dm

### DIFF
--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -459,7 +459,7 @@
 		/obj/item/weapon/plastique/breaching/longrange/covenant = 0,
 		/obj/item/weapon/armor_patch/cov = 0,
 		/obj/item/weapon/armor_patch/mini/cov = 0,
-		/obj/item/weapon/pinpointer/artifact = 0
+		/obj/item/weapon/pinpointer/artifact = 0,
 		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(\

--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -101,7 +101,6 @@
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15,
 		/obj/item/turret_deploy_kit/plasturret = 3,
-		/obj/item/drop_pod_beacon/covenant = 25
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/sangheili/equipment // Equipment for Sangheili

--- a/code/modules/halo/covenant/structures_machines/covvendors.dm
+++ b/code/modules/halo/covenant/structures_machines/covvendors.dm
@@ -91,7 +91,8 @@
 		/obj/item/weapon/grenade/plasma = 0,
 		/obj/item/weapon/grenade/smokebomb/covenant = 0,
 		"Misc" = -1,
-		/obj/item/turret_deploy_kit/plasturret = 0
+		/obj/item/turret_deploy_kit/plasturret = 0,
+		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(\
 		/obj/item/weapon/gun/projectile/fuel_rod = 1,
@@ -99,7 +100,8 @@
 		/obj/item/weapon/gun/energy/beam_rifle = 2,
 		/obj/item/weapon/grenade/plasma = 15,
 		/obj/item/weapon/grenade/smokebomb/covenant = 15,
-		/obj/item/turret_deploy_kit/plasturret = 3
+		/obj/item/turret_deploy_kit/plasturret = 3,
+		/obj/item/drop_pod_beacon/covenant = 25
 	)
 
 /obj/machinery/pointbased_vending/armory/covenant/sangheili/equipment // Equipment for Sangheili
@@ -185,6 +187,7 @@
 		/obj/item/weapon/grenade/frag/spike = 0,
 		"Misc" = -1,
 		/obj/item/turret_deploy_kit/plasturret = 0,
+		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(
 		/obj/item/weapon/gun/launcher/grenade/brute_shot = 3,
@@ -273,7 +276,8 @@
 		/obj/item/weapon/grenade/plasma = 0,
 		/obj/item/weapon/grenade/smokebomb/covenant = 0,
 		"Misc" = -1,
-		/obj/item/turret_deploy_kit/plasturret = 0
+		/obj/item/turret_deploy_kit/plasturret = 0,
+		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(\
 		/obj/item/weapon/gun/energy/beam_rifle = 2,
@@ -365,7 +369,8 @@
 		/obj/item/weapon/grenade/plasma = 0,
 		/obj/item/weapon/grenade/smokebomb/covenant = 0,
 		"Misc" = -1,
-		/obj/item/turret_deploy_kit/plasturret = 0
+		/obj/item/turret_deploy_kit/plasturret = 0,
+		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(\
 		/obj/item/weapon/gun/projectile/fuel_rod = 2,
@@ -455,6 +460,7 @@
 		/obj/item/weapon/armor_patch/cov = 0,
 		/obj/item/weapon/armor_patch/mini/cov = 0,
 		/obj/item/weapon/pinpointer/artifact = 0
+		/obj/item/drop_pod_beacon/covenant = 0
 	)
 	amounts = list(\
 		/obj/item/stack/barbedwire/covenant/fifteen = 5,


### PR DESCRIPTION
:cl: Antonio72
rscadd: Now the covenant has drop pod beacons inside their ventors
/:cl:
~~gave them half of UNSC, even tough they still get a lot more, I doubt neither of the factions is even able to use 100, so it should be no problem~~ 
Now its default amount