### PR TITLE
Boltshot  tweaks

### DIFF
--- a/code/modules/halo/weapons/forerunner/ammo.dm
+++ b/code/modules/halo/weapons/forerunner/ammo.dm
@@ -47,9 +47,7 @@
 	icon = 'code/modules/halo/weapons/icons/forerunner_sprites.dmi'
 	icon_state = "boltshot_ammo"
 	fire_sound = 'code/modules/halo/sounds/boltshot_sg_fire.ogg'
-	damage = 25
-	pellets = 8
-	range_step = 1
+	penetrating = 1
 
 /obj/item/ammo_magazine/binaryrifle
 	name = "Z-750 SASR magazine"

--- a/code/modules/halo/weapons/forerunner/pistols.dm
+++ b/code/modules/halo/weapons/forerunner/pistols.dm
@@ -38,7 +38,7 @@
 	else
 		if(istype(ammo_magazine,/obj/item/ammo_magazine/boltshot_sg))
 			icon_state = "boltshot_shotgun"
-			fire_delay = initial(fire_delay) + 4
+			fire_delay = initial(fire_delay) + 6
 		else
 			icon_state = "boltshot"
 			fire_delay = initial(fire_delay)

--- a/code/modules/halo/weapons/forerunner/rifles.dm
+++ b/code/modules/halo/weapons/forerunner/rifles.dm
@@ -16,7 +16,7 @@
 	handle_casings = CASELESS
 	magazine_type = /obj/item/ammo_magazine/suppressor
 
-	fire_delay = 8
+	fire_delay = 10
 	burst = 6
 	burst_delay = 1.7
 	one_hand_penalty = -1


### PR DESCRIPTION
:cl: XO-11
tweak: Boltshot ammo should now fit the statistics of a low power shotgun shell load  i.e Weaker than the one used in pump action shotguns
tweak: Supressor tweak fire delay changed from 6 to 10
tweak:  Boltshot  tweak initial fire delay  changed from 4 to 6
/:cl: