### PR TITLE
fixes ex_act applicability

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -99,9 +99,9 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 							else
 								m.apply_damage(guaranteed_damage/2,BRUTE,,m.run_armor_check(null,"bomb"))
 								m.apply_damage(guaranteed_damage/2,BURN,,m.run_armor_check(null,"bomb"))
-								if(AM && AM.simulated && !T.protects_atom(AM))
-									AM.ex_act(dist,epicenter)
-									exploded += AM
+					if(AM && AM.simulated && !T.protects_atom(AM))
+						AM.ex_act(dist,epicenter)
+						exploded += AM
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare


### PR DESCRIPTION
:cl: XO-11
tweak: Explosion effects should now properly apply. This might lead to explosion power varying massively from what it originally was intended to be, so this should be followed with a balance pass quickly after merging and seeing the effects.
/:cl:
This might lead to explosion power varying massively from what it originally was intended to be, so this should be followed with a balance pass quickly after merging and seeing the effects.