### PR TITLE
Allows for Belt Internals

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -252,6 +252,10 @@
 								breathes = H.species.breath_type
 								nicename = list ("suit", "back", "belt", "right hand", "left hand", "left pocket", "right pocket")
 								tankcheck = list (H.s_store, C.back, H.belt, C.r_hand, C.l_hand, H.l_store, H.r_store)
+								if(istype(H.belt,/obj/item/weapon/storage/belt))
+									for(var/i in H.belt.contents)
+										nicename += "belt storage"
+										tankcheck += i
 							else
 								nicename = list("right hand", "left hand", "back")
 								tankcheck = list(C.r_hand, C.l_hand, C.back)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -271,7 +271,7 @@ var/list/global/tank_gauge_cache = list()
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/item/weapon/tank/Topic(user, href_list)
+/obj/item/weapon/tank/Topic(href, href_list)
 	..()
 	if (usr.stat|| usr.restrained())
 		return 0

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -250,7 +250,6 @@ var/list/global/tank_gauge_cache = list()
 		else if(istype(src.loc, /obj/item/weapon/rig) && src.loc in location)	// or the rig is in the mobs possession
 			if(!location.internal)		// and they do not have any active internals
 				mask_check = 1
-
 		if(mask_check)
 			if(location.wear_mask && (location.wear_mask.item_flags & AIRTIGHT))
 				data["maskConnected"] = 1
@@ -272,10 +271,11 @@ var/list/global/tank_gauge_cache = list()
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/item/weapon/tank/Topic(href, href_list)
+/obj/item/weapon/tank/Topic(user, href_list)
 	..()
 	if (usr.stat|| usr.restrained())
 		return 0
+
 	if (src.loc != usr)
 		return 0
 
@@ -295,30 +295,35 @@ var/list/global/tank_gauge_cache = list()
 	return 1
 
 /obj/item/weapon/tank/proc/toggle_valve(var/mob/user)
+	var/mob/living/carbon/location = loc
 	if(istype(loc,/mob/living/carbon))
-		var/mob/living/carbon/location = loc
-		if(location.internal == src)
-			location.internal = null
-			location.internals.icon_state = "internal0"
-			to_chat(user, "<span class='notice'>You close the tank release valve.</span>")
-			if (location.internals)
-				location.internals.icon_state = "internal0"
-		else
-			var/can_open_valve
-			if(location.wear_mask && (location.wear_mask.item_flags & AIRTIGHT))
-				can_open_valve = 1
-			else if(istype(location,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = location
-				if(H.head && (H.head.item_flags & AIRTIGHT))
-					can_open_valve = 1
+		location = loc
+	else if(istype(loc,/obj/item/weapon/storage/belt))
+		if(istype(loc.loc,/mob/living/carbon))
+			location = loc.loc
 
-			if(can_open_valve)
-				location.internal = src
-				to_chat(user, "<span class='notice'>You open \the [src] valve.</span>")
-				if (location.internals)
-					location.internals.icon_state = "internal1"
-			else
-				to_chat(user, "<span class='warning'>You need something to connect to \the [src].</span>")
+	if(location.internal == src)
+		location.internal = null
+		location.internals.icon_state = "internal0"
+		to_chat(user, "<span class='notice'>You close the tank release valve.</span>")
+		if (location.internals)
+			location.internals.icon_state = "internal0"
+	else
+		var/can_open_valve
+		if(location.wear_mask && (location.wear_mask.item_flags & AIRTIGHT))
+			can_open_valve = 1
+		else if(istype(location,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = location
+			if(H.head && (H.head.item_flags & AIRTIGHT))
+				can_open_valve = 1
+
+		if(can_open_valve)
+			location.internal = src
+			to_chat(user, "<span class='notice'>You open \the [src] valve.</span>")
+			if (location.internals)
+				location.internals.icon_state = "internal1"
+		else
+			to_chat(user, "<span class='warning'>You need something to connect to \the [src].</span>")
 
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -296,7 +296,11 @@
 //				rig_supply = s.internal_air_tank
 //Work in progress
 
-		if (!rig_supply && (!contents.Find(internal) || !((wear_mask && (wear_mask.item_flags & AIRTIGHT)) || (head && (head.item_flags & AIRTIGHT)))))
+		var/list/holding = contents.Copy()
+		if(istype(belt,/obj/item/weapon/storage/belt))
+			holding += belt.contents
+
+		if (!rig_supply && (!holding.Find(internal) || !((wear_mask && (wear_mask.item_flags & AIRTIGHT)) || (head && (head.item_flags & AIRTIGHT)))))
 			internal = null
 
 		if(internal)


### PR DESCRIPTION
You can now use tanks that fit in belt items i.e. (ammo belt/martial belt) inside of those belts.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: BladeburstNINJA
rscadd: Oxygen tanks work inside of respective belt items.
/:cl:
![image](https://github.com/HaloSpaceStation/HaloSpaceStation13/assets/67651604/2b38187d-a3e9-47de-b03c-eddaae94b82a)
