### PR TITLE
RCD Invisible Vehicle Bug

### DIFF
--- a/code/modules/halo/misc/RCD_modified.dm
+++ b/code/modules/halo/misc/RCD_modified.dm
@@ -184,6 +184,11 @@
 			continue
 		if(!rcdm.can_handle_work(rcd, target))
 			continue
+		if(isturf(target))
+			for(var/obj/vehicles/V in world)
+				if(V.locs && (target in V.locs))
+					to_chat(user, "<span class='warning'>An RCD won't work here, a vehicle is blocking the area!</span>")
+					return FALSE
 		if(!rcd.useResource(rcdm.cost, user))
 			to_chat(user, "<span class='warning'>Insufficient resources.</span>")
 			return FALSE


### PR DESCRIPTION
Prevents vehicles from being hidden when an RCD is used to build a turf under it. Also stops the RCD being used under **any** tile the vehicle is on to prevent other shennanigans.

https://github.com/HaloSpaceStation/HaloSpaceStation13/issues/3366

:cl: nameacow
bugfix: RCDs can no longer build under a vehicle.
bugfix: Fixes how simplemobs w shields handle their overlays to prevent multiple appearing atop eachother.
/:cl:
