### PR TITLE
gun tracking and brute unpowered yeet fix

### DIFF
--- a/code/controllers/voting/initiate_vote.dm
+++ b/code/controllers/voting/initiate_vote.dm
@@ -47,7 +47,7 @@
 
 /datum/vote/proc/announce_vote(var/announce_text)
 	to_world("<font color='purple'><b>[announce_text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src];view_vote=1'>here</a> to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
-	to_world(sound(announce_ogg, repeat = 0, wait = 0, volume = 50, channel = 3))
+	to_target(world,sound(announce_ogg, repeat = 0, wait = 0, volume = 50, channel = 3))
 
 /datum/vote/proc/update_question()
 	question = "Place your vote for [name]"

--- a/code/modules/halo/weapons/covenant/brute.dm
+++ b/code/modules/halo/weapons/covenant/brute.dm
@@ -85,7 +85,7 @@
 	lunge_dist = 2
 	salvage_components = list()
 	matter = list("duridium" = 1)
-	
+
 	firemodes = list(\
 	list(mode_name="firing mode",  burst=3),
 	list(mode_name="melee mode",  burst=0)
@@ -167,7 +167,7 @@
 	lunge_dist = 2
 	salvage_components = list()
 	matter = list("duridium" = 1)
-	
+
 	firemodes = list(\
 	list(mode_name="firing mode",  burst=1),
 	list(mode_name="melee mode",  burst=0)
@@ -238,8 +238,9 @@
 
 /obj/item/weapon/grav_hammer/attack(var/mob/m,var/mob/user)
 	. = ..()
-	var/throw_dir = get_dir(user,m)
-	m.throw_at(get_edge_target_turf(m, throw_dir),2,4,user)
+	if(unique_afterattack)
+		var/throw_dir = get_dir(user,m)
+		m.throw_at(get_edge_target_turf(m, throw_dir),2,4,user)
 
 /obj/item/weapon/grav_hammer/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
 	if(lunge_dist > 0)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -340,7 +340,7 @@ var/list/points_of_interest = list()
 /obj/effect/overmap/process()
 	for(var/e in active_effects)
 		var/datum/overmap_effect/effect = e
-		if(!effect.process_effect())
+		if(effect && !effect.process_effect())
 			active_effects -= src
 			qdel(effect)
 	if(!isnull(targeting_datum.current_target) && !(targeting_datum.current_target in range(src,7)))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -411,7 +411,7 @@
 			var/mob/living/targ_m = target
 			if(istype(targ_m))
 				if(!targ_m.lying)
-					use_targ = targloc
+					use_targ = targ_m
 				else
 					use_targ = targloc
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -411,9 +411,9 @@
 			var/mob/living/targ_m = target
 			if(istype(targ_m))
 				if(!targ_m.lying)
-					use_targ = targ_m
-				else
 					use_targ = targloc
+				else
+					use_targ = stored_targ
 
 		process_accuracy(projectile, user, use_targ, i, held_twohanded)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -412,8 +412,8 @@
 			if(istype(targ_m))
 				if(!targ_m.lying)
 					use_targ = targloc
-			else
-				use_targ = targloc
+				else
+					use_targ = targloc
 
 		process_accuracy(projectile, user, use_targ, i, held_twohanded)
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -15,7 +15,7 @@
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 2
 	var/recentpump = 0 // to prevent spammage
-	var/min_pump_time_diff = 5
+	var/min_pump_time_diff = 4
 
 /obj/item/weapon/gun/projectile/shotgun/pump/consume_next_projectile()
 	if(chambered)


### PR DESCRIPTION
:cl: XO-11
tweak: We have removed the final power cell in the unpowered brute hammer and it will no longer throw people backwards on hit.
tweak: You can no longer automatically track people for an entire burst with a single click.
/:cl: