### PR TITLE
Alt-Title Radio Speech Size Fix

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -213,9 +213,9 @@
 
 	//Shifted up for rank-check reasons.
 	var/datum/job/speaker_job
+	speaker_job = job_master.GetJob(speaker.mind.assigned_role)
 	if(rank_text)
 		speaker_name += " ([rank_text])"
-		speaker_job = job_master.GetJob("[rank_text]")
 
 	var/speech_size = 100
 	var/faction_speech = 1 //Does this speech-size only apply to our own faction?


### PR DESCRIPTION
Instead of using the getjob proc which IS affected by alt-titles, it instead opts to immediately go to the player's assigned role, which is not affected by alt-titles. 
now alt-titles can finally have funny large speech...

:cl: nameacow
tweak: Fixed some code regarding radio speech size, now alt titles are functional with the system.
/:cl:
