### PR TITLE
glassing beam and mac gun blast fixes

### DIFF
--- a/code/modules/halo/overmap/weapons/Energy_projector.dm
+++ b/code/modules/halo/overmap/weapons/Energy_projector.dm
@@ -139,18 +139,17 @@
 
 /obj/item/projectile/projector_laser_damage_proj/check_penetrate(var/atom/a)
 	. = ..()
-	if(istype(a,/obj/effect/shield))
+	if(istype(a,/obj/effect/shield)) //Intentionally no blast against shields.
 		return 0
-
-/obj/item/projectile/projector_laser_damage_proj/on_hit(var/atom/a)
-	if(isnull(glass_effect_beam))
-		glass_effect_beam = new
-	explosion(get_turf(a),-1,-1,2,5, adminlog = 0)
-	glass_effect_beam.do_glassing_effect(a,4,/turf/unsimulated/floor/lava/glassed_turf/to_space)//Value of 3 chosen due to min light damage radius of MACs
-	if(!warned)
-		warned = 1
-		var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]
-		S.adminwarn_attack()
+	if(. == 0)
+		if(isnull(glass_effect_beam))
+			glass_effect_beam = new
+		explosion(get_turf(a),-1,-1,2,5, adminlog = 0)
+		glass_effect_beam.do_glassing_effect(a,4,/turf/unsimulated/floor/lava/glassed_turf/to_space)//Value of 3 chosen due to min light damage radius of MACs
+		if(!warned)
+			warned = 1
+			var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]
+			S.adminwarn_attack()
 
 /obj/item/projectile/projector_laser_damage_proj/Destroy()
 	. = ..()

--- a/code/modules/halo/overmap/weapons/MAC.dm
+++ b/code/modules/halo/overmap/weapons/MAC.dm
@@ -31,10 +31,7 @@
 
 /obj/machinery/mac_cannon/ammo_loader/proc/update_ammo()
 	for(var/obj/machinery/overmap_weapon_console/console in linked_consoles)
-		for(var/obj/round in contained_rounds)
-			if(round in console.loaded_ammo)
-				continue
-			console.loaded_ammo += round
+		console.loaded_ammo |= contained_rounds
 
 /obj/machinery/mac_cannon/ammo_loader/examine(var/mob/user)
 	. = ..()
@@ -268,17 +265,15 @@
 
 /obj/item/projectile/mac_round/check_penetrate(var/atom/impacted)
 	. = ..()
-	if(istype(impacted,/obj/effect/shield))
+	if(istype(impacted,/obj/effect/shield)) //Intentionally not exploding against shields.
 		return 0
-
-/obj/item/projectile/mac_round/on_hit(var/atom/impacted)
-	var/increase_from_damage = round(damage/250)
-	explosion(get_turf(impacted),2 + increase_from_damage,4 + increase_from_damage,5 + increase_from_damage,8 + increase_from_damage, adminlog = 0)
-	if(!warned)
-		warned = 1
-		var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]
-		S.adminwarn_attack()
-	. = ..()
+	if(. == 0)
+		var/increase_from_damage = round(damage/250)
+		explosion(get_turf(impacted),2 + increase_from_damage,4 + increase_from_damage,5 + increase_from_damage,8 + increase_from_damage, adminlog = 0)
+		if(!warned)
+			warned = 1
+			var/obj/effect/overmap/sector/S = map_sectors["[src.z]"]
+			S.adminwarn_attack()
 
 //BROKEN COMPONENTS//
 /obj/structure/repair_component/mac_console

--- a/code/modules/halo/overmap/weapons/overmap_weapon_ammo.dm
+++ b/code/modules/halo/overmap/weapons/overmap_weapon_ammo.dm
@@ -24,7 +24,7 @@
 	icon = 'code/modules/halo/overmap/weapons/mac_ammo.dmi'
 	icon_state = "slug"
 
-/obj/overmap_weapon_ammo/mac/Move()
+/obj/overmap_weapon_ammo/Projector_laser/Move()
 	.=..()
 	if(dir == NORTH || SOUTH)
 		bounds = "32,288"


### PR DESCRIPTION
🆑 XO-11
tweak: Modifies the way glassing beams and mac gun shells trigger their explosion. Should fix dud issues.
/:cl:
