### PR TITLE
adds the weapons from #3417 to the ONI arsenal too

### DIFF
--- a/code/modules/halo/unsc/supply/specweapons.dm
+++ b/code/modules/halo/unsc/supply/specweapons.dm
@@ -26,3 +26,36 @@
 	cost = 1500
 	contains = list(/obj/item/weapon/gun/energy/spartanlaser = 1)
 	containername = "\improper M6 G/GNR crate"
+
+/**/
+/* ONI - Need a separate category for faction lock code. */
+/**/
+
+/decl/hierarchy/supply_pack/oni_weapons_special
+	name = "ONI Experimental Weapons"
+	faction_lock = "ONI"
+	containertype = /obj/structure/closet/crate/secure/weapon
+
+/decl/hierarchy/supply_pack/oni_weapons_special/railgun
+	name = "ARC-920 Experimental Railgun"
+	cost = 1000
+	contains = list(/obj/item/weapon/gun/projectile/railrifle = 1,/obj/item/ammo_box/railrifle = 6)
+	containername = "\improper ARC-920 crate"
+
+/decl/hierarchy/supply_pack/oni_weapons_special/railgun_ammo
+	name = "ARC-920 HE Slugs"
+	cost = 50
+	contains = list(/obj/item/ammo_box/railrifle = 6)
+	containername = "\improper ARC-920 HE ammo crate"
+
+/decl/hierarchy/supply_pack/oni_weapons_special/railgun_ammo_ap
+	name = "ARC-920 AP Slugs"
+	cost = 150
+	contains = list(/obj/item/ammo_box/railrifle/AP = 3)
+	containername = "\improper ARC-920 AP ammo crate"
+
+/decl/hierarchy/supply_pack/oni_weapons_special/spartanlaser
+	name = "M6 Grindell/Galilean Nonlinear Rifle"
+	cost = 1500
+	contains = list(/obj/item/weapon/gun/energy/spartanlaser = 1)
+	containername = "\improper M6 G/GNR crate"

--- a/code/modules/halo/weapons/ammo_railslug.dm
+++ b/code/modules/halo/weapons/ammo_railslug.dm
@@ -34,11 +34,11 @@
 	steps_between_delays = 6
 
 /obj/item/projectile/bullet/railslug/HE
-	damage = 65
-	armor_penetration = 50
+	damage = 60
+	armor_penetration = 60
 	shield_damage = 175
 	penetrating = 0
 
 /obj/item/projectile/bullet/railslug/HE/on_impact(var/atom/target)
-	explosion(get_turf(target), 0, 1, 2, 4,guaranteed_damage = 35,guaranteed_damage_range = 1)
+	explosion(get_turf(target), -1, 1, 2, 4,guaranteed_damage = 20,guaranteed_damage_range = 1)
 	..()

--- a/code/modules/halo/weapons/covenant/ammo.dm
+++ b/code/modules/halo/weapons/covenant/ammo.dm
@@ -359,7 +359,7 @@
 /obj/item/projectile/bullet/covenant/concussion_rifle
 	name = "heavy plasma round"
 	damage = 50
-	armor_penetration = 40
+	armor_penetration = 50
 	shield_damage = 50
 	step_delay = 0.75 //slower than most
 	icon = 'code/modules/halo/weapons/icons/Covenant_Projectiles.dmi'

--- a/code/modules/halo/weapons/railrifle.dm
+++ b/code/modules/halo/weapons/railrifle.dm
@@ -28,4 +28,4 @@
 	w_class = ITEM_SIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	ammo_type = /obj/item/ammo_casing/railslug
-	slowdown_general = 0.4//Slightly lighter than an lmg.
+	slowdown_general = 0.5

--- a/code/modules/halo/weapons/railrifle.dm
+++ b/code/modules/halo/weapons/railrifle.dm
@@ -28,4 +28,4 @@
 	w_class = ITEM_SIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	ammo_type = /obj/item/ammo_casing/railslug
-	slowdown_general = 0.5
+	slowdown_general = 0.4//Slightly lighter than an lmg.

--- a/code/modules/halo/weapons/spartan_laser.dm
+++ b/code/modules/halo/weapons/spartan_laser.dm
@@ -15,7 +15,7 @@
 
 	one_hand_penalty = -1
 	self_recharge = 1
-	recharge_time = 150
+	recharge_time = 200
 	max_shots = 4
 	is_charged_weapon = TRUE
 

--- a/code/modules/halo/weapons/spartan_laser.dm
+++ b/code/modules/halo/weapons/spartan_laser.dm
@@ -16,7 +16,7 @@
 	one_hand_penalty = -1
 	self_recharge = 1
 	recharge_time = 150
-	max_shots = 8
+	max_shots = 4
 	is_charged_weapon = TRUE
 
 	arm_time = 25 //Deciseconds


### PR DESCRIPTION
:cl: XO-11
tweak: The ONI arsenal now also has access to the new experimental weapons.
tweak: Concussion rifle tweak armor penetration from 40 to 50
tweak: Railrifle and lmg weight tweaked to slowdown general being now 0.4
tweak: HE Slugs have been tweaked that  damaged has been changed  from 65 to 60 and armor penetration changed from 50 to 60
tweak: Spartan laser recharge time changed from 150 to 200
/:cl: