### PR TITLE
Fixes T'vaoan Separatists on Firefight and Adds Them to Stranded

### DIFF
--- a/maps/firefight/map.dm
+++ b/maps/firefight/map.dm
@@ -24,4 +24,5 @@
 		/datum/job/unsc/odst/squad_leader/firefight,\
 		/datum/job/unsc/spartan_two/firefight,\
 		/datum/job/colonist/firefight,\
-		/datum/job/unsc/skirmseppie/firefight,)
+		/datum/job/unsc/skirmseppie/firefight\
+		)

--- a/maps/stranded/map.dm
+++ b/maps/stranded/map.dm
@@ -23,4 +23,6 @@
 		/datum/job/unsc/odst/firefight,\
 		/datum/job/unsc/odst/squad_leader/firefight,\
 		/datum/job/unsc/spartan_two/firefight,\
-		/datum/job/colonist/firefight)
+		/datum/job/colonist/firefight,\
+		/datum/job/unsc/skirmseppie/firefight\
+		)


### PR DESCRIPTION
Fixes a syntax error preventing T'vaoan Separatists spawning on Firefight, also adds them to the Stranded gamemode.

:cl: CommanderXor
rscadd: Added Tvaoan Separatists to Stranded.
bugfix: Fixed syntax error preventing Tvaoan Separatist spawns on Firefight.
/:cl:
