### PR TITLE
Fixes plasma grenades

### DIFF
--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -55,6 +55,7 @@
 			h.update_inv_r_hand()
 
 /obj/item/weapon/grenade/plasma/throw_impact(var/atom/A)
+	start_timer()
 	if(!active)
 		return
 	var/mob/living/L = A
@@ -104,5 +105,11 @@
 	throw_range = 0
 	alt_explosion_range = 4
 	alt_explosion_damage_max = 60
+	
+/obj/item/weapon/grenade/plasma/suicide/dropped(var/onto)
+	. = ..()
+	if(active == 1 && starttimer_on_hit)
+		active = 2
+		start_timer()
 
 #undef ADHERENCE_TIME

--- a/code/modules/halo/weapons/covenant/grenades.dm
+++ b/code/modules/halo/weapons/covenant/grenades.dm
@@ -55,9 +55,9 @@
 			h.update_inv_r_hand()
 
 /obj/item/weapon/grenade/plasma/throw_impact(var/atom/A)
-	start_timer()
 	if(!active)
 		return
+	start_timer()
 	var/mob/living/L = A
 	if(!istype(L))
 		return


### PR DESCRIPTION
:cl: OuterMostMonk
tweak: Plasma grenades explode when thrown
tweak: Martyrdom grenades work again
/:cl:

Plasma grenades will now explode even if they do not embed in a target. Martyrdom grenades will also explode properly when dropped/thrown as intended.