### PR TITLE
Orion conversion syringe in-game

### DIFF
--- a/code/modules/halo/trade/trade_items/bars.dm
+++ b/code/modules/halo/trade/trade_items/bars.dm
@@ -8,7 +8,7 @@
 	item_type = /obj/item/stack/material/iron
 	category = "ore"
 	quantity = 0
-	value = 50
+	value = 35
 	trader_weight = 0
 
 /datum/trade_item/sheet_silver
@@ -16,7 +16,7 @@
 	item_type = /obj/item/stack/material/silver
 	category = "ore"
 	quantity = 0
-	value = 100
+	value = 50
 	trader_weight = 0
 
 /datum/trade_item/sheet_gold
@@ -24,7 +24,7 @@
 	item_type = /obj/item/stack/material/gold
 	category = "ore"
 	quantity = 0
-	value = 150
+	value = 70
 	trader_weight = 0
 
 /datum/trade_item/sheet_diamond
@@ -32,7 +32,7 @@
 	item_type = /obj/item/stack/material/diamond
 	category = "ore"
 	quantity = 0
-	value = 300
+	value = 150
 	trader_weight = 0
 
 /datum/trade_item/sheet_phoron
@@ -40,7 +40,7 @@
 	item_type = /obj/item/stack/material/phoron
 	category = "ore"
 	quantity = 0
-	value = 500
+	value = 170
 	trader_weight = 0
 
 /datum/trade_item/sheet_uranium
@@ -48,7 +48,7 @@
 	item_type = /obj/item/stack/material/uranium
 	category = "ore"
 	quantity = 0
-	value = 250
+	value = 125
 	trader_weight = 0
 
 /datum/trade_item/sheet_steel
@@ -56,7 +56,7 @@
 	item_type = /obj/item/stack/material/steel
 	category = "ore"
 	quantity = 150
-	value = 50
+	value = 25
 	trader_weight = 1
 
 /datum/trade_item/sheet_hydrogen
@@ -64,7 +64,7 @@
 	item_type = /obj/item/stack/material/mhydrogen
 	category = "ore"
 	quantity = 0
-	value = 100
+	value = 75
 	trader_weight = 0
 
 /datum/trade_item/sheet_platinum
@@ -72,5 +72,5 @@
 	item_type = /obj/item/stack/material
 	category = "ore"
 	quantity = 20
-	value = 150
+	value = 100
 	trader_weight = 1

--- a/code/modules/halo/trade/trade_items/ore.dm
+++ b/code/modules/halo/trade/trade_items/ore.dm
@@ -27,7 +27,7 @@
 	item_type = /obj/item/weapon/ore/iron
 	category = "ore"
 	quantity = 0
-	value = 50
+	value = 20
 	trader_weight = 0
 
 /datum/trade_item/silver
@@ -35,7 +35,7 @@
 	item_type = /obj/item/weapon/ore/silver
 	category = "ore"
 	quantity = 0
-	value = 100
+	value = 25
 	trader_weight = 0
 
 /datum/trade_item/gold
@@ -43,7 +43,7 @@
 	item_type = /obj/item/weapon/ore/gold
 	category = "ore"
 	quantity = 0
-	value = 150
+	value = 35
 	trader_weight = 0
 
 /datum/trade_item/platinum
@@ -51,7 +51,7 @@
 	item_type = /obj/item/weapon/ore/osmium
 	category = "ore"
 	quantity = 0
-	value = 200
+	value = 50
 	trader_weight = 0
 
 /datum/trade_item/hydrogen
@@ -59,7 +59,7 @@
 	item_type = /obj/item/weapon/ore/hydrogen
 	category = "ore"
 	quantity = 0
-	value = 100
+	value = 50
 	trader_weight = 0
 
 /datum/trade_item/diamond
@@ -67,7 +67,7 @@
 	item_type = /obj/item/weapon/ore/diamond
 	category = "ore"
 	quantity = 0
-	value = 500
+	value = 100
 	trader_weight = 0
 
 /datum/trade_item/uranium
@@ -75,7 +75,7 @@
 	item_type = /obj/item/weapon/ore/uranium
 	category = "ore"
 	quantity = 0
-	value = 250
+	value = 80
 	trader_weight = 0
 
 /datum/trade_item/phoron
@@ -83,7 +83,7 @@
 	item_type = /obj/item/weapon/ore/phoron
 	category = "ore"
 	quantity = 0
-	value = 250
+	value = 100
 	trader_weight = 0
 
 /datum/trade_item/corundum
@@ -91,7 +91,7 @@
 	item_type = /obj/item/weapon/ore/corundum
 	category = "ore"
 	quantity = 0
-	value = 175
+	value = 80
 	trader_weight = 0
 
 /datum/trade_item/duridium
@@ -99,7 +99,7 @@
 	item_type = /obj/item/weapon/ore/duridium
 	category = "ore"
 	quantity = 0
-	value = 200
+	value = 100
 	trader_weight = 0
 
 /datum/trade_item/kemocite
@@ -107,5 +107,5 @@
 	item_type = /obj/item/weapon/ore/kemocite
 	category = "ore"
 	quantity = 0
-	value = 85
+	value = 50
 	trader_weight = 0

--- a/code/modules/halo/unsc/supply/onispecial.dm
+++ b/code/modules/halo/unsc/supply/onispecial.dm
@@ -18,7 +18,8 @@
 	/obj/item/organ/internal/eyes/occipital_reversal/theta = 1,
 	/obj/item/organ/internal/heart/spartan/theta = 1,
 	/obj/item/organ/internal/liver/spartan/theta = 1,
-	/obj/item/organ/internal/lungs/theta = 1
+	/obj/item/organ/internal/lungs/theta = 1,
+	/obj/item/species_convert/orion = 1
 	)
 	cost = 3500
 	containername = "\improper Orion organs freezer"

