### PR TITLE
Simplemob Shield Overlay Fix

### DIFF
--- a/code/modules/halo/covenant/simple_mobs/elite.dm
+++ b/code/modules/halo/covenant/simple_mobs/elite.dm
@@ -18,6 +18,7 @@
 	var/recharge_rate = 10
 	var/last_damage = 0
 	var/recharging = 0
+	var/flickering = 0
 
 /mob/living/simple_animal/hostile/covenant/elite/major
 	name = "Elite Major (NPC)"

--- a/code/modules/halo/covenant/simple_mobs/elite_shield.dm
+++ b/code/modules/halo/covenant/simple_mobs/elite_shield.dm
@@ -1,4 +1,3 @@
-
 /mob/living/simple_animal/hostile/covenant/elite/adjustBruteLoss(damage)
 	last_damage = world.time
 	if(recharging)
@@ -7,21 +6,24 @@
 
 	//take damage from shield first
 	if(shield_left > 0)
-		overlays |= "shield_flicker"
+		if(!flickering)
+			overlays |= "shield_flicker"
+			flickering = 1
 		var/shield_absorbed = min(shield_left, damage)
 		shield_left -= shield_absorbed
 		damage -= shield_absorbed
-
 	. = ..(damage)
 
 /mob/living/simple_animal/hostile/covenant/elite/Life()
 	. = ..()
 
 	//dont need to display damage any more
-	overlays -= "shield_flicker"
+	if(flickering)
+		overlays -= "shield_flicker"
+		flickering = 0
 
 	if(stat == DEAD)
-		overlays -= "shield_recharge"
+		overlays.Cut() // Gets rid of all overlays to make visiblity over dead enemies easier.
 	else
 		//are we currently recharging?
 		if(recharging)

--- a/code/modules/halo/covenant/simple_mobs/grunt_shield.dm
+++ b/code/modules/halo/covenant/simple_mobs/grunt_shield.dm
@@ -6,6 +6,7 @@
 	var/recharge_rate = 10
 	var/last_damage = 0
 	var/recharging = 0
+	var/flickering = 0
 
 /mob/living/simple_animal/hostile/covenant/grunt/adjustBruteLoss(damage)
 	last_damage = world.time
@@ -15,7 +16,9 @@
 
 	//take damage from shield first
 	if(shield_left > 0)
-		overlays |= "shield_overlay_damage"
+		if(!flickering)
+			overlays |= "shield_overlay_damage"
+			flickering = 1
 		var/shield_absorbed = min(shield_left, damage)
 		shield_left -= shield_absorbed
 		damage -= shield_absorbed
@@ -26,10 +29,12 @@
 	. = ..()
 
 	//dont need to display damage any more
-	overlays -= "shield_overlay_damage"
+	if(flickering)
+		overlays -= "shield_overlay_damage"
+		flickering = 0
 
 	if(stat == DEAD)
-		overlays -= "shield_overlay_recharge"
+		overlays.Cut()
 	else
 		//are we currently recharging?
 		if(recharging)

--- a/code/modules/halo/unsc/simple_mobs.dm
+++ b/code/modules/halo/unsc/simple_mobs.dm
@@ -79,7 +79,7 @@
 	var/recharge_rate = 30
 	var/last_damage = 0
 	var/recharging = 0
-	var/fickering = 0
+	var/flickering = 0
 
 /obj/item/weapon/gun/energy/spartanlaser/npc
 	fire_sound = 'code/modules/halo/sounds/Spartan_Laser_Beam_Shot_Sound_Effect.ogg'

--- a/code/modules/halo/unsc/simple_mobs.dm
+++ b/code/modules/halo/unsc/simple_mobs.dm
@@ -79,6 +79,7 @@
 	var/recharge_rate = 30
 	var/last_damage = 0
 	var/recharging = 0
+	var/fickering = 0
 
 /obj/item/weapon/gun/energy/spartanlaser/npc
 	fire_sound = 'code/modules/halo/sounds/Spartan_Laser_Beam_Shot_Sound_Effect.ogg'
@@ -91,7 +92,9 @@
 
 	//take damage from shield first
 	if(shield_left > 0)
-		overlays |= "shield_flicker"
+		if(!flickering)
+			overlays |= "shield_flicker"
+			flickering = 1
 		var/shield_absorbed = min(shield_left, damage)
 		shield_left -= shield_absorbed
 		damage -= shield_absorbed
@@ -102,10 +105,12 @@
 	. = ..()
 
 	//dont need to display damage any more
-	overlays -= "shield_flicker"
+	if(flickering)
+		overlays -= "shield_flicker"
+		flickering = 0
 
 	if(stat == DEAD)
-		overlays -= "shield_recharge"
+		overlays.Cut()
 	else
 		//are we currently recharging?
 		if(recharging)


### PR DESCRIPTION
Adds a new 'flickering' variable to mobs w/ a shield to make sure multiple flickering overlays aren't added that give the effect of a complete solid blue (or orange) orb around them. Also changes the death result on overlays from just removing the flicker, to instead cut all overlays.

:cl: nameacow
tweak: Fixes how simplemobs w/ shields handle their overlays to prevent multiple appearing atop eachother.
/:cl:
