### PR TITLE
Tweaks how slowdown applies to humanmobs

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -262,3 +262,5 @@
 #define SUPPRESSION_SCREAM_CHANCE 5
 #define SUPPRESSION_SHAKE_CHANCE 10
 #define SCREAM_COOLDOWN 1.5 SECOND
+#define HEALTHDEFICIENCY_THRESHOLD 0.2 //20% health loss before we start feeling any sort of slowdown.
+#define HEALTHDEFICIENCY_HPLOSS_ONEPOINTSLOWDOWN_MOD 0.175 //17.5% hp loss per slowdown point

--- a/code/modules/halo/clothing/odst.dm
+++ b/code/modules/halo/clothing/odst.dm
@@ -48,7 +48,7 @@
 
 /obj/item/clothing/suit/armor/special/odst
 	name = "ODST Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has standard grey markings denoting its user to be a rifleman. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has standard grey markings denoting its user to be a rifleman. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 	icon = ITEM_INHAND
 	icon_state = "Odst Armour"
 	icon_override = ODST_OVERRIDE
@@ -122,7 +122,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/cqb
 	name = "ODST CQB Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has deep red markings to relay that its user is specialized in Close Quarters Battle. It has a combat knife sheath attached to the left shoulder as well as additional up-armoring on the chest and legs. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has deep red markings to relay that its user is specialized in Close Quarters Battle. It has a combat knife sheath attached to the left shoulder as well as additional up-armoring on the chest and legs. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 
 	icon_state = "Odst Armour CQB"
 
@@ -140,7 +140,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/sharpshooter
 	name = "ODST Sharpshooter Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has no markings to enhance stealth capabilities and to relay that its wearer is a designated marksman or sniper. It has had its right shoulder armor removed in order to increase ease of aim and fire for right-handed shooters, as well as its left shoulder armor enlarged to provide extra protection from fire coming from the left side . EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has no markings to enhance stealth capabilities and to relay that its wearer is a designated marksman or sniper. It has had its right shoulder armor removed in order to increase ease of aim and fire for right-handed shooters, as well as its left shoulder armor enlarged to provide extra protection from fire coming from the left side . EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 
 	icon_state = "Odst Armour Sharpshooter"
 
@@ -159,7 +159,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/medic
 	name = "ODST Medic Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has maroon markings to relay that its wearer is a designated combat medic. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has maroon markings to relay that its wearer is a designated combat medic. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 
 	icon_state = "Odst Armour Medic"
 
@@ -192,7 +192,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/engineer
 	name = "ODST Engineer Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has orange markings to relay that its wearer is a designated combat engineer. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has orange markings to relay that its wearer is a designated combat engineer. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 
 	icon_state = "Odst Armour Engineer"
 
@@ -211,7 +211,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/old
 	name = "ODST Armour"
-	desc = "Lightweight, durable armour issued to Orbital Drop Shock Troopers for increased survivability in the field. This particular BDU appears to be of a older pattern."
+	desc = "Lightweight, durable armour issued to Orbital Drop Shock Troopers for increased survivability in the field. This particular BDU appears to be of a older pattern. Contains minature servomotors to amplify movement speed,"
 
 	item_state = "h2_odst_armor_worn"
 	icon_state = "h2_odst_armor_obj"
@@ -231,7 +231,7 @@
 
 /obj/item/clothing/suit/armor/special/odst/squadleader
 	name = "ODST Squad Leader Armour"
-	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has blue markings to relay that its wearer is an NCO or officer. It has a combat knife sheath attached to the left shoulder. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one."
+	desc = "The armor of the standard Orbital Drop Shock Trooper Battle Dress Uniform(BDU), this one has blue markings to relay that its wearer is an NCO or officer. It has a combat knife sheath attached to the left shoulder. EVA Capable, protective, and lightweight; a fine piece of armor if there ever was one. Contains minature servomotors to amplify movement speed,"
 
 	icon_state = "Odst Armor Squad Leader"
 

--- a/code/modules/halo/covenant/species/tvoan/skirmisher.dm
+++ b/code/modules/halo/covenant/species/tvoan/skirmisher.dm
@@ -24,7 +24,7 @@
 	pain_mod = 0.9
 	brute_mod = 1.2
 	burn_mod = 1.2
-	slowdown = -0.4
+	slowdown = -0.5
 
 	equipment_slowdown_multiplier = 1.1 //Disincentives multiple weapon carry
 	gibbed_anim = null

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -20,7 +20,8 @@
 		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
 
 	var/health_deficiency = (maxHealth - health)
-	if(health_deficiency >= 40) tally += (health_deficiency / 35)
+	//20% health loss, then we start giving slowdown.
+	if(health_deficiency >= (maxHealth*HEALTHDEFICIENCY_THRESHOLD)) tally += (health_deficiency / (maxHealth * HEALTHDEFICIENCY_HPLOSS_ONEPOINTSLOWDOWN_MOD))
 
 	if(can_feel_pain())
 		if(get_shock() >= 20) tally += (get_shock() / 30) //halloss shouldn't slow you down if you can't even feel it
@@ -44,7 +45,8 @@
 
 		if(ignore_equipment_threshold && equipment_slowdown > ignore_equipment_threshold)
 			equipment_slowdown -= ignore_equipment_threshold
-		equipment_slowdown *= species.equipment_slowdown_multiplier
+		if(equipment_slowdown > 0) //Only use our modifier if it's actually slowing us down. Speedups are unmodded.
+			equipment_slowdown *= species.equipment_slowdown_multiplier
 
 		tally += equipment_slowdown
 
@@ -61,10 +63,13 @@
 
 	if(aiming && aiming.aiming_at) tally += 5 // Iron sights make you slower, it's a well-known fact.
 
+	var/species_coldtemp = 283.222
+	if(species)
+		species_coldtemp = species.cold_discomfort_level
 	if(FAT in src.mutations)
 		tally += 1.5
-	if (bodytemperature < 283.222)
-		tally += (283.222 - bodytemperature) / 10 * 1.75
+	if (bodytemperature < species_coldtemp)
+		tally += (species_coldtemp - bodytemperature) / 10 * 1.75
 
 	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -145,9 +145,9 @@
 
 /mob/proc/movement_delay()
 	. = 0
-	if(istype(loc, /turf))
-		var/turf/T = loc
-		. += T.movement_delay
+	var/turf/T = get_turf(src)
+	if(src.elevation == T.elevation)
+		. += T.get_movement_delay()
 	. += currently_firing
 
 	if(pulling)


### PR DESCRIPTION
:cl: XO-11
tweak: Damage based slowdown now applies on a percentile basis rather than flat numbers. A minor buff to the higher health units.
tweak: Equipment speedups should no longer be modified by a species equipment slowdown mod.
/:cl: