### PR TITLE
Explosion smoke tweak

### DIFF
--- a/code/modules/halo/misc/custom_explosion.dm
+++ b/code/modules/halo/misc/custom_explosion.dm
@@ -55,7 +55,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 		if(approximate_intensity >= 2)
 			if(isnull(effect_datum_override))
-				if(approximate_intensity >= 4)
+				if(approximate_intensity >= 25)//Let's not make smoke unless we *really* need to.
 					effect_datum_override = /datum/effect/system/explosion/has_smoke
 				else
 					effect_datum_override = /datum/effect/system/explosion

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -103,15 +103,16 @@
 	var/throw_mob = FALSE
 	var/throw_range = 0
 	var/eyeflash_duration = 20
+	var/ear_damage_stats = null//list(ear damage add, ear damage upper cap, ear deaf add, ear deaf upper cap)
 	switch (severity)
 		if (1.0)
 			b_loss = 90
 			f_loss = 90
 			eyeflash_duration = 20
+			ear_damage_stats = list(30,50,120,120)
 			if (!prob(getarmor(null, "bomb")))
 				b_loss = 150
 				f_loss = 150
-				return
 			else
 				throw_mob = TRUE
 				throw_range = 200 //Be happy you survived the bomb's gibbing
@@ -124,20 +125,20 @@
 			f_loss = 60
 			eyeflash_duration = 10
 
-			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
-				ear_damage = min(ear_damage + 30,50*species.explosion_effect_mod)
-				ear_deaf = min(ear_damage + 120,120*species.explosion_effect_mod)
+			ear_damage_stats = list(30,50,120,120)
 			throw_mob = TRUE
 			throw_range = rand(world.view - 2,world.view)
 
 		if(3.0)
 			b_loss = 30
 			eyeflash_duration = 5
-			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
-				ear_damage = min(ear_damage + 15,50*species.explosion_effect_mod)
-				ear_deaf = min(ear_damage + 60,120*species.explosion_effect_mod)
+			ear_damage_stats = list(15,50,60,120)
 			throw_mob = TRUE
 			throw_range = rand(world.view - 4, world.view - 2)
+
+	if (!isnull(ear_damage_stats) && !istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+		ear_damage = min(ear_damage + ear_damage_stats[1],ear_damage_stats[2]*species.explosion_effect_mod)
+		ear_deaf = min(ear_damage + ear_damage_stats[3],ear_damage_stats[4]*species.explosion_effect_mod)
 
 	if(!blinded)
 		flash_eyes(FLASH_PROTECTION_MODERATE,FALSE,FALSE,FALSE, /obj/screen/fullscreen/flash, eyeflash_duration)


### PR DESCRIPTION
🆑 : XO-11
tweak: Explosions will now only give out smoke on especially large explosions. Normal gameplay should see less visual obstruction.
/:cl: