### PR TITLE
MultiZ Visibility Tweaks, Toproping Removal

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -5,6 +5,7 @@
 	density = 0
 	layer = ABOVE_WINDOW_LAYER
 	w_class = ITEM_SIZE_NORMAL
+	vis_flags = VIS_HIDE
 
 /obj/structure/sign/ex_act(severity)
 	switch(severity)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -13,6 +13,7 @@
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 10
+	vis_flags = VIS_HIDE
 	var/datum/money_account/authenticated_account
 	var/number_incorrect_tries = 0
 	var/previous_account_number = 0

--- a/code/modules/halo/misc/capture_node.dm
+++ b/code/modules/halo/misc/capture_node.dm
@@ -205,6 +205,7 @@ GLOBAL_LIST_EMPTY(capture_nodes)
 	var/image/faction_logo
 	var/fade_alpha1 = 100
 	var/fade_alpha2 = 0
+	vis_flags = VIS_HIDE
 
 /obj/structure/capture_marker/proc/set_owner(var/new_faction)
 	GLOB.processing_objects.Remove(src)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -197,7 +197,7 @@
 		return species.can_fall(src)
 
 /atom/movable/proc/handle_fall(var/turf/landing)
-	Move(landing)
+	forceMove(landing)
 	if(locate(/obj/structure/stairs) in landing)
 		return 1
 	else

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -150,6 +150,7 @@ var/global/list/light_type_cache = list()
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
+	vis_flags = VIS_HIDE
 
 	var/on = 0					// 1 if on, 0 if off
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN


### PR DESCRIPTION
:cl: Aroliacue
rscadd: Implemented new checks to hide certain objects and structures between zlevels.
rscdel: Removed toproping. May be reimplemented in the future.
/:cl: