### PR TITLE
Alt-Title Speech Size Fix^2

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -216,12 +216,15 @@
 	speaker_job = job_master.GetJob(speaker.mind.assigned_role)
 	if(rank_text)
 		speaker_name += " ([rank_text])"
+		speaker_job = job_master.GetJob("[rank_text]")
 
+	var/datum/job/speaker_role
+	speaker_role = job_master.GetJob(speaker.mind.assigned_role)
 	var/speech_size = 100
 	var/faction_speech = 1 //Does this speech-size only apply to our own faction?
-	if(speaker_job)
-		speech_size = speaker_job.radio_speech_size
-		faction_speech =  speaker_job.radio_speech_faction
+	if (speaker_role)
+		speech_size = speaker_role.radio_speech_size
+		faction_speech =  speaker_role.radio_speech_faction
 
 	var/speech_size_modify = 0 //Should we modify the speech size?
 	if(!faction_speech)//Only bother with radio speech size if they're our faction. (Or we're not checking that.)


### PR DESCRIPTION
Foolproofed. No longer meddles with any previous variables, and infact declares a completely new one. If this somehow breaks the radio then I'm declaring martial law and stealing the codebase.


:cl: Nameacow01
rscadd: Alt titles now work properly with radio speech size.
/:cl:
