### PR TITLE
Vehicle tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -142,9 +142,10 @@
 #define ARMOR_BLOCK_CHANCE_MULT 1.0
 
 // Special return values from bullet_act(). Positive return values are already used to indicate the blocked level of the projectile.
-#define PROJECTILE_CONTINUE   -1 //if the projectile should continue flying after calling bullet_act()
-#define PROJECTILE_FORCE_MISS -2 //if the projectile should treat the attack as a miss (suppresses attack and admin logs) - only applies to mobs.
-#define PROJECTILE_ABSORB -3	 //if the projectile should not continue processing and silently delete
+#define PROJECTILE_CONTINUE   -1		//if the projectile should continue flying after calling bullet_act()
+#define PROJECTILE_FORCE_MISS -2		//if the projectile should treat the attack as a miss (suppresses attack and admin logs) - only applies to mobs.
+#define PROJECTILE_ABSORB -3			//if the projectile should not continue processing and silently delete
+#define PROJECTILE_CONTINUE_NODAMAGE -4	//If the projectile should continue flying after calling bullet_act() and also do no damage.
 
 //Camera capture modes
 #define CAPTURE_MODE_REGULAR 0 //Regular polaroid camera mode

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -15,7 +15,11 @@
 	ai_access_level = 1
 
 /obj/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	switch(is_processing)
+		if("SSobj")
+			STOP_PROCESSING(SSobj, src)
+		if("SSprojectiles")
+			STOP_PROCESSING(SSprojectiles, src)
 	return ..()
 
 /obj/Topic(href, href_list, var/datum/topic_state/state = GLOB.default_state)

--- a/code/modules/halo/misc/atom_despawner.dm
+++ b/code/modules/halo/misc/atom_despawner.dm
@@ -48,11 +48,11 @@ var/global/datum/controller/process/atom_despawner/atom_despawner = new
 	//check if its time to despawn
 	if(world.time > spawn_time + atom_timeout)
 
+		cleanables -= target
 		//if we're being carried, dont bother cleaning us
 		var/mob/M = target.loc
 		if(!istype(M))
 			qdel(target)
-		cleanables -= target
 
 /datum/controller/process/atom_despawner/proc/mark_for_despawn(var/atom/movable/AM)
 	. = 0

--- a/code/modules/halo/vehicles/__defs.dm
+++ b/code/modules/halo/vehicles/__defs.dm
@@ -5,7 +5,7 @@
 #define ITEM_SIZE_VEHICLE 8
 #define ITEM_SIZE_VEHICLE_LARGE 9
 
-#define VEHICLE_ACCBOOST_SMALL 0 //Small or nimble craft. eg Ghost. Mongoose
+#define VEHICLE_ACCBOOST_SMALL 1 //Small or nimble craft. Originally for mongeese but their single tile nature makes them pretty evasive already.
 #define VEHICLE_ACCBOOST_STANDARD 2 //Most vehicles. eg. Warthog
 #define VEHICLE_ACCBOOST_LARGE 4 //Slow and unevasive vehicles. eg. Scorpion. Dropships
 #define VEHICLE_ACCBOOST_VERY_LARGE 6

--- a/code/modules/halo/vehicles/__defs.dm
+++ b/code/modules/halo/vehicles/__defs.dm
@@ -5,9 +5,9 @@
 #define ITEM_SIZE_VEHICLE 8
 #define ITEM_SIZE_VEHICLE_LARGE 9
 
-#define VEHICLE_ACCBOOST_SMALL 1 //Small or nimble craft. Originally for mongeese but their single tile nature makes them pretty evasive already.
-#define VEHICLE_ACCBOOST_STANDARD 2 //Most vehicles. eg. Warthog
-#define VEHICLE_ACCBOOST_LARGE 4 //Slow and unevasive vehicles. eg. Scorpion. Dropships
+#define VEHICLE_ACCBOOST_SMALL 0 //Small or nimble craft. Originally for mongeese but their single tile nature makes them pretty evasive already.
+#define VEHICLE_ACCBOOST_STANDARD 1 //Most vehicles. eg. Warthog
+#define VEHICLE_ACCBOOST_LARGE 3 //Slow and unevasive vehicles. eg. Scorpion. Dropships
 #define VEHICLE_ACCBOOST_VERY_LARGE 6
 
 #define BASE_VEHICLE_DEATH_EXPLODE_DAMAGE 35

--- a/code/modules/halo/vehicles/__defs.dm
+++ b/code/modules/halo/vehicles/__defs.dm
@@ -4,5 +4,11 @@
 #define ITEM_SIZE_VEHICLE_SMALL 7
 #define ITEM_SIZE_VEHICLE 8
 #define ITEM_SIZE_VEHICLE_LARGE 9
+
+#define VEHICLE_ACCBOOST_SMALL 0 //Small or nimble craft. eg Ghost. Mongoose
+#define VEHICLE_ACCBOOST_STANDARD 2 //Most vehicles. eg. Warthog
+#define VEHICLE_ACCBOOST_LARGE 4 //Slow and unevasive vehicles. eg. Scorpion. Dropships
+#define VEHICLE_ACCBOOST_VERY_LARGE 6
+
 #define BASE_VEHICLE_DEATH_EXPLODE_DAMAGE 35
 #define LIST_OVERRUN_COLLIDE_DESTROY list(/obj/structure/destructible/steel_barricade,/obj/structure/destructible/plasteel_barricade,/obj/structure/destructible/marine_barricade,/obj/structure/destructible/covenant_barricade,/obj/structure/destructible/explosion_debris,/obj/structure/energybarricade)

--- a/code/modules/halo/vehicles/types/SOEIV.dm
+++ b/code/modules/halo/vehicles/types/SOEIV.dm
@@ -6,6 +6,8 @@
 
 	light_color = "#E1FDFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 /obj/vehicles/drop_pod/overmap/SOEIV
 	name = "SOEIV"
 	desc = "Single Occupant Exoatmospheric Insertion Vehice, also known as a drop pod."
@@ -13,3 +15,5 @@
 	icon_state = "SOEIV"
 
 	light_color = "#E1FDFF"
+
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL

--- a/code/modules/halo/vehicles/types/banshee.dm
+++ b/code/modules/halo/vehicles/types/banshee.dm
@@ -37,7 +37,7 @@
 
 /obj/item/vehicle_component/health_manager/banshee
 	integrity = 400
-	resistances = list("bullet"=60,"energy"=60,"emp"=40,"bomb"=65)
+	resistances = list("bullet"=70,"energy"=70,"emp"=40,"bomb"=65)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/banshee

--- a/code/modules/halo/vehicles/types/boarding_pod.dm
+++ b/code/modules/halo/vehicles/types/boarding_pod.dm
@@ -18,7 +18,7 @@
 
 /obj/item/vehicle_component/health_manager/drop_pod/reinforced
 	integrity = 300
-	resistances = list("bullet"= 50,"energy"= 50,"emp"= 25,"bomb" = 50)
+	resistances = list("bullet"= 60,"energy"= 60,"emp"= 25,"bomb" = 50)
 
 /obj/vehicles/drop_pod/overmap/boarding_pod/update_object_sprites()
 	//Enclosed, we don't need to care about the person-sprites.

--- a/code/modules/halo/vehicles/types/bull.dm
+++ b/code/modules/halo/vehicles/types/bull.dm
@@ -48,7 +48,7 @@
 
 /obj/item/vehicle_component/health_manager/bull
 	integrity = 500
-	resistances = list("bullet"=80,"energy"=80,"emp"=30,"bomb"=45)
+	resistances = list("bullet"=90,"energy"=90,"emp"=30,"bomb"=45)
 
 /datum/component_profile/bull
 	pos_to_check = "gunner"

--- a/code/modules/halo/vehicles/types/cobra.dm
+++ b/code/modules/halo/vehicles/types/cobra.dm
@@ -129,18 +129,18 @@
 	name = "Cobra Cannon"
 	desc = "Twin linked railguns."
 
-	fire_delay = 2 SECONDS
+	fire_delay = 10
 	fire_sound = 'code/modules/halo/sounds/scorp_cannon_fire.ogg'
 
 	burst = 2
-	burst_delay = 0.5 SECONDS
+	burst_delay = 5
 	magazine_type = /obj/item/ammo_magazine/cobra_cannon
 
 /obj/item/weapon/gun/vehicle_turret/cobra_sniper
 	name = "Cobra Sniper Cannon"
 	desc = "Railgun single fire mode, heavy anti armour."
 
-	fire_delay = 35
+	fire_delay = 30
 	fire_sound = 'code/modules/halo/sounds/scorp_cannon_fire.ogg'
 
 	burst = 1

--- a/code/modules/halo/vehicles/types/cobra.dm
+++ b/code/modules/halo/vehicles/types/cobra.dm
@@ -117,7 +117,7 @@
 
 /obj/item/vehicle_component/health_manager/cobra
 	integrity = 500
-	resistances = list("bullet"=75,"energy"=75,"emp"=25,"bomb"=70)
+	resistances = list("bullet"=85,"energy"=75,"emp"=25,"bomb"=70)
 	repair_materials = list("plasteel")
 
 /datum/component_profile/cobra

--- a/code/modules/halo/vehicles/types/drop_pod.dm
+++ b/code/modules/halo/vehicles/types/drop_pod.dm
@@ -19,6 +19,8 @@
 
 	exposed_positions = list()
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 	can_smoke = 1
 	smoke_ammo = 1
 	smoke_ammo_max = 1

--- a/code/modules/halo/vehicles/types/drop_pod.dm
+++ b/code/modules/halo/vehicles/types/drop_pod.dm
@@ -251,7 +251,7 @@
 
 /obj/item/vehicle_component/health_manager/drop_pod
 	integrity = 200
-	resistances = list("bullet"= 25,"energy"= 25,"emp"= 25,"bomb" = 25)		//very little armour
+	resistances = list("bullet"= 35,"energy"= 35,"emp"= 25,"bomb" = 25)		//very little armour
 
 /obj/structure/drop_pod_launchbay
 	name = "Drop Pod Launch Bay"

--- a/code/modules/halo/vehicles/types/drop_pod_covenant.dm
+++ b/code/modules/halo/vehicles/types/drop_pod_covenant.dm
@@ -6,6 +6,8 @@
 	icon_state = "cov_pod"
 	faction_tag = "Covenant"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 /obj/structure/drop_pod_launchbay/covenant
 	icon = 'code/modules/halo/vehicles/types/drop_pod_covenant.dmi'
 	icon_state = "cov_bay"

--- a/code/modules/halo/vehicles/types/drop_pod_covenant.dm
+++ b/code/modules/halo/vehicles/types/drop_pod_covenant.dm
@@ -6,8 +6,6 @@
 	icon_state = "cov_pod"
 	faction_tag = "Covenant"
 
-	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
-
 /obj/structure/drop_pod_launchbay/covenant
 	icon = 'code/modules/halo/vehicles/types/drop_pod_covenant.dmi'
 	icon_state = "cov_bay"

--- a/code/modules/halo/vehicles/types/escape_pelican.dm
+++ b/code/modules/halo/vehicles/types/escape_pelican.dm
@@ -8,6 +8,8 @@
 
 	occupants = list(2,0)
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	bound_height = 128
 	bound_width = 128
 

--- a/code/modules/halo/vehicles/types/ghost.dm
+++ b/code/modules/halo/vehicles/types/ghost.dm
@@ -28,8 +28,6 @@
 
 	light_color = "#C1CEFF"
 
-	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
-
 	can_smoke = 1
 	smoke_ammo = 1
 	smoke_ammo_max = 1
@@ -73,7 +71,7 @@
 
 	fire_sound = 'code/modules/halo/sounds/plasrifle3burst.ogg'
 	burst_delay = 2
-	fire_delay = 15
+	fire_delay = 7
 
 	burst = 8
 	dispersion = list(0.15,0.3,0.45,0.5,0.55)

--- a/code/modules/halo/vehicles/types/ghost.dm
+++ b/code/modules/halo/vehicles/types/ghost.dm
@@ -28,6 +28,8 @@
 
 	light_color = "#C1CEFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 	can_smoke = 1
 	smoke_ammo = 1
 	smoke_ammo_max = 1

--- a/code/modules/halo/vehicles/types/ghost.dm
+++ b/code/modules/halo/vehicles/types/ghost.dm
@@ -56,7 +56,7 @@
 
 /obj/item/vehicle_component/health_manager/ghost
 	integrity = 350
-	resistances = list("bullet"=65,"energy"=65,"emp"=15,"bomb" = 0)
+	resistances = list("bullet"=75,"energy"=75,"emp"=15,"bomb" = 0)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/ghost

--- a/code/modules/halo/vehicles/types/goblin.dm
+++ b/code/modules/halo/vehicles/types/goblin.dm
@@ -55,7 +55,7 @@
 
 /obj/item/vehicle_component/health_manager/goblin
 	integrity = 500
-	resistances = list("bullet"=65,"energy"=65,"emp"=25,"bomb"=45)
+	resistances = list("bullet"=75,"energy"=75,"emp"=25,"bomb"=45)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/goblin

--- a/code/modules/halo/vehicles/types/hrunting.dm
+++ b/code/modules/halo/vehicles/types/hrunting.dm
@@ -42,7 +42,7 @@
 
 /obj/item/vehicle_component/health_manager/hrunting
 	integrity = 500
-	resistances = list("bullet"=65,"energy"=65,"emp"=25,"bomb"=45)
+	resistances = list("bullet"=75,"energy"=75,"emp"=25,"bomb"=45)
 	repair_materials = list("plasteel")
 
 /datum/component_profile/hrunting

--- a/code/modules/halo/vehicles/types/mongoose.dm
+++ b/code/modules/halo/vehicles/types/mongoose.dm
@@ -23,6 +23,8 @@
 
 	light_color = "#E1FDFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 	can_smoke = 1
 	smoke_ammo = 3
 	smoke_ammo_max = 3

--- a/code/modules/halo/vehicles/types/mongoose.dm
+++ b/code/modules/halo/vehicles/types/mongoose.dm
@@ -65,7 +65,7 @@
 //Mongoose component profile define//
 /obj/item/vehicle_component/health_manager/mongoose
 	integrity = 300
-	resistances = list("bullet"=50,"energy"=50,"emp"=15,"bomb" = 0)
+	resistances = list("bullet"=60,"energy"=60,"emp"=15,"bomb" = 0)
 
 /datum/component_profile/mongoose
 	vital_components = newlist(/obj/item/vehicle_component/health_manager/mongoose)

--- a/code/modules/halo/vehicles/types/pelican.dm
+++ b/code/modules/halo/vehicles/types/pelican.dm
@@ -47,7 +47,7 @@
 //Pelican component profile define//
 /obj/item/vehicle_component/health_manager/pelican
 	integrity = 600
-	resistances = list("bullet"=70,"energy"=70,"emp"=50,"bomb" = 60)
+	resistances = list("bullet"=80,"energy"=80,"emp"=50,"bomb" = 60)
 
 /datum/component_profile/pelican
 	pos_to_check = "driver"

--- a/code/modules/halo/vehicles/types/pelican.dm
+++ b/code/modules/halo/vehicles/types/pelican.dm
@@ -29,6 +29,8 @@
 
 	light_color = "#E1FDFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	can_smoke = 1
 	smoke_ammo = 10
 	smoke_ammo_max = 10

--- a/code/modules/halo/vehicles/types/phantom_dropship.dm
+++ b/code/modules/halo/vehicles/types/phantom_dropship.dm
@@ -56,7 +56,7 @@
 
 /obj/item/vehicle_component/health_manager/phantom
 	integrity = 600
-	resistances = list("bullet"=70,"energy"=70,"emp"=50,"bomb"=60)
+	resistances = list("bullet"=80,"energy"=80,"emp"=50,"bomb"=60)
 	repair_materials = list("nanolaminate")
 
 

--- a/code/modules/halo/vehicles/types/phantom_dropship.dm
+++ b/code/modules/halo/vehicles/types/phantom_dropship.dm
@@ -36,6 +36,8 @@
 
 	light_color = "#C1CEFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	can_smoke = 1
 	smoke_ammo = 10
 	smoke_ammo_max = 10

--- a/code/modules/halo/vehicles/types/prophet_chair.dm
+++ b/code/modules/halo/vehicles/types/prophet_chair.dm
@@ -50,7 +50,7 @@
 
 /obj/item/vehicle_component/health_manager/throne
 	integrity = 500
-	resistances = list("bullet"=70,"energy"=70,"emp"=15,"bomb" = 0)
+	resistances = list("bullet"=80,"energy"=80,"emp"=15,"bomb" = 0)
 
 /datum/component_profile/throne
 	gunner_weapons = list()

--- a/code/modules/halo/vehicles/types/prophet_chair.dm
+++ b/code/modules/halo/vehicles/types/prophet_chair.dm
@@ -30,6 +30,8 @@
 
 	light_color = "#C1CEFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_SMALL
+
 /obj/vehicles/prophet_throne/update_object_sprites()
 	overlays.Cut()
 	var/list/offsets_to_use = sprite_offsets["[dir]"]

--- a/code/modules/halo/vehicles/types/scorpion.dm
+++ b/code/modules/halo/vehicles/types/scorpion.dm
@@ -79,7 +79,7 @@
 	burst_size = 10
 	burst_delay = 1
 	dispersion = list(0.55)
-	fire_delay = 8
+	fire_delay = 7
 	fire_sound = 'code/modules/halo/sounds/scorp_machinegun_fire.ogg'
 	mag_used = /obj/item/ammo_magazine/scorp_coax
 

--- a/code/modules/halo/vehicles/types/scorpion.dm
+++ b/code/modules/halo/vehicles/types/scorpion.dm
@@ -27,6 +27,8 @@
 
 	light_color = "#E1FDFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	can_smoke = 1
 	smoke_ammo = 5
 	smoke_ammo_max = 5

--- a/code/modules/halo/vehicles/types/scorpion.dm
+++ b/code/modules/halo/vehicles/types/scorpion.dm
@@ -41,7 +41,7 @@
 
 /obj/item/vehicle_component/health_manager/scorpion
 	integrity = 750
-	resistances = list("bullet"=85,"energy"=85,"emp"=40,"bomb"=40)
+	resistances = list("bullet"=95,"energy"=95,"emp"=40,"bomb"=40)
 	repair_materials = list("plasteel")
 
 /datum/component_profile/scorpion

--- a/code/modules/halo/vehicles/types/shadow.dm
+++ b/code/modules/halo/vehicles/types/shadow.dm
@@ -61,7 +61,7 @@
 	name = "Shadow Cannon"
 	desc = "A fast firing plasma weapon capable of inflicting heavy damage."
 
-	fire_delay = 8
+	fire_delay = 5
 	fire_sound = 'code/modules/halo/sounds/shadow_cannon_fire.ogg'
 
 	dispersion = list(0.15,0.3,0.45,0.5,0.55)

--- a/code/modules/halo/vehicles/types/shadow.dm
+++ b/code/modules/halo/vehicles/types/shadow.dm
@@ -49,7 +49,7 @@
 
 /obj/item/vehicle_component/health_manager/shadow
 	integrity = 650
-	resistances = list("bullet"=65,"energy"=65,"emp"=20,"bomb"=45)
+	resistances = list("bullet"=75,"energy"=75,"emp"=20,"bomb"=45)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/shadow

--- a/code/modules/halo/vehicles/types/sparrowhawk.dm
+++ b/code/modules/halo/vehicles/types/sparrowhawk.dm
@@ -35,7 +35,7 @@
 
 /obj/item/vehicle_component/health_manager/sparrowhawk
 	integrity = 400
-	resistances = list("bullet"=60,"energy"=60,"emp"=40,"bomb"=65)
+	resistances = list("bullet"=70,"energy"=70,"emp"=40,"bomb"=65)
 
 /datum/component_profile/sparrowhawk
 	pos_to_check = "driver"

--- a/code/modules/halo/vehicles/types/spirit_dropship.dm
+++ b/code/modules/halo/vehicles/types/spirit_dropship.dm
@@ -30,6 +30,8 @@
 
 	light_color = "#C1CEFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	can_smoke = 1
 	smoke_ammo = 10
 	smoke_ammo_max = 10

--- a/code/modules/halo/vehicles/types/spirit_dropship.dm
+++ b/code/modules/halo/vehicles/types/spirit_dropship.dm
@@ -57,7 +57,7 @@
 //Pelican component profile define//
 /obj/item/vehicle_component/health_manager/spirit
 	integrity = 600
-	resistances = list("bullet"=70,"energy"=70,"emp"=50,"bomb"=60)
+	resistances = list("bullet"=80,"energy"=80,"emp"=50,"bomb"=60)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/spirit

--- a/code/modules/halo/vehicles/types/warthog.dm
+++ b/code/modules/halo/vehicles/types/warthog.dm
@@ -43,7 +43,7 @@
 
 /obj/item/vehicle_component/health_manager/warthog
 	integrity = 500
-	resistances = list("bullet"=65,"energy"=65,"emp"=25,"bomb"=45)
+	resistances = list("bullet"=75,"energy"=75,"emp"=25,"bomb"=45)
 
 /datum/component_profile/warthog
 	pos_to_check = "gunner"

--- a/code/modules/halo/vehicles/types/warthog.dm
+++ b/code/modules/halo/vehicles/types/warthog.dm
@@ -66,6 +66,7 @@
 
 	burst = 15
 	burst_delay = 1.75
+	fire_delay = 5
 
 	magazine_type = /obj/item/ammo_magazine/warthog_mag
 

--- a/code/modules/halo/vehicles/types/wraith.dm
+++ b/code/modules/halo/vehicles/types/wraith.dm
@@ -27,6 +27,8 @@
 
 	light_color = "#C1CEFF"
 
+	passive_tohit_boost = VEHICLE_ACCBOOST_LARGE
+
 	can_smoke = 1
 	smoke_ammo = 5
 	smoke_ammo_max = 5

--- a/code/modules/halo/vehicles/types/wraith.dm
+++ b/code/modules/halo/vehicles/types/wraith.dm
@@ -74,8 +74,8 @@
 	desc = "A short burst, mounted Plasma Rifle, used for anti-infantry purposes."
 	burst_size = 10
 	burst_delay = 1
+	fire_delay = 7
 	dispersion = list(0.55)
-	fire_delay = 8
 	fire_sound = 'code/modules/halo/sounds/plasrifle3burst.ogg'
 	mag_used = /obj/item/ammo_magazine/wraith_coax
 

--- a/code/modules/halo/vehicles/types/wraith.dm
+++ b/code/modules/halo/vehicles/types/wraith.dm
@@ -41,7 +41,7 @@
 
 /obj/item/vehicle_component/health_manager/wraith
 	integrity = 750
-	resistances = list("bullet"=85,"energy"=85,"emp"=40,"bomb"=50)
+	resistances = list("bullet"=95,"energy"=95,"emp"=40,"bomb"=50)
 	repair_materials = list("nanolaminate")
 
 /datum/component_profile/wraith

--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -38,7 +38,8 @@
 		else if(prob(100 - max_comp_coverage))
 			comp_to_dam = pick(vital_components)
 	var/comp_resistance = comp_to_dam.get_resistance_for(proj_damtype)/100
-	comp_to_dam.damage_integrity(proj_damage*(1 - comp_resistance))
+	//This is intentionally Floor() and not Round(). They're vehicles, we'll give them the upside here. Round down. always.
+	comp_to_dam.damage_integrity(Floor(proj_damage*(1 - comp_resistance)))
 
 /datum/component_profile/proc/take_comp_explosion_dam(var/ex_severity)
 	var/max_comp_coverage = get_coverage_sum()

--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -27,7 +27,7 @@
 		coverage_sum += component.coverage * (component.integrity/initial(component.integrity))
 	return coverage_sum
 
-/datum/component_profile/proc/take_component_damage(var/proj_damage,var/proj_damtype)
+/datum/component_profile/proc/take_component_damage(var/proj_damage=0,var/proj_damtype="bullet",var/proj_ap=0)
 	var/max_comp_coverage = get_coverage_sum()
 	var/obj/item/vehicle_component/comp_to_dam
 	if(!components || !components.len)
@@ -37,7 +37,7 @@
 			comp_to_dam = pick(components)
 		else if(prob(100 - max_comp_coverage))
 			comp_to_dam = pick(vital_components)
-	var/comp_resistance = comp_to_dam.get_resistance_for(proj_damtype)/100
+	var/comp_resistance = (comp_to_dam.get_resistance_for(proj_damtype)-proj_ap)/100
 	//This is intentionally Floor() and not Round(). They're vehicles, we'll give them the upside here. Round down. always.
 	comp_to_dam.damage_integrity(Floor(proj_damage*(1 - comp_resistance)))
 

--- a/code/modules/halo/vehicles/vehicle_component_profiles.dm
+++ b/code/modules/halo/vehicles/vehicle_component_profiles.dm
@@ -37,7 +37,9 @@
 			comp_to_dam = pick(components)
 		else if(prob(100 - max_comp_coverage))
 			comp_to_dam = pick(vital_components)
-	var/comp_resistance = (comp_to_dam.get_resistance_for(proj_damtype)-proj_ap)/100
+	var/comp_resistance = max(comp_to_dam.get_resistance_for(proj_damtype)-proj_ap,0)
+	if(comp_resistance > 0)
+		comp_resistance /= 100
 	//This is intentionally Floor() and not Round(). They're vehicles, we'll give them the upside here. Round down. always.
 	comp_to_dam.damage_integrity(Floor(proj_damage*(1 - comp_resistance)))
 

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -573,7 +573,7 @@
 	var/distance = get_dist(P.starting,P.loc)
 	var/miss_modifier = passive_tohit_boost
 	miss_modifier = max(PROJECTILE_MISS_CHANCE_PERTILE*(distance-PROJECTILE_MISS_CHANCE_DIST_REDUCTION) - round(PROJECTILE_MISS_CHANCE_PERTILE*P.accuracy) + miss_modifier, 0)
-	if(prob(round(miss_modifier * 1.3,1))) //We're mimicking normal hit chances, which have a 30% chance to hit a random limb when they miss. We don't have limbs, so we just improve the hit chance.
+	if(round(miss_modifier))
 		visible_message("<span class='notice'>\The [P] misses [src] narrowly!</span>")
 		return PROJECTILE_CONTINUE_NODAMAGE
 

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -11,6 +11,7 @@
 	var/movement_destroyed = 0
 	var/block_enter_exit //Set this to block entering/exiting.
 	var/can_traverse_zs = 0
+	var/passive_tohit_boost = VEHICLE_ACCBOOST_STANDARD//This is the boost people get to acc when hitting this vehicle.
 
 	var/next_move_input_at = 0//When can we send our next movement input?
 	var/moving_x = 0
@@ -569,6 +570,13 @@
 				playsound(loc,move_sound,75,0,4)
 
 /obj/vehicles/bullet_act(var/obj/item/projectile/P, var/def_zone)
+	var/distance = get_dist(P.starting,P.loc)
+	var/miss_modifier = passive_tohit_boost
+	miss_modifier = max(PROJECTILE_MISS_CHANCE_PERTILE*(distance-PROJECTILE_MISS_CHANCE_DIST_REDUCTION) - round(PROJECTILE_MISS_CHANCE_PERTILE*P.accuracy) + miss_modifier, 0)
+	if(prob(round(miss_modifier * 1.3,1))) //We're mimicking normal hit chances, which have a 30% chance to hit a random limb when they miss. We don't have limbs, so we just improve the hit chance.
+		visible_message("<span class='notice'>\The [P] misses [src] narrowly!</span>")
+		return PROJECTILE_CONTINUE_NODAMAGE
+
 	var/pos_to_dam = should_damage_occ()
 	var/mob/mob_to_dam
 	if(movement_destroyed)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -593,7 +593,7 @@
 		var/should_continue = damage_occupant(pos_to_dam,P)
 		if(!should_continue)
 			return
-	comp_prof.take_component_damage(P.get_structure_damage(),P.check_armour)
+	comp_prof.take_component_damage(P.get_structure_damage(),P.check_armour,P.armor_penetration)
 	visible_message("<span class = 'danger'>[P] hits [src]!</span>")
 
 /obj/vehicles/ex_act(var/severity)

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -570,11 +570,10 @@
 				playsound(loc,move_sound,75,0,4)
 
 /obj/vehicles/bullet_act(var/obj/item/projectile/P, var/def_zone)
-	var/distance = get_dist(P.starting,P.loc)
+	var/distance = get_dist(P.starting,loc)
 	var/miss_modifier = max(PROJECTILE_MISS_CHANCE_PERTILE*(distance-PROJECTILE_MISS_CHANCE_DIST_REDUCTION) - round(PROJECTILE_MISS_CHANCE_PERTILE*(P.accuracy+passive_tohit_boost)), 0)
-	miss_modifier = round(miss_modifier * 0.7,1)
-	log_debug("Miss Mod:[miss_modifier]")
-	if(prob(miss_modifier))  //The x0.7 is replicating the 30% chance to hit a random limb in mob-targeting.
+	miss_modifier = round(miss_modifier * 0.7,1) //The x0.7 is replicating the 30% chance to hit a random limb in mob-targeting.
+	if(prob(miss_modifier))
 		visible_message("<span class='notice'>\The [P] misses [src] narrowly!</span>")
 		return PROJECTILE_CONTINUE_NODAMAGE
 

--- a/code/modules/halo/vehicles/vehiclebase.dm
+++ b/code/modules/halo/vehicles/vehiclebase.dm
@@ -571,9 +571,10 @@
 
 /obj/vehicles/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	var/distance = get_dist(P.starting,P.loc)
-	var/miss_modifier = passive_tohit_boost
-	miss_modifier = max(PROJECTILE_MISS_CHANCE_PERTILE*(distance-PROJECTILE_MISS_CHANCE_DIST_REDUCTION) - round(PROJECTILE_MISS_CHANCE_PERTILE*P.accuracy) + miss_modifier, 0)
-	if(round(miss_modifier))
+	var/miss_modifier = max(PROJECTILE_MISS_CHANCE_PERTILE*(distance-PROJECTILE_MISS_CHANCE_DIST_REDUCTION) - round(PROJECTILE_MISS_CHANCE_PERTILE*(P.accuracy+passive_tohit_boost)), 0)
+	miss_modifier = round(miss_modifier * 0.7,1)
+	log_debug("Miss Mod:[miss_modifier]")
+	if(prob(miss_modifier))  //The x0.7 is replicating the 30% chance to hit a random limb in mob-targeting.
 		visible_message("<span class='notice'>\The [P] misses [src] narrowly!</span>")
 		return PROJECTILE_CONTINUE_NODAMAGE
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -302,7 +302,12 @@
 		else
 			passthrough = 1 //so ghosts don't stop bullets
 	else
-		passthrough = (A.bullet_act(src, def_zone) == PROJECTILE_CONTINUE) //backwards compatibility
+		var/bulRet = A.bullet_act(src, def_zone)
+		if(bulRet == PROJECTILE_CONTINUE_NODAMAGE)
+			permutated.Add(A)
+			return 0
+		else
+			passthrough = (bulRet == PROJECTILE_CONTINUE) //backwards compatibility
 		if(isturf(A))
 			for(var/obj/O in A)
 				O.bullet_act(src)


### PR DESCRIPTION
🆑 XO-11
rscadd: Vehicles can now be missed by projectiles in the same way mobs can. Smaller vehicles act just like mobs whilst bigger or slower vehicles are easier to hit Scorp is easier to hit than a hog, which is easier than a mongoose.
tweak: Many vehicle mounted guns have had their fire delays tweaked slightly.
tweak: All vehicles have had their bullet and energy weapon armour upped. Bomb has stayed the same.
tweak: Vehicle armour reduction is now reduced by weapon AP.
/:cl: