### PR TITLE
Vehicle Gun Spawning Fix

### DIFF
--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -56,12 +56,13 @@
 /datum/component_profile/proc/give_gunner_weapons(var/obj/vehicles/source_vehicle)
 	var/list/gunners = source_vehicle.get_occupants_in_position(pos_to_check)
 	for(var/mob/living/carbon/human/gunner in gunners)
-		if(gunner.get_active_hand() || gunner.get_inactive_hand()) //Let's not give anyone a gun if they're messing with their inventory, or already have a gun.
-			continue
 		var/obj/item/weapon/gun/vehicle_turret/weapon = gunner_weapons[gunners.Find(gunner)]
 		if(isnull(weapon))
 			continue
 		weapon = new weapon(source_vehicle)
+		if(istype(gunner.get_active_hand(),weapon) || istype(gunner.get_inactive_hand(),weapon)) //If they have vehicle gun in their hand(s), let's not bother.
+			qdel(weapon)
+			continue
 		gunner.put_in_hands(weapon)
 		source_vehicle.update_user_view(gunner,1)
 		spawn(1)

--- a/code/modules/halo/vehicles/vehicle_occupant.dm
+++ b/code/modules/halo/vehicles/vehicle_occupant.dm
@@ -95,8 +95,7 @@
 	return null
 
 /obj/vehicles/proc/enter_as_position(var/mob/user,var/position = "passenger",var/forced_by_faction = null)
-	if(!is_processing)
-		START_PROCESSING(SSobj,src)
+	START_PROCESSING(SSobj, src)
 	var/driver_faction = get_driver_faction()
 	var/faction_use = user.faction
 	if(forced_by_faction && forced_by_faction != "neutral")


### PR DESCRIPTION
I've tested this locally and everything, on mapspawn and non mapspawn vehicles. If specific vehicles are the issue, please relay them.
:cl: XO-11
tweak: Vehicle guns should start spawning now.
tweak: Explosions will now only give out smoke on especially large explosions. Normal gameplay should see less visual obstruction.
/:cl: