### PR TITLE
Flamer Changes

### DIFF
--- a/code/modules/halo/weapons/flamethrowers.dm
+++ b/code/modules/halo/weapons/flamethrowers.dm
@@ -1,5 +1,7 @@
-//For whatever reason this wasn't defined here?
+
 #define CLEAR_CASINGS 1
+#define FLAMER_FIRE_LEVEL 10
+#define FLAMER_FIRE_FUEL 5
 
 //NA4 Defoliant Projector
 /obj/item/weapon/gun/projectile/na4_dp
@@ -10,18 +12,23 @@
 	item_state = "na4"
 	slot_flags = SLOT_BACK
 	handle_casings = CLEAR_CASINGS
-	burst = 3
+	burst = 8
 	hud_bullet_usebar = 1
 	caliber="flamethrower"
 	fire_delay = 7
 	one_hand_penalty = 3
-	slowdown_general = 0.20
-	dispersion = list(0.4)
+	slowdown_general = 0.15
+	dispersion = list(2.5)
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/na4_tank
 	allowed_magazines = list(/obj/item/ammo_magazine/na4_tank)
 	wielded_item_state="na4_loaded"
 	fire_sound = 'sound/effects/extinguish.ogg'
+
+	firemodes = list(\
+	list(mode_name="wide spread",  burst=8, dispersion=list(2.5)),
+	list(mode_name="accurate fire",  burst=4, dispersion=list(0.4))
+	)
 
 	item_icons = list(
 		slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi',
@@ -49,7 +56,8 @@
 	shield_damage =30
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "fire"
-	kill_count = 6 //No sniping!
+	kill_count = 6 //We change this when launched anyway. Limits shooting to  vis range.
+	var/kill_half = 0 //Automatically set on proj launch.
 
 /obj/item/projectile/bullet/fire/attack_mob(var/mob/living/carbon/C)
 	damage_type = BURN
@@ -60,12 +68,24 @@
 			C.IgniteMob()
 	return ..()
 
+/obj/item/projectile/bullet/fire/proc/spawn_fire(var/turf/targloc,var/created_firelevel = FLAMER_FIRE_LEVEL)
+	if(!ismob(targloc))
+		var/obj/effect/fire/f = locate() in targloc
+		if(f)
+			f.fire_fuel++ //Only a small increase if there's already a fire there.
+		else
+			f = new /obj/effect/fire/noheat(targloc)
+			f.firelevel = created_firelevel
+			f.fire_fuel = FLAMER_FIRE_FUEL
+
 /obj/item/projectile/bullet/fire/on_impact(var/atom/impacted)
 	..()
-	var/impacted_loc = loc
-	if(!ismob(loc))
-		var/obj/effect/fire/f = new /obj/effect/fire/noheat(impacted_loc)
-		f.firelevel = 8
+	spawn_fire(impacted.loc)
+
+/obj/item/projectile/bullet/fire/Move()
+	if(kill_count <= kill_half && !ismob(loc))
+		spawn_fire(loc)
+	.=..()
 
 /obj/item/projectile/bullet/fire/launch_from_gun(var/atom/target)
 	. = ..()
@@ -73,6 +93,7 @@
 	if(!isturf(target))
 		targturf = get_turf(target)
 	kill_count = get_dist(loc,targturf)
+	kill_half = round(kill_count/2)
 
 
 /obj/item/ammo_magazine/na4_tank
@@ -91,4 +112,6 @@
 	caliber = "flamethrower"
 	projectile_type = /obj/item/projectile/bullet/fire
 
+#undef FLAMER_FIRE_LEVEL
+#undef FLAMER_FIRE_FUEL
 #undef CLEAR_CASINGS


### PR DESCRIPTION
:cl: XO-11
tweak: The NA4 Defoliant Projector is now more versatile. Its default firemode has awful dispersion but fires a lot of projectiles, whilst a secondary firemode allows for more accurate fire placement but with less shots.
tweak: Fire projectiles now leave fire objects on the second half of their movement path, rather than just at the impact point.
/:cl: