### PR TITLE
makes tracerless ammo urf bolt action rifle only

### DIFF
--- a/code/modules/halo/unsc/supply/specammo.dm
+++ b/code/modules/halo/unsc/supply/specammo.dm
@@ -45,12 +45,6 @@
 
 /* SRS99 */
 
-/decl/hierarchy/supply_pack/unsc_specammo/srs99_m233 //Same as M232 but the projectile's invisible.
-	name = "SRS99 14.5mm M233 tracerless magazines (2x4 boxes)"
-	cost = 200
-	contains = list(/obj/item/weapon/storage/box/srs99_m233 = 2)
-	containername = "\improper SRS99 ammo crate (M233 tracerless)"
-
 /decl/hierarchy/supply_pack/unsc_specammo/srs99_m234 //High Velocity Armor Piercing.
 	name = "SRS99 14.5mm M234 HVAP magazines (2x4 boxes)"
 	cost = 500
@@ -113,12 +107,6 @@
 	containername = "\improper M5 ammo crate (M443 rubber)"
 
 /* SRS99 */
-
-/decl/hierarchy/supply_pack/oni_specammo/srs99_m233 //Same as M232 but the projectile's invisible.
-	name = "SRS99 14.5mm M233 tracerless magazines (2x4 boxes)"
-	cost = 200
-	contains = list(/obj/item/weapon/storage/box/srs99_m233 = 2)
-	containername = "\improper SRS99 ammo crate (M233 tracerless)"
 
 /decl/hierarchy/supply_pack/oni_specammo/srs99_m234 //High Velocity Armor Piercing.
 	name = "SRS99 14.5mm M234 HVAP magazines (2x4 boxes)"

--- a/code/modules/halo/weapons/Handgonne.dm
+++ b/code/modules/halo/weapons/Handgonne.dm
@@ -8,7 +8,7 @@
 	icon_state = "handcannon"
 	item_state = "handgonne"
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	caliber = "14.5mm"
+	caliber = "14.5mmtracerless"
 	screen_shake = 1 //extra kickback
 	max_shells = 3
 	one_hand_penalty = 0

--- a/code/modules/halo/weapons/SRS99.dm
+++ b/code/modules/halo/weapons/SRS99.dm
@@ -66,17 +66,6 @@
 	name = "box of SRS99 (14.5mm) M232 magazines"
 	startswith = list(/obj/item/ammo_magazine/srs99/m232 = 4)
 
-//M233 tracerless Ammunition
-
-/obj/item/ammo_magazine/srs99/m233
-	name = "SRS99 magazine (14.5mm) M233"
-	desc = "14.5×114mm M233 armor piercing, fin-stabilized, discarding sabot (AP-FS-DS) magazine for the SRS99 containing 4 rounds. Reduced velocity and penetration but no tracers."
-	ammo_type = /obj/item/ammo_casing/m233
-
-/obj/item/weapon/storage/box/srs99_m233
-	name = "box of SRS99 (14.5mm) M232 tracerless magazines"
-	startswith = list(/obj/item/ammo_magazine/srs99/m233 = 4)
-
 //M234 HVAP ammounition
 
 /obj/item/ammo_magazine/srs99/m234

--- a/code/modules/halo/weapons/ammo_14-5mm.dm
+++ b/code/modules/halo/weapons/ammo_14-5mm.dm
@@ -26,11 +26,11 @@
 	step_delay = 0
 
 /* M233 tracerless rounds  */
-//used by: SRS99 sniper rifle
+//used by: URF Bolt Action Rifle
 
 /obj/item/ammo_casing/m233
 	desc = "A 14.5mm bullet casing."
-	caliber = "14.5mm"
+	caliber = "14.5mmtracerless"
 	projectile_type = /obj/item/projectile/bullet/m233
 
 /obj/item/projectile/bullet/m233 //Modified slightly to provide a downside for using the innie-heavy-sniper-rounds over normal rounds.

--- a/code/modules/halo/weapons/heavysniper.dm
+++ b/code/modules/halo/weapons/heavysniper.dm
@@ -8,7 +8,7 @@
 	force = 10
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)
-	caliber = "14.5mm"
+	caliber = "14.5mmtracerless"
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING
 	max_shells = 2


### PR DESCRIPTION
:cl: XO-11
tweak: Budget cuts have removed tracerless ammo from the SRS ammo pool
/:cl: