### PR TITLE
Projectile Parry Tweaks

### DIFF
--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -12,14 +12,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/weapon/material/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-
-	if(default_parry_check(user, attacker, damage_source) && prob(50))
-		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
-		playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
-		return 1
-	return 0
-
 /obj/item/weapon/material/sword/replica
 	edge = 0
 	sharp = 0

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -57,14 +57,6 @@
 	..()
 	update_icon()
 
-//Allow a small chance of parrying melee attacks when wielded - maybe generalize this to other weapons someday
-/obj/item/weapon/material/twohanded/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(wielded && default_parry_check(user, attacker, damage_source) && prob(15))
-		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
-		playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
-		return 1
-	return 0
-
 /obj/item/weapon/material/twohanded/update_icon()
 	icon_state = "[base_icon][wielded]"
 	item_state_slots[slot_l_hand_str] = icon_state
@@ -78,7 +70,7 @@
 	base_icon = "fireaxe"
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
-	
+
 	// 15/32 with hardness 60 (steel) and 20/42 with hardness 80 (plasteel)
 	force_divisor = 0.525
 	unwielded_force_divisor = 0.25

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -143,17 +143,6 @@
 	attack_verb = list()
 	icon_state = initial(icon_state)
 
-/obj/item/weapon/melee/energy/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(active && default_parry_check(user, attacker, damage_source) && prob(50))
-		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
-
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, user.loc)
-		spark_system.start()
-		playsound(user.loc, 'sound/weapons/blade1.ogg', 50, 1)
-		return 1
-	return 0
-
 /obj/item/weapon/melee/energy/sword/pirate
 	name = "energy cutlass"
 	desc = "Arrrr matey."

--- a/code/modules/halo/weapons/melee.dm
+++ b/code/modules/halo/weapons/melee.dm
@@ -42,7 +42,7 @@
 	unbreakable = 1
 	attack_verb = list("chopped", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	unacidable = 0
+	unacidable = 1
 	lunge_dist = 2
 
 	executions_allowed = TRUE
@@ -51,7 +51,7 @@
 
 /obj/item/weapon/material/machete/officersword
 	name = "Officer's Sword"
-	desc = "A reinforced sword capable of safely parrying blows from energy weapons."
+	desc = "A reinforced sword. Lighter than it looks, allowing for longer range lunges."
 	icon_state = "COsword_obj"
 	item_state = "officer-sword"
 	slot_flags = SLOT_BELT | SLOT_BACK

--- a/code/modules/halo/weapons/melee.dm
+++ b/code/modules/halo/weapons/melee.dm
@@ -10,6 +10,7 @@
 	edge = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	armor_penetration = 70
+	unacidable = 1
 
 	force_divisor = 0.5
 	thrown_force_divisor = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -296,6 +296,8 @@
 	for(var/obj/mecha/M in in_sight)
 		L += M
 
+	L -= src //Just in case we added ourselves to our own targets list.
+
 	return L
 
 /mob/living/simple_animal/hostile/death(gibbed, deathmessage, show_dead_message)


### PR DESCRIPTION
:cl: XO-11
tweak: Parrying projectiles happens less often and produces less chat log spam.
tweak: Hostile mobs should stop targeting themselves.
tweak: Machetes and combat knives have been treated to not melt against plasma bolts.
/:cl: