### PR TITLE
Wave respawns and some popbalance tweaks

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -191,11 +191,10 @@
 	if(!is_species_allowed(S))
 		to_chat(feedback, "<span class='boldannounce'>Restricted species, [S], for [title].</span>")
 		return TRUE
-
 	poplock_bypassing = 0
 	//is this gamemode trying to balance the faction population?
 	var/num_balancing_factions = ticker.mode ? ticker.mode.faction_balance.len : 0
-	if(num_balancing_factions >= 2)
+	if(ticker.current_state == GAME_STATE_PLAYING && num_balancing_factions >= 2) //Only popbalance if we're actually playing rn.
 		if(Debug2)	to_debug_listeners("Checking gamemode balance for [src.title]...")
 
 		//are we out of the safe time?
@@ -239,7 +238,7 @@
 						if(minds_balance.len != 0)
 							for(var/datum/mind/player in minds_balance)
 								var/add_as_players = 1
-								if(!player.current || !istype(player.current,/mob/living) || !player.active || isnull(player.current.ckey) ||  player.current.stat == DEAD)
+								if(!player.current || !istype(player.current,/mob/living) || isnull(player.current.ckey) || player.current.stat == DEAD)
 									continue
 								if(player.assigned_role)
 									var/datum/job/j = job_master.occupations_by_title[player.assigned_role]

--- a/code/modules/halo/factions/_faction.dm
+++ b/code/modules/halo/factions/_faction.dm
@@ -54,6 +54,10 @@
 	var/next_special_job = 0
 
 	var/list/listening_programs = list()
+
+	var/wave_respawn = 1
+	var/wave_timeofdeath_use = 0
+
 	var/datum/repository/crew/crew_repo
 
 /datum/faction/New()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -246,7 +246,7 @@ var/global/chicken_count = 0
 	. =..()
 	if(!.)
 		return
-	if(!stat && prob(3) && eggsleft > 0)
+	if(!stat && istype(loc,/turf) && prob(3) && eggsleft > 0)
 		visible_message("[src] [pick("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")]")
 		eggsleft--
 		var/obj/item/weapon/reagent_containers/food/snacks/egg/E = new(get_turf(src))
@@ -257,7 +257,7 @@ var/global/chicken_count = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/var/amount_grown = 0
 /obj/item/weapon/reagent_containers/food/snacks/egg/process()
-	if(isturf(loc))
+	if(chicken_count < MAX_CHICKENS && isturf(loc))
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
 			visible_message("[src] hatches with a quiet cracking sound.")

--- a/maps/_gamemodes/_popbalance.dm
+++ b/maps/_gamemodes/_popbalance.dm
@@ -1,5 +1,5 @@
 //GLOBAL_VAR_INIT(max_overpop, 0.5)		//now a config var
-GLOBAL_VAR_INIT(round_no_balance_time, 2.9 MINUTES)//Just below roundstart. We're doing this so people don't have issues setting up occupations preround.
+GLOBAL_VAR_INIT(round_no_balance_time, 0 MINUTES) //Nothing, right now.
 GLOBAL_VAR_INIT(last_admin_notice_overpop, 0)
 GLOBAL_VAR_INIT(min_players_balance, 3)
 


### PR DESCRIPTION
:cl: XO-11
rscadd: Respawns now function in waves, and you will be informed if you are the first person in your faction to die in a wave.
tweak: Popbalance should no longer interfere in jobpref selection and now applies at roundstart.
/:cl:
Popbalance should now kick in even during roundstart. Expect to be thrown back to the lobby more often. I put a check into the system to make setting up your preferences less of a pain.