--- a/maps/faction_bases/complex046/complex046.dmm
+++ b/maps/faction_bases/complex046/complex046.dmm
@@ -309,6 +309,7 @@
 "fW" = (/obj/machinery/light,/turf/simulated/floor/pavement/empty,/area/faction_base/oni)
 "fX" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 4},/obj/structure/table/standard,/obj/item/stack/nanopaste,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back."; name = "Surgery Cleaner"},/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
 "fY" = (/obj/structure/closet/crate/large{icon_state = "secgearcrate"; name = "Plasteel Crate"; tag = "icon-secgearcrate"},/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/obj/item/stack/material/plasteel/fifty,/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
+"fZ" = (/obj/structure/closet/crate/freezer,/obj/structure/window/reinforced/treated{dir = 1},/obj/machinery/door/window{icon_state = "left"; dir = 4},/obj/effect/floor_decal/industrial/warning/full,/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 4},/obj/item/organ/internal/lungs/theta,/obj/item/organ/internal/liver/spartan/theta,/obj/item/organ/internal/heart/spartan/theta,/obj/item/organ/internal/eyes/occipital_reversal/theta,/obj/item/species_convert/orion,/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
 "ga" = (/obj/structure/sign/halo_floorsign/hangar{icon_state = "hangar"; dir = 4},/turf/simulated/floor/tech/steel,/area/faction_base/oni/garage)
 "gb" = (/obj/structure/closet/crate,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/tech/maint,/area/faction_base/oni/hangar)
 "gc" = (/obj/structure/sign/halo_floorsign/cargobay{dir = 4; icon_state = "cargobay"; pixel_y = 16},/turf/simulated/floor/tiled/dark,/area/faction_base/oni/hangar)
@@ -396,7 +397,6 @@
 "hG" = (/obj/machinery/light/colored/red{icon_state = "red1"; dir = 4},/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
 "hH" = (/obj/machinery/light/colored/red{icon_state = "red1"; dir = 8},/turf/simulated/floor/reinforced,/area/faction_base/oni/research)
 "hI" = (/turf/unsimulated/wall,/area/faction_base/oni/digsite)
-"hJ" = (/obj/structure/closet/crate/freezer,/obj/structure/window/reinforced/treated{dir = 1},/obj/machinery/door/window{icon_state = "left"; dir = 4},/obj/effect/floor_decal/industrial/warning/full,/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 4},/obj/item/organ/internal/lungs/theta,/obj/item/organ/internal/lungs/theta,/obj/item/organ/internal/liver/spartan/theta,/obj/item/organ/internal/liver/spartan/theta,/obj/item/organ/internal/heart/spartan/theta,/obj/item/organ/internal/heart/spartan/theta,/obj/item/organ/internal/eyes/occipital_reversal/theta,/obj/item/organ/internal/eyes/occipital_reversal/theta,/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
 "hK" = (/obj/machinery/light/colored/blue{icon_state = "blue1"; dir = 8},/obj/structure/closet,/obj/item/weapon/storage/box/masks,/obj/item/weapon/storage/box/gloves,/turf/simulated/floor/tiled/white,/area/faction_base/oni/research)
 "hL" = (/obj/machinery/light/colored/red{icon_state = "red1"; dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
 "hM" = (/obj/machinery/door/window{icon_state = "left"; dir = 4},/turf/simulated/floor/tech/gray,/area/faction_base/oni/research)
@@ -552,7 +552,7 @@ aabFbFbFbFbFbFbFbFbFbFbFbFbFbFbFbxkCQlQZbxkCQlQZbxeWeVeWeVeVbxbFEvhebJebebbJsdbF
 aabFejeseEfvfAbFbFfXgkgqeJgugwbFbxbxbxbxbxbxbxbxbxbxbxbxcTbxbxbFXZheheebebbJlmbFLnhlQELnhlhlCqLnLnbNaa
 aabFaxgQhngQaxbFbFhoeJhpeJeJeJbFbFbFbFbFbFbFbFbFbFbFbFbFbFbFbFbFkEbJheebebbJYmbFhmhlBlLnLnhlBlLncDbNaa
 aabFaxaxgQaxaxbFbFibhqhqhqhqhrbFhshshthuhvhwhyhzhAbFhBhChDhEhFbFwsbJbJbJVobJYabFaKLnKeLnLnhlKeLnaKbNaa
-aabFhGaxgQaxhHbFbFhJeJeJeJeJhKbFhLcccchMbJbJbJbJhNbFdkbJbJbJWwbFoghPbJhYbFbJlNbFbNbNbNLngWLnbNbNbNbNaa
+aabFhGaxgQaxhHbFbFfZeJeJeJeJhKbFhLcccchMbJbJbJbJhNbFdkbJbJbJWwbFoghPbJhYbFbJlNbFbNbNbNLngWLnbNbNbNbNaa
 aabFbFbFhObFbFbFbFbFbFhZhQbFbFbFhRhRhRhSbJbJhUhUhWbFbJebhXebbJUlhThehebJbFxfbFbFLnLnUJLnLnLnVLhlhlbNaa
 aabFbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJbJhehebJbFaxhbbFTaLnBlLnLnLnBlhlcDbNaa
 aabFbJVobJbJVobJbJVobJbJVobJbJiabJbJVobJbJbJVobJbJiabJbJVobJbJbJbJbJVobJbFfegJbFaKLnKeLnGRLnKehlaKbNaa


### PR DESCRIPTION
:cl: Aroliacue
rscadd: Makes the Orion Conversion Syringe purchasable via cargo and adds one to the preset Orion organs in ONI base.
tweak: Trade value of mined ores and smelted bars reduced.
/:cl: