### PR TITLE
Cheaper NPCs and Conversion Contracts

### DIFF
--- a/code/modules/halo/covenant/supply/covNPCs.dm
+++ b/code/modules/halo/covenant/supply/covNPCs.dm
@@ -6,14 +6,14 @@
 /decl/hierarchy/supply_pack/covenant_allies/grunt
 	name = "Unggoy Soldier (1)"
 	contains = list(/mob/living/simple_animal/hostile/covenant/grunt = 1)
-	cost = 500
+	cost = 100
 
 /decl/hierarchy/supply_pack/covenant_allies/jackal
 	name = "KigYar Soldier (1)"
 	contains = list(/mob/living/simple_animal/hostile/covenant/jackal = 1)
-	cost = 500
+	cost = 100
 
 /decl/hierarchy/supply_pack/covenant_allies/drone
 	name = "Yanmee Soldier (1)"
 	contains = list(/mob/living/simple_animal/hostile/covenant/drone = 1)
-	cost = 500
+	cost = 100

--- a/code/modules/halo/covenant/supply/covmisc.dm
+++ b/code/modules/halo/covenant/supply/covmisc.dm
@@ -68,3 +68,11 @@
 	contains = list(/obj/item/weapon/pinpointer/advpinpointer/bombplantlocator = 1)
 	cost = 50
 	containername = "\improper Bomb Plant Pinpointer crate"
+
+/* CONVERSION CONTRACTS */
+
+/decl/hierarchy/supply_pack/covenant_equipment/contract
+	name = "Field Asset Contract (1)"
+	contains = list(/obj/item/conversion_contract/cov = 1)
+	cost = 50
+	containername = "\improper Field Asset Contract crate"

--- a/code/modules/halo/unsc/supply/NPCs.dm
+++ b/code/modules/halo/unsc/supply/NPCs.dm
@@ -6,7 +6,7 @@
 /decl/hierarchy/supply_pack/unsc_npcs/marine
 	name = "UNSC Marine (1)"
 	contains = list(/mob/living/simple_animal/hostile/unsc/marine = 1)
-	cost = 500
+	cost = 100
 
 /**/
 /* ONI - Need a separate category for faction lock code. */
@@ -20,4 +20,4 @@
 /decl/hierarchy/supply_pack/oni_npcs/marine
 	name = "UNSC Marine (1)"
 	contains = list(/mob/living/simple_animal/hostile/unsc/marine = 1)
-	cost = 500
+	cost = 100

--- a/code/modules/halo/unsc/supply/misc.dm
+++ b/code/modules/halo/unsc/supply/misc.dm
@@ -103,3 +103,17 @@
 	contains = list(/obj/item/weapon/pinpointer/artifact = 1)
 	cost = 5000
 	containername = "\improper Artifact Pinpointers crate"
+
+/*CONVERSION CONTRACTS*/
+
+/decl/hierarchy/supply_pack/unsc_misc/contract
+	name = "Field Asset Contract (1)"
+	contains = list(/obj/item/conversion_contract/unsc = 1)
+	cost = 50
+	containername = "\improper Field Asset Contract crate"
+
+/decl/hierarchy/supply_pack/oni_misc/contract
+	name = "Field Asset Contract (1)"
+	contains = list(/obj/item/conversion_contract/unsc = 1)
+	cost = 50
+	containername = "\improper Field Asset Contract crate"


### PR DESCRIPTION
:cl: XO-11
tweak: NPCs in cargo are now way cheaper, 100 per npc instead of 500.
rscadd: Adds conversion contracts to cargo for 50 each.
/:cl: