### PR TITLE
minor hyperzine nerf

### DIFF
--- a/code/modules/halo/chemicals/medicine.dm
+++ b/code/modules/halo/chemicals/medicine.dm
@@ -173,7 +173,7 @@
 
 /datum/reagent/hyperzine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(0.5)
-	M.add_chemical_effect_diminishing(CE_SLOWREMOVE, 1,dose,metabolism)
+	M.add_chemical_effect_diminishing(CE_SLOWREMOVE, 0.5,dose,metabolism)
 	M.add_chemical_effect(CE_PULSE, 2)
 
 /datum/reagent/hyperzine_concentrated


### PR DESCRIPTION
:cl: XO-11
tweak: Intelligence reports have noted a marked reduction in the effective of the Hyperzine light stimulant, likely due to overuse.
/:cl: