### PR TITLE
Weapon Slowdown tweaks and turret tweaks

### DIFF
--- a/code/modules/halo/weapons/M545.dm
+++ b/code/modules/halo/weapons/M545.dm
@@ -23,7 +23,9 @@
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
 		)
 	burst_delay = 1.5
-	slowdown_general = 0.5
+	slowdown_general = 0.3
+	move_delay_malus = 1.1
+	fire_delay = 5 //Slightly lower than normal.
 
 	burst = 12
 

--- a/code/modules/halo/weapons/M739.dm
+++ b/code/modules/halo/weapons/M739.dm
@@ -25,7 +25,9 @@
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',
 		slot_back_str = 'code/modules/halo/weapons/icons/Back_Weapons.dmi',
 		)
-	slowdown_general = 0.5
+	slowdown_general = 0.3
+	move_delay_malus = 1.1
+	fire_delay = 5 //Slightly lower than normal.
 
 	burst = 12
 

--- a/code/modules/halo/weapons/SRS99.dm
+++ b/code/modules/halo/weapons/SRS99.dm
@@ -33,6 +33,7 @@
 		slot_s_store_str = 'code/modules/halo/weapons/icons/Armor_Weapons.dmi',
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_icon.dmi'
+	slowdown_general = 0.3
 
 /obj/item/weapon/gun/projectile/srs99_sniper/can_use_when_prone()
 	return 1

--- a/code/modules/halo/weapons/XM98.dm
+++ b/code/modules/halo/weapons/XM98.dm
@@ -16,12 +16,12 @@
 	burst = 2
 	burst_delay = 0.9
 	one_hand_penalty = -1
-	dispersion = list(0.0,0.1,0.2,0.2)
+	dispersion = list(0.0,0.1)
 	hud_bullet_row_num = 20
 	silenced = 1
 
 	firemodes = list(\
-	list(mode_name="3 round burst",  burst=3, dispersion=list(0.0,0.1,0.2)),
+	list(mode_name="2 round burst",  burst=2, dispersion=list(0.0,0.1)),
 	list(mode_name="5 round burst",  burst=5, dispersion=list(0.5,0.5,0.6,0.6,0.8)),
 	)
 

--- a/code/modules/halo/weapons/covenant/lmg.dm
+++ b/code/modules/halo/weapons/covenant/lmg.dm
@@ -14,7 +14,9 @@
 	charge_meter = 0
 	dispersion = list(0.2, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3, 0.3, 0.4, 0.4, 0.4, 0.5)
 	w_class = ITEM_SIZE_HUGE
-	slowdown_general = 0.5
+	slowdown_general = 0.3
+	move_delay_malus = 1.1
+	fire_delay = 5 //Slightly lower than normal.
 	item_icons = list(
 		slot_l_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_left.dmi',
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/Weapon_Inhands_right.dmi',

--- a/code/modules/halo/weapons/covenant/snipers.dm
+++ b/code/modules/halo/weapons/covenant/snipers.dm
@@ -93,6 +93,8 @@
 		)
 	crosshair_file = 'code/modules/halo/weapons/icons/dragaim_icon.dmi'
 
+	slowdown_general = 0.3
+
 /obj/item/weapon/gun/energy/beam_rifle/can_use_when_prone()
 	return 1
 

--- a/code/modules/halo/weapons/flamethrowers.dm
+++ b/code/modules/halo/weapons/flamethrowers.dm
@@ -15,7 +15,6 @@
 	burst = 8
 	hud_bullet_usebar = 1
 	caliber="flamethrower"
-	fire_delay = 7
 	one_hand_penalty = 3
 	slowdown_general = 0.15
 	dispersion = list(2.5)

--- a/code/modules/halo/weapons/forerunner/snipers.dm
+++ b/code/modules/halo/weapons/forerunner/snipers.dm
@@ -33,6 +33,8 @@
 
 	scoped_accuracy = 7
 
+	slowdown_general = 0.3
+
 	item_icons = list(
 		slot_l_hand_str = 'code/modules/halo/weapons/icons/forerunner_sprites_inhand_l.dmi',
 		slot_r_hand_str = 'code/modules/halo/weapons/icons/forerunner_sprites_inhand_r.dmi',

--- a/code/modules/halo/weapons/railrifle.dm
+++ b/code/modules/halo/weapons/railrifle.dm
@@ -28,4 +28,4 @@
 	w_class = ITEM_SIZE_LARGE
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	ammo_type = /obj/item/ammo_casing/railslug
-	slowdown_general = 0.5
+	slowdown_general = 0.4

--- a/code/modules/halo/weapons/turrets/HMG.dm
+++ b/code/modules/halo/weapons/turrets/HMG.dm
@@ -18,15 +18,15 @@
 	caliber = "12.7mm"
 	magazine_type = /obj/item/ammo_magazine/HMG_boxmag
 
-	fire_delay = 5 //1 lower than normal
+	fire_delay = 4 //1 lower than normal
 	dispersion = list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45)
 
 	load_time = 7
 	//Chaingun dispersions on paced shots with worse dispersion on longburst. Higher damage, but faster firing on paced shots
 	//Than chaingun provides.
 	firemodes = list(\
-	list(mode_name="paced shots",  burst=30,burst_delay = 3,fire_delay = 5, accuracy = 0, dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45)),
-	list(mode_name="long bursts",  burst=40,burst_delay = 2,fire_delay = 7, accuracy = -1,dispersion=list(0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.55,0.55,0.6,0.6))
+	list(mode_name="paced shots",  burst=30,burst_delay = 3,fire_delay = 4, accuracy = 0, dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45)),
+	list(mode_name="long bursts",  burst=40,burst_delay = 2,fire_delay = 6, accuracy = -1,dispersion=list(0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.55,0.55,0.6,0.6))
 	)
 
 	burst = 30
@@ -40,12 +40,12 @@
 		)
 
 	move_delay_malus = 2
-	fire_delay = 8
+	fire_delay = 7
 	accuracy = -1
 
 	firemodes = list(\
-	list(mode_name="paced shots",  burst=20,burst_delay = 3,fire_delay = 8, accuracy = -1, dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45)),
-	list(mode_name="long bursts",  burst=10,burst_delay = 2,fire_delay = 10, accuracy = -2,dispersion=list(0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.55,0.55,0.6,0.6))
+	list(mode_name="paced shots",  burst=20,burst_delay = 3,fire_delay = 7, accuracy = -1, dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45)),
+	list(mode_name="long bursts",  burst=10,burst_delay = 2,fire_delay = 9, accuracy = -2,dispersion=list(0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.55,0.55,0.6,0.6))
 	)
 
 	burst = 20

--- a/code/modules/halo/weapons/turrets/ammo.dm
+++ b/code/modules/halo/weapons/turrets/ammo.dm
@@ -22,6 +22,7 @@
 
 /obj/item/projectile/bullet/hmg127_he
 	damage = 40
+	armor_penetration = 30
 
 //CHAINGUN AMMO DEFINES//
 /obj/item/ammo_magazine/chaingun_boxmag
@@ -40,6 +41,10 @@
 	multiple_sprites = 1
 
 //PLASTURRET AMMO DEFINES//
+
+/obj/item/projectile/bullet/covenant/plasmarepeater/plasturret
+	armor_penetration = 15
+
 /obj/item/ammo_magazine/plasturret_boxmag
 	name = "cell container (Type-52 Directed Energy Support Weapon)"
 	desc = "A container for cells, designed for use with the Type-52 Directed Energy Support Weapon"
@@ -60,4 +65,4 @@
 	desc = "A self-contained power cell for the Type-52 Directed Energy Support Weapon"
 	icon = 'code/modules/halo/weapons/turrets/turret_cov_casing.dmi'
 	caliber = "plas_turret_cells"
-	projectile_type = /obj/item/projectile/bullet/covenant/plasmarifle
+	projectile_type = /obj/item/projectile/bullet/covenant/plasmarepeater/plasturret

--- a/code/modules/halo/weapons/turrets/chaingun.dm
+++ b/code/modules/halo/weapons/turrets/chaingun.dm
@@ -18,15 +18,15 @@
 	caliber = "a762"
 	magazine_type = /obj/item/ammo_magazine/chaingun_boxmag
 
-	fire_delay = 5 //1 lower than normal
+	fire_delay = 4 //1 lower than normal
 	accuracy = -1
 	dispersion = list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)
 
 	load_time = 5
 
 	firemodes = list(\
-	list(mode_name="long bursts",  burst=50,burst_delay = 1,fire_delay = 5, accuracy = -1,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
-	list(mode_name="paced shots",  burst=25,burst_delay = 4,fire_delay = 7, accuracy = 0,dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45))
+	list(mode_name="long bursts",  burst=50,burst_delay = 1,fire_delay = 4, accuracy = -1,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
+	list(mode_name="paced shots",  burst=25,burst_delay = 4,fire_delay = 6, accuracy = 0,dispersion=list(0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.4,0.4,0.4,0.4,0.45))
 	)
 
 	burst = 50
@@ -40,12 +40,12 @@
 		)
 
 	move_delay_malus = 2
-	fire_delay = 8
+	fire_delay = 7
 	accuracy = -2
 	//Accuracy drops by -1 on both modes.
 	firemodes = list(\
-	list(mode_name="long bursts",  burst=30,burst_delay = 1,fire_delay = 8, accuracy = -2,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
-	list(mode_name="paced shots",  burst=12,burst_delay = 4,fire_delay = 10, accuracy = -1,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
+	list(mode_name="long bursts",  burst=30,burst_delay = 1,fire_delay = 7, accuracy = -2,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
+	list(mode_name="paced shots",  burst=12,burst_delay = 4,fire_delay = 9, accuracy = -1,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
 	)
 
 	burst = 30

--- a/code/modules/halo/weapons/turrets/plas_turret.dm
+++ b/code/modules/halo/weapons/turrets/plas_turret.dm
@@ -29,14 +29,14 @@
 
 	//burst = 10
 	//burst_delay = 2
-	fire_delay = 5
+	fire_delay = 4
 	dispersion = list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)
 
 	load_time = 5
 	//No acc penalty on long bursts for this, but it's still using chaingun dispersion for both modes.
 	firemodes = list(\
-	list(mode_name="long bursts",  burst=50,burst_delay = 1,fire_delay = 5, accuracy = 0,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
-	list(mode_name="paced shots",  burst=25,burst_delay = 4,fire_delay = 7, accuracy = 0,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
+	list(mode_name="long bursts",  burst=50,burst_delay = 1,fire_delay = 4, accuracy = 0,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
+	list(mode_name="paced shots",  burst=25,burst_delay = 4,fire_delay = 6, accuracy = 0,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
 	)
 
 	burst = 30
@@ -50,12 +50,12 @@
 		)
 
 	move_delay_malus = 2
-	fire_delay = 8
+	fire_delay = 7
 	accuracy = -2
 
 	firemodes = list(\
-	list(mode_name="long bursts",  burst=15,burst_delay = 1,fire_delay = 8, accuracy = -1,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
-	list(mode_name="paced shots",  burst=12,burst_delay = 4,fire_delay = 10, accuracy = -1,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
+	list(mode_name="long bursts",  burst=15,burst_delay = 1,fire_delay = 7, accuracy = -1,dispersion=list(0.2,0.2,0.2,0.3,0.3,0.4,0.4,0.5,0.5,0.5,0.5,0.55)),
+	list(mode_name="paced shots",  burst=12,burst_delay = 4,fire_delay = 9, accuracy = -1,dispersion=list(0.0,0.0,0.1,0.1,0.1,0.2,0.2,0.3,0.3,0.3,0.3,0.35))
 	)
 
 

--- a/code/modules/halo/weapons/turrets/turret.dm
+++ b/code/modules/halo/weapons/turrets/turret.dm
@@ -22,9 +22,9 @@
 	var/obj/item/weapon/gun/projectile/turret_gun = /obj/item/weapon/gun/projectile/turret //The "gun" the turret uses to fire.
 	var/obj/stand = /obj/structure/bipod //The object reference to the object to replace with when the gun is removed.
 	var/remove_time = 5 //The time it takes to rip the gun off the stand, in seconds. Quarter this is pack-up time.
-	var/bullet_deflect_chance = 75
-	var/bullet_deflect_chance_max = 75 //The chance the gun has to reflect projectiles, from the sides
-	var/bullet_deflect_chance_min = 30
+	var/bullet_deflect_chance = 75 //The chance the gun has to deflect (cause-no-damage-to-user) projectiles.
+	var/bullet_deflect_chance_max = 75
+	var/bullet_deflect_chance_min = 35
 	var/armor_pen_divisor = 2 //Used when calculating how much armor pen is converted into extra damage to the deflect chance.
 	var/bullet_deflect_chance_reset_time = 4 SECONDS //How long it takes until the game fully resets the deflect chance.
 	var/bullet_deflect_reset_at = 0


### PR DESCRIPTION
🆑 XO-11
tweak: Emplacement turrets now have a lower fire delay between bursts.
tweak: HMGs now have AP, as do Plasturrets.
tweak: LMGs now have a lower overall slowdown, but higher slowdown when firing. Theyre still overall slightly faster than before.
/:cl: