### PR TITLE
Bruteshot Nerf, Bodypart Toughness and Vehicle Repair Buff

### DIFF
--- a/code/modules/halo/covenant/jobs/AI.dm
+++ b/code/modules/halo/covenant/jobs/AI.dm
@@ -8,6 +8,6 @@
 	whitelisted_species = list()
 	access = list(access_covenant, access_covenant_command, access_covenant_slipspace)
 	pop_balance_mult = 0.5
-	poplock_divisor = 12
+	poplock_divisor = 11
 
 	radio_speech_size = RADIO_SPEECH_SPECIALIST

--- a/code/modules/halo/covenant/jobs/AI.dm
+++ b/code/modules/halo/covenant/jobs/AI.dm
@@ -8,5 +8,6 @@
 	whitelisted_species = list()
 	access = list(access_covenant, access_covenant_command, access_covenant_slipspace)
 	pop_balance_mult = 0.5
+	poplock_divisor = 12
 
 	radio_speech_size = RADIO_SPEECH_SPECIALIST

--- a/code/modules/halo/misc/explosion_debris.dm
+++ b/code/modules/halo/misc/explosion_debris.dm
@@ -16,7 +16,7 @@
 	loot_types = list()
 	scrap_types = list()
 	bump_climb = 1
-	mob_climb_time = 0.7 SECONDS
+	mob_climb_time = 0.5 SECONDS
 	dodge_pass = 1
 
 /obj/structure/destructible/proc/check_ignore_list(var/obj/i)

--- a/code/modules/halo/unsc/jobs/ai.dm
+++ b/code/modules/halo/unsc/jobs/ai.dm
@@ -8,5 +8,6 @@
 	//faction_whitelist = "UNSC" //Uncomment this once testing is done.
 	whitelisted_species = list()
 	pop_balance_mult = 0.5
+	poplock_divisor = 12
 
 	radio_speech_size = RADIO_SPEECH_SPECIALIST

--- a/code/modules/halo/unsc/jobs/ai.dm
+++ b/code/modules/halo/unsc/jobs/ai.dm
@@ -8,6 +8,6 @@
 	//faction_whitelist = "UNSC" //Uncomment this once testing is done.
 	whitelisted_species = list()
 	pop_balance_mult = 0.5
-	poplock_divisor = 12
+	poplock_divisor = 11
 
 	radio_speech_size = RADIO_SPEECH_SPECIALIST

--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -1,6 +1,6 @@
 #define REPAIR_TOOLS_LIST list(/obj/item/weapon/screwdriver,/obj/item/weapon/wrench,/obj/item/weapon/weldingtool,/obj/item/weapon/crowbar,/obj/item/weapon/wirecutters)
-#define BASE_INTEGRITY_RESTORE_PERSHEET 20 //Amount of integrity restored per sheet of material.
-#define COMPONENT_REPAIR_DELAY 10 SECONDS
+#define BASE_INTEGRITY_RESTORE_PERSHEET 50 //Amount of integrity restored per sheet of material.
+#define COMPONENT_REPAIR_DELAY 8 SECONDS
 #define COMPONENT_INSPECT_DELAY 1.5 SECONDS
 
 /datum/component_profile

--- a/code/modules/halo/weapons/covenant/brute.dm
+++ b/code/modules/halo/weapons/covenant/brute.dm
@@ -400,7 +400,7 @@
 	to_chat(user, "<span class='info'>It has [amount] grenade[amount != 1 ? "s" : ""] remaining on the belt.</span>")
 
 /obj/item/weapon/grenade/brute_shot/detonate()
-	explosion(get_turf(src), 0, max(round(amount/5),2), max(round(amount / 3), 3), max(amount, 5), guaranteed_damage = 20, guaranteed_damage_range = 3)
+	explosion(get_turf(src), 0, max(round(amount/4),1), max(round(amount / 2), 2), max(amount, 4), guaranteed_damage = 20, guaranteed_damage_range = 3)
 	. = ..()
 	qdel(src)
 

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -4,9 +4,9 @@
 	icon_name = "head"
 	name = "head"
 	slot_flags = SLOT_BELT
-	max_damage = 75
+	max_damage = 100
 	min_broken_damage = 35
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_LARGE
 	body_part = HEAD
 	parent_organ = BP_CHEST
 	joint = "jaw"

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -44,7 +44,7 @@
 	icon_name = "groin"
 	max_damage = 100
 	min_broken_damage = 35
-	w_class = ITEM_SIZE_LARGE
+	w_class = ITEM_SIZE_HUGE
 	body_part = LOWER_TORSO
 	vital = 1
 	parent_organ = BP_CHEST
@@ -52,6 +52,7 @@
 	joint = "hip"
 	dislocated = -1
 	gendered_icon = 1
+	cannot_amputate = 1
 	artery_name = "iliac artery"
 
 /obj/item/organ/external/arm


### PR DESCRIPTION
:cl: Aroliacue
tweak: Damage output of the bruteshot has been reduced further.
tweak: Groins can no longer be easily amputated for an instant kill. Aim for the head instead.
tweak: Manual vehicle repair is now faster.
tweak: Climbing over explosive debris is now slightly faster.
tweak: AI roles now require at least 11 players online to be played.
/:cl: