### PR TITLE
Grenade effectiveness tweaks

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -16,7 +16,7 @@
 	var/can_adjust_timer = 1
 
 	var/alt_explosion_damage_max = 500 //The amount of armour + shield piercing damage done when grenade is stuck inside someone.
-	var/alt_explosion_damage_cap = 20 //How much damage can the alt-explosion apply in one instance.
+	var/alt_explosion_damage_cap = 15 //How much damage can the alt-explosion apply in one instance.
 	var/multiplier_non_direct = 1 //The multiplier to apply to the alt explosion max damage if the grenade is not directly on top of or inside someone.
 	var/alt_explosion_range = -1 //if set to -1, no armor bypass explosion
 
@@ -130,7 +130,7 @@
 
 	for(var/mob/living/m in range(alt_explosion_range,loc))
 		var/mult = 1
-		if(get_turf(m) != get_turf(loc))
+		if(multiplier_non_direct != mult && get_turf(m) != get_turf(loc))
 			mult = multiplier_non_direct
 		var/dmg_max = alt_explosion_damage_max * mult
 		while(dmg_max > 0)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -146,12 +146,6 @@
 	..()
 	return
 
-/obj/item/weapon/grenade/dropped(var/onto)
-	. = ..()
-	if(active == 1 && starttimer_on_hit)
-		active = 2
-		start_timer()
-
 /obj/item/weapon/grenade/throw_impact(var/atom/hit)
 	if(active == 1 && starttimer_on_hit)
 		active = 2

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo.dm
@@ -40,6 +40,8 @@
 	resistance = 20 //Multiplied by two during melee fights.
 	attack_sound = 'sound/weapons/heavysmash.ogg'
 
+	see_in_dark = 7
+
 	/*response_help   = "pokes"
 	response_disarm = "pokes"
 	response_harm   = "thinks better about punching"*/

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo.dm
@@ -47,7 +47,7 @@
 
 	var/datum/mgalekgolo_weapon/active_weapon = /datum/mgalekgolo_weapon/fuel_rod_cannon
 	var/atom/current_target
-	var/regeneration = 0.5
+	var/regeneration = 2.5
 
 	var/hud_setup = 0
 

--- a/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
+++ b/code/modules/halo/covenant/species/lekgolo/lekgolo_defence.dm
@@ -17,9 +17,6 @@
 	. = ..()
 
 /mob/living/simple_animal/mgalekgolo/ex_act(severity)
-	if(!blinded)
-		flash_eyes()
-
 	var/damage
 	switch (severity)
 		if (1.0)

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -137,7 +137,7 @@
 /obj/item/projectile/bullet/covenant/needles
 	name = "Needle"
 	desc = "A sharp, pink crystalline shard"
-	damage = 15 //A little lower than the smg because of the shrapnel dam
+	damage = 10 //SMG gets some AP on top of higher damage.
 	shield_damage = 15
 	icon = 'code/modules/halo/weapons/icons/Covenant_Projectiles.dmi'
 	icon_state = "Needler Shot"
@@ -175,7 +175,7 @@
 					L.contents -= I
 					I.forceMove(get_turf(L))//And placing it on the ground below
 					qdel(I)
-	if(prob(NEEDLER_EMBED_PROB)) //Most of the weapon's damage comes from embedding. This is here to make it more common.
+	if(prob(NEEDLER_EMBED_PROB))
 		var/obj/item/weapon/material/shard/shrapnel/needleshrap/shard = new
 		shard.name = shard_name
 		shard.die_at = world.time + NEEDLER_SHARD_DET_TIME

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -1,5 +1,4 @@
 #define ADHERENCE_TIME 5
-#define PLASNADE_EMBEDDED_DAM_ADD 10
 
 //plasma grenade visual effect
 /obj/effect/plasma_explosion
@@ -65,7 +64,7 @@
 	else
 		L.embed(src)
 		A.visible_message("<span class = 'danger'>[src.name] sticks to [L.name]!</span>")
-		det_time += 1.5 SECONDS
+		det_time += 15
 	. = ..()
 
 /obj/item/weapon/grenade/plasma/detonate()
@@ -86,7 +85,6 @@
 				M.playsound_local(epicenter, 'code/modules/halo/sounds/Plasmanadedetonate.ogg', 100, 1)
 	var/mob/living/carbon/human/mob_containing = loc
 	if(istype(mob_containing))
-		alt_explosion_damage_max += PLASNADE_EMBEDDED_DAM_ADD
 		do_alt_explosion()
 		explosion(get_turf(src), -1, 2, 2, 0)
 		mob_containing.contents -= src
@@ -106,4 +104,3 @@
 	alt_explosion_damage_max = 60
 
 #undef ADHERENCE_TIME
-#undef PLASNADE_EMBEDDED_DAM_ADD

--- a/code/modules/halo/weapons/forerunner/grenade.dm
+++ b/code/modules/halo/weapons/forerunner/grenade.dm
@@ -21,7 +21,8 @@
 	. = ..()
 	if(istype(crosser))
 		visible_message("<span class = 'danger'>Shards within [src] track [crosser], and explode!</span>")
-		crosser.adjustFireLoss(50)
+		crosser.adjustFireLoss(12)
+		crosser.adjustBruteLoss(12)
 
 /obj/item/weapon/grenade/splinter
 	name = "Z-400 Pursuit Disruption Grid Generator"
@@ -30,6 +31,7 @@
 	icon_state = "splinternade"
 	can_adjust_timer = 0
 	det_time = 25
+	starttimer_on_hit = 1
 	alt_explosion_range = 2
 	alt_explosion_damage_max = 50
 

--- a/code/modules/halo/weapons/grenades.dm
+++ b/code/modules/halo/weapons/grenades.dm
@@ -7,7 +7,7 @@
 	num_fragments = 8
 	can_adjust_timer = 0
 	starttimer_on_hit = 1
-	det_time = 20
+	det_time = 30
 	explosion_size = 3
 	alt_explosion_range = 3
 	alt_explosion_damage_max = 40
@@ -20,7 +20,7 @@
 /obj/item/weapon/grenade/frag/m9_hedp/throw_impact(var/mob/living/mob_hit)
 	. = ..()
 	if(istype(mob_hit) && loc != mob_hit) //If we hit a mob and they don't catch us, then lower our det time by a second.
-		det_time -= 5
+		det_time -= 15
 
 /obj/item/weapon/storage/box/m9_frag
 	name = "box of M9 frag grenades (WARNING)"


### PR DESCRIPTION
:cl: XO-11
tweak: Modifies some grenade damage distribution numbers to make them less likely to one-shot people.
tweak: Increases some grenade detonation timers.
tweak: Dropping a grenade no longer primes it for explosion
tweak: lekgolo general balance passes such as regen boost, no more explosion eye flash , darkvis
tweak: promethean grenade tweaks
/:cl: