### PR TITLE
Adds Zealot as an alt-title

### DIFF
--- a/code/modules/halo/covenant/jobs/sangheili.dm
+++ b/code/modules/halo/covenant/jobs/sangheili.dm
@@ -10,6 +10,8 @@
 	outfit_type = /decl/hierarchy/outfit/sangheili/shipmaster
 	faction_whitelist = "Covenant"
 	whitelisted_species = list(/datum/species/sangheili)
+	alt_titles = list(\
+	"Sangheili Zealot" = /decl/hierarchy/outfit/sangheili/zealot)
 	access = list(access_covenant, access_covenant_command, access_covenant_slipspace, access_covenant_cargo)
 	pop_balance_mult = 2.5
 


### PR DESCRIPTION
Made Zealot an Alt-Title to Shipmaster, since they are the exact same class barring a different sprite. The original Zealot job still exists, just incase.

:cl: nameacow01
rscadd: Zealot is now also a alt title under the Shipmaster job.
/:cl:
