### PR TITLE
Lets orions use autodocs

### DIFF
--- a/code/modules/halo/machinery/autosurgeon/autosurgeon.dm
+++ b/code/modules/halo/machinery/autosurgeon/autosurgeon.dm
@@ -33,7 +33,7 @@
 	var/obj/item/organ/external/surgery_target_ext
 	var/obj/item/organ/internal/surgery_target_int
 
-	var/list/allowed_species = list(/datum/species/human, /datum/species/spartan)
+	var/list/allowed_species = list(/datum/species/human, /datum/species/orion, /datum/species/spartan)
 
 /obj/machinery/autosurgeon/New()
 	. = ..()


### PR DESCRIPTION
Not being able to use autodoc without having an autopsied Orion sucks, spartans can use by default so I think orions should be logically be able to as well.

Didn't test this but code complied so I'm guessing it works.

<!-- If you need a change log update the below. Other wise you should remove it-->
:cl:
rscadd: Orions can now use autodocs by default like spartans and humans
/:cl:
