### PR TITLE
Adds explosive immunity to stairs

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -224,3 +224,6 @@
 	west
 		dir = WEST
 		bound_width = 64
+
+/obj/structure/stairs/ex_act(var/severity)  //Explosion invulnerability
+	return


### PR DESCRIPTION
Effectively makes stairs immune to destruction. 

Stairs are often fought over as they make a good defensive location, grenades are good to push anyone camping the stairs off of them for a bit, but two grenades or so are enough to destroy the stairs.

This can lead to scenarios where assaulting or escaping from a location becomes incredibly difficult, particularly if you are trapped on the lower level.

Uncertain if ladders should be made immune as well, if it is desired, I can add that too.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl: Outermonk
tweak: Stairs cannot be destroyed
/:cl:
