### PR TITLE
Alt-Title Speech Size Fix^3

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -215,7 +215,7 @@
 	var/datum/job/speaker_job
 	if(rank_text)
 		speaker_name += " ([rank_text])"
-		speaker_job = job_master.GetJob("[rank_text]")
+		speaker_job = job_master.GetJob(speaker.mind?.assigned_role)
 
 	var/speech_size = 100
 	var/faction_speech = 1 //Does this speech-size only apply to our own faction?


### PR DESCRIPTION
AND YES, Unlike previous times, I actually **got** to test this one! have some proof :)

<img width="929" height="61" alt="image_2025-10-26_015020450" src="https://github.com/user-attachments/assets/998dc2c6-d136-4d1d-a244-c98e14ad0b85" />


Doesn't touch any of the code, except replaces what is given to the job_master.GetJob() proc to ensure it is given an actual job name, and not an alternate job title that will return null.

🆑 nameacow
rscadd: Alt titles now work properly with radio speech size.
/:cl